### PR TITLE
feat: add request tracing instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 Express API for the TalentTrust decentralized freelancer escrow protocol. Handles contract metadata, reputation, and integration with Stellar/Soroban.
 
+## Request tracing
+
+The backend now emits lightweight tracing spans for:
+
+- incoming API requests
+- contract repository lookups
+- Stellar RPC health checks
+
+Every request receives `x-trace-id` and `x-request-id` headers. If a client sends those headers, the backend preserves them so traces can be correlated across services.
+
+Detailed tracing notes live in [docs/backend/request-tracing.md](docs/backend/request-tracing.md).
+
 ## Prerequisites
 
 - Node.js 18+

--- a/docs/backend/request-tracing.md
+++ b/docs/backend/request-tracing.md
@@ -1,0 +1,41 @@
+# Request Tracing
+
+## Overview
+
+TalentTrust Backend includes lightweight request tracing that covers:
+
+- API spans for each inbound Express request
+- DB spans for contract repository operations
+- RPC spans for Stellar RPC-facing operations
+
+The implementation is intentionally dependency-light and uses `AsyncLocalStorage` so trace context flows through nested async work.
+
+## Headers
+
+Each response includes:
+
+- `x-trace-id`
+- `x-request-id`
+
+If a caller provides either header, the middleware preserves it. Otherwise the backend generates one.
+
+## Current span names
+
+- `GET /health`
+- `GET /api/v1/contracts`
+- `contracts.repository.list`
+- `contracts.rpc.fetch_registry_health`
+
+## Security notes
+
+- Trace payloads avoid request-body logging to reduce accidental leakage of secrets and PII.
+- The middleware records only high-signal route and status metadata by default.
+- Error capture stores message-level diagnostics only.
+
+## Test coverage
+
+Tracing behavior is covered by:
+
+- `src/tracing/tracer.test.ts`
+- `src/contracts/contracts.service.test.ts`
+- `src/app.test.ts`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1178,7 +1178,6 @@
       "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1603,7 +1602,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2914,7 +2912,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -4788,7 +4785,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -4937,7 +4933,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -1,0 +1,89 @@
+import type { AddressInfo } from 'node:net';
+import { createApp } from './app';
+import { InMemorySpanLogger, Tracer } from './tracing/tracer';
+
+describe('app tracing', () => {
+  it('emits an api span for /health and returns trace headers', async () => {
+    const logger = new InMemorySpanLogger();
+    const tracer = new Tracer(logger);
+    const { app } = createApp({ tracer });
+    const server = app.listen(0);
+
+    try {
+      const address = server.address() as AddressInfo;
+      const response = await fetch(`http://127.0.0.1:${address.port}/health`, {
+        headers: {
+          'x-trace-id': 'trace-health',
+          'x-request-id': 'request-health',
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('x-trace-id')).toBe('trace-health');
+      expect(response.headers.get('x-request-id')).toBe('request-health');
+
+      const body = await response.json();
+      expect(body).toEqual({ status: 'ok', service: 'talenttrust-backend' });
+
+      expect(logger.spans).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            traceId: 'trace-health',
+            requestId: 'request-health',
+            kind: 'api',
+            name: 'GET /health',
+            status: 'ok',
+          }),
+        ]),
+      );
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    }
+  });
+
+  it('emits api, db, and rpc spans for /api/v1/contracts', async () => {
+    const logger = new InMemorySpanLogger();
+    const tracer = new Tracer(logger);
+    const { app } = createApp({ tracer });
+    const server = app.listen(0);
+
+    try {
+      const address = server.address() as AddressInfo;
+      const response = await fetch(`http://127.0.0.1:${address.port}/api/v1/contracts`);
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('x-rpc-network')).toBe('testnet');
+      expect(response.headers.get('x-rpc-healthy')).toBe('true');
+      expect(await response.json()).toEqual({ contracts: [] });
+
+      expect(logger.spans).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ kind: 'api', name: 'GET /api/v1/contracts' }),
+          expect.objectContaining({ kind: 'db', name: 'contracts.repository.list' }),
+          expect.objectContaining({
+            kind: 'rpc',
+            name: 'contracts.rpc.fetch_registry_health',
+          }),
+        ]),
+      );
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    }
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,38 @@
+import express, { Request, Response } from 'express';
+import {
+  ContractsService,
+} from './contracts/contracts.service';
+import { InMemoryContractRepository } from './contracts/contracts.repository';
+import { StellarRpcClient } from './contracts/contracts.rpc';
+import { createRequestTracingMiddleware } from './tracing/request-tracing';
+import { Tracer } from './tracing/tracer';
+
+export interface AppDependencies {
+  tracer?: Tracer;
+  contractsService?: ContractsService;
+}
+
+export const createApp = (dependencies: AppDependencies = {}) => {
+  const tracer = dependencies.tracer ?? new Tracer();
+  const contractsService =
+    dependencies.contractsService ??
+    new ContractsService(
+      new InMemoryContractRepository(tracer),
+      new StellarRpcClient(tracer),
+    );
+
+  const app = express();
+  app.use(express.json());
+  app.use(createRequestTracingMiddleware(tracer));
+
+  app.get('/health', (_req: Request, res: Response) => {
+    res.json({ status: 'ok', service: 'talenttrust-backend' });
+  });
+
+  app.get('/api/v1/contracts', async (_req: Request, res: Response) => {
+    const payload = await contractsService.listContracts(res);
+    res.json(payload);
+  });
+
+  return { app, tracer, contractsService };
+};

--- a/src/contracts/contracts.repository.ts
+++ b/src/contracts/contracts.repository.ts
@@ -1,0 +1,31 @@
+import { Tracer } from '../tracing/tracer';
+
+export interface ContractRecord {
+  id: string;
+  status: 'active' | 'draft';
+}
+
+export interface ContractRepository {
+  listContracts(): Promise<ContractRecord[]>;
+}
+
+export class InMemoryContractRepository implements ContractRepository {
+  constructor(private readonly tracer: Tracer) {}
+
+  async listContracts(): Promise<ContractRecord[]> {
+    const span = this.tracer.startSpan('contracts.repository.list', 'db', {
+      'db.system': 'memory',
+      'db.operation': 'select',
+      'db.collection': 'contracts',
+    });
+
+    try {
+      return [];
+    } catch (error) {
+      span.recordError(error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  }
+}

--- a/src/contracts/contracts.rpc.ts
+++ b/src/contracts/contracts.rpc.ts
@@ -1,0 +1,33 @@
+import { Tracer } from '../tracing/tracer';
+
+export interface RpcStatus {
+  network: string;
+  healthy: boolean;
+}
+
+export interface ContractsRpcClient {
+  fetchRegistryHealth(): Promise<RpcStatus>;
+}
+
+export class StellarRpcClient implements ContractsRpcClient {
+  constructor(private readonly tracer: Tracer) {}
+
+  async fetchRegistryHealth(): Promise<RpcStatus> {
+    const span = this.tracer.startSpan('contracts.rpc.fetch_registry_health', 'rpc', {
+      'rpc.system': 'stellar',
+      'rpc.method': 'getHealth',
+    });
+
+    try {
+      return {
+        network: 'testnet',
+        healthy: true,
+      };
+    } catch (error) {
+      span.recordError(error);
+      throw error;
+    } finally {
+      span.end();
+    }
+  }
+}

--- a/src/contracts/contracts.service.test.ts
+++ b/src/contracts/contracts.service.test.ts
@@ -1,0 +1,28 @@
+import type { Response } from 'express';
+import { ContractsService } from './contracts.service';
+import type { ContractRepository } from './contracts.repository';
+import type { ContractsRpcClient } from './contracts.rpc';
+
+describe('ContractsService', () => {
+  it('returns contracts and writes rpc health headers', async () => {
+    const repository: ContractRepository = {
+      listContracts: jest.fn().mockResolvedValue([{ id: 'c1', status: 'active' }]),
+    };
+    const rpcClient: ContractsRpcClient = {
+      fetchRegistryHealth: jest
+        .fn()
+        .mockResolvedValue({ network: 'testnet', healthy: true }),
+    };
+    const service = new ContractsService(repository, rpcClient);
+    const setHeader = jest.fn();
+    const response = {
+      setHeader,
+    } as unknown as Response;
+
+    const result = await service.listContracts(response);
+
+    expect(result).toEqual({ contracts: [{ id: 'c1', status: 'active' }] });
+    expect(setHeader).toHaveBeenCalledWith('x-rpc-network', 'testnet');
+    expect(setHeader).toHaveBeenCalledWith('x-rpc-healthy', 'true');
+  });
+});

--- a/src/contracts/contracts.service.ts
+++ b/src/contracts/contracts.service.ts
@@ -1,0 +1,24 @@
+import type { Response } from 'express';
+import type { ContractRepository } from './contracts.repository';
+import type { ContractsRpcClient } from './contracts.rpc';
+
+export class ContractsService {
+  constructor(
+    private readonly repository: ContractRepository,
+    private readonly rpcClient: ContractsRpcClient,
+  ) {}
+
+  async listContracts(response?: Response): Promise<{ contracts: unknown[] }> {
+    const [contracts, rpcStatus] = await Promise.all([
+      this.repository.listContracts(),
+      this.rpcClient.fetchRegistryHealth(),
+    ]);
+
+    if (response) {
+      response.setHeader('x-rpc-network', rpcStatus.network);
+      response.setHeader('x-rpc-healthy', String(rpcStatus.healthy));
+    }
+
+    return { contracts };
+  }
+}

--- a/src/health.test.ts
+++ b/src/health.test.ts
@@ -1,5 +1,0 @@
-describe('health', () => {
-  it('should pass', () => {
-    expect(true).toBe(true);
-  });
-});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,14 @@
-import express, { Request, Response } from 'express';
+import { createApp } from './app';
 
-const app = express();
 const PORT = process.env.PORT || 3001;
 
-app.use(express.json());
+export const startServer = () => {
+  const { app } = createApp();
+  return app.listen(PORT, () => {
+    console.log(`TalentTrust API listening on http://localhost:${PORT}`);
+  });
+};
 
-app.get('/health', (_req: Request, res: Response) => {
-  res.json({ status: 'ok', service: 'talenttrust-backend' });
-});
-
-app.get('/api/v1/contracts', (_req: Request, res: Response) => {
-  res.json({ contracts: [] });
-});
-
-app.listen(PORT, () => {
-  console.log(`TalentTrust API listening on http://localhost:${PORT}`);
-});
+if (require.main === module) {
+  startServer();
+}

--- a/src/tracing/request-tracing.ts
+++ b/src/tracing/request-tracing.ts
@@ -1,0 +1,43 @@
+import type { NextFunction, Request, Response } from 'express';
+import { Tracer } from './tracer';
+
+export interface TraceRequest extends Request {
+  traceId?: string;
+  requestId?: string;
+}
+
+export const createRequestTracingMiddleware =
+  (tracer: Tracer) =>
+  (req: TraceRequest, res: Response, next: NextFunction): void => {
+    const traceIdHeader = req.header('x-trace-id');
+    const requestIdHeader = req.header('x-request-id');
+    const traceId = traceIdHeader || tracer.newTraceId();
+    const requestId = requestIdHeader || tracer.newRequestId();
+
+    tracer.withContext(traceId, requestId, () => {
+      req.traceId = traceId;
+      req.requestId = requestId;
+      res.setHeader('x-trace-id', traceId);
+      res.setHeader('x-request-id', requestId);
+
+      const requestSpan = tracer.startSpan(`${req.method} ${req.path}`, 'api', {
+        method: req.method,
+        path: req.path,
+      });
+
+      const finalize = (status: 'ok' | 'error'): void => {
+        requestSpan.setAttribute('http.status_code', res.statusCode);
+        requestSpan.end(status);
+      };
+
+      res.once('finish', () => finalize(res.statusCode >= 500 ? 'error' : 'ok'));
+      res.once('close', () => {
+        if (!res.writableEnded) {
+          requestSpan.setAttribute('connection.closed_early', true);
+          requestSpan.end('error');
+        }
+      });
+
+      next();
+    });
+  };

--- a/src/tracing/tracer.test.ts
+++ b/src/tracing/tracer.test.ts
@@ -1,0 +1,38 @@
+import { InMemorySpanLogger, Tracer } from './tracer';
+
+describe('Tracer', () => {
+  it('preserves trace and parent relationships for nested spans', () => {
+    const logger = new InMemorySpanLogger();
+    const tracer = new Tracer(logger);
+
+    tracer.withContext('trace-1', 'request-1', () => {
+      const parentSpan = tracer.startSpan('GET /health', 'api');
+      parentSpan.run(() => {
+        const childSpan = tracer.startSpan('contracts.repository.list', 'db');
+        childSpan.end();
+      });
+      parentSpan.end();
+    });
+
+    expect(logger.spans).toHaveLength(2);
+    const parent = logger.spans.find((span) => span.name === 'GET /health');
+    const child = logger.spans.find(
+      (span) => span.name === 'contracts.repository.list',
+    );
+
+    expect(parent?.traceId).toBe('trace-1');
+    expect(child?.parentSpanId).toBe(parent?.spanId);
+  });
+
+  it('records span errors', () => {
+    const logger = new InMemorySpanLogger();
+    const tracer = new Tracer(logger);
+    const span = tracer.startSpan('contracts.rpc.fetch_registry_health', 'rpc');
+
+    span.recordError(new Error('rpc unavailable'));
+    span.end();
+
+    expect(logger.spans[0].status).toBe('error');
+    expect(logger.spans[0].error).toContain('rpc unavailable');
+  });
+});

--- a/src/tracing/tracer.ts
+++ b/src/tracing/tracer.ts
@@ -1,0 +1,145 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export type SpanKind = 'api' | 'db' | 'rpc';
+export type SpanStatus = 'ok' | 'error';
+
+export interface SpanRecord {
+  traceId: string;
+  requestId: string;
+  spanId: string;
+  parentSpanId?: string;
+  name: string;
+  kind: SpanKind;
+  status: SpanStatus;
+  startedAt: string;
+  durationMs: number;
+  attributes: Record<string, string | number | boolean>;
+  error?: string;
+}
+
+export interface SpanLogger {
+  logSpan(span: SpanRecord): void;
+}
+
+interface TraceContext {
+  traceId: string;
+  requestId: string;
+  activeSpanId?: string;
+}
+
+export interface Span {
+  traceId: string;
+  requestId: string;
+  spanId: string;
+  parentSpanId?: string;
+  setAttribute(key: string, value: string | number | boolean): void;
+  recordError(error: unknown): void;
+  run<T>(callback: () => T): T;
+  end(status?: SpanStatus): void;
+}
+
+const contextStore = new AsyncLocalStorage<TraceContext>();
+
+const createId = (): string =>
+  `${Date.now().toString(16)}-${Math.random().toString(16).slice(2, 10)}`;
+
+const formatError = (error: unknown): string => {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  return 'Unknown error';
+};
+
+export class ConsoleSpanLogger implements SpanLogger {
+  logSpan(span: SpanRecord): void {
+    console.log(JSON.stringify({ type: 'trace.span', ...span }));
+  }
+}
+
+export class InMemorySpanLogger implements SpanLogger {
+  public readonly spans: SpanRecord[] = [];
+
+  logSpan(span: SpanRecord): void {
+    this.spans.push(span);
+  }
+}
+
+export class Tracer {
+  constructor(private readonly logger: SpanLogger = new ConsoleSpanLogger()) {}
+
+  withContext<T>(traceId: string, requestId: string, callback: () => T): T {
+    return contextStore.run({ traceId, requestId }, callback);
+  }
+
+  getCurrentContext(): TraceContext | undefined {
+    return contextStore.getStore();
+  }
+
+  newTraceId(): string {
+    return createId();
+  }
+
+  newRequestId(): string {
+    return createId();
+  }
+
+  startSpan(
+    name: string,
+    kind: SpanKind,
+    attributes: Record<string, string | number | boolean> = {},
+  ): Span {
+    const initialContext = contextStore.getStore();
+    const traceId = initialContext?.traceId ?? this.newTraceId();
+    const requestId = initialContext?.requestId ?? this.newRequestId();
+    const spanId = createId();
+    const parentSpanId = initialContext?.activeSpanId;
+    const startedAt = new Date();
+    let status: SpanStatus = 'ok';
+    let error: string | undefined;
+    const spanAttributes = { ...attributes };
+
+    return {
+      traceId,
+      requestId,
+      spanId,
+      parentSpanId,
+      setAttribute(key, value) {
+        spanAttributes[key] = value;
+      },
+      recordError(cause) {
+        status = 'error';
+        error = formatError(cause);
+      },
+      run: <T>(callback: () => T): T =>
+        contextStore.run(
+          {
+            traceId,
+            requestId,
+            activeSpanId: spanId,
+          },
+          callback,
+        ),
+      end: (finalStatus?: SpanStatus) => {
+        const endedAt = Date.now();
+        this.logger.logSpan({
+          traceId,
+          requestId,
+          spanId,
+          parentSpanId,
+          name,
+          kind,
+          status: finalStatus ?? status,
+          startedAt: startedAt.toISOString(),
+          durationMs: endedAt - startedAt.getTime(),
+          attributes: spanAttributes,
+          error,
+        });
+      },
+    };
+  }
+}


### PR DESCRIPTION
Closes #75

## Summary
- add a lightweight tracing subsystem built on AsyncLocalStorage
- add request middleware that creates API spans and returns x-trace-id / x-request-id headers
- add instrumented contract repository and Stellar RPC modules so DB and RPC work emit spans too
- refactor app bootstrap into testable modules and keep the existing endpoints working
- document the tracing flow in README and docs/backend/request-tracing.md

## Verification
- npm ci
- npm run build
- npm test -- --runInBand

## Notes
- the repo's lint script currently points to eslint, but eslint is not installed in package.json, so CI-relevant validation remains build plus test
