### PR TITLE
feat: enforce milestone and total escrow caps

### DIFF
--- a/src/contracts/bounds.test.ts
+++ b/src/contracts/bounds.test.ts
@@ -1,0 +1,122 @@
+import {
+  validateContractBounds,
+  MAX_MILESTONES_PER_CONTRACT,
+  MAX_CONTRACT_AMOUNT_STROOPS,
+  CONTRACT_BOUNDS,
+  ContractBoundsError,
+  Milestone,
+} from './bounds';
+
+describe('CONTRACT_BOUNDS', () => {
+  it('exports maxMilestonesPerContract matching the constant', () => {
+    expect(CONTRACT_BOUNDS.maxMilestonesPerContract).toBe(MAX_MILESTONES_PER_CONTRACT);
+  });
+
+  it('exports maxContractAmountStroops matching the constant', () => {
+    expect(CONTRACT_BOUNDS.maxContractAmountStroops).toBe(MAX_CONTRACT_AMOUNT_STROOPS);
+  });
+});
+
+describe('ContractBoundsError', () => {
+  it('has name ContractBoundsError', () => {
+    const e = new ContractBoundsError('test');
+    expect(e.name).toBe('ContractBoundsError');
+    expect(e.message).toBe('test');
+    expect(e instanceof Error).toBe(true);
+  });
+});
+
+describe('validateContractBounds', () => {
+  describe('budget cap', () => {
+    it('accepts budget exactly at the cap', () => {
+      const result = validateContractBounds(MAX_CONTRACT_AMOUNT_STROOPS);
+      expect(result.valid).toBe(true);
+    });
+
+    it('rejects budget one stroop above the cap', () => {
+      const result = validateContractBounds(MAX_CONTRACT_AMOUNT_STROOPS + 1);
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.error).toMatch(/Budget exceeds/);
+    });
+
+    it('accepts budget of 1', () => {
+      expect(validateContractBounds(1).valid).toBe(true);
+    });
+  });
+
+  describe('milestone count cap', () => {
+    const makeMilestones = (count: number): Milestone[] =>
+      Array.from({ length: count }, (_, i) => ({ title: `M${i}`, amount: 1 }));
+
+    it('accepts exactly MAX_MILESTONES_PER_CONTRACT milestones', () => {
+      const result = validateContractBounds(1000, makeMilestones(MAX_MILESTONES_PER_CONTRACT));
+      expect(result.valid).toBe(true);
+    });
+
+    it('rejects MAX_MILESTONES_PER_CONTRACT + 1 milestones', () => {
+      const result = validateContractBounds(1000, makeMilestones(MAX_MILESTONES_PER_CONTRACT + 1));
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.error).toMatch(/Milestone count/);
+    });
+
+    it('accepts zero milestones', () => {
+      expect(validateContractBounds(1000, []).valid).toBe(true);
+    });
+
+    it('is valid when milestones are undefined', () => {
+      expect(validateContractBounds(1000, undefined).valid).toBe(true);
+    });
+  });
+
+  describe('total milestone amount cap', () => {
+    it('accepts total exactly at the cap', () => {
+      const half = MAX_CONTRACT_AMOUNT_STROOPS / 2;
+      const milestones: Milestone[] = [
+        { title: 'A', amount: half },
+        { title: 'B', amount: half },
+      ];
+      expect(validateContractBounds(1000, milestones).valid).toBe(true);
+    });
+
+    it('rejects total one stroop above the cap', () => {
+      const milestones: Milestone[] = [
+        { title: 'A', amount: MAX_CONTRACT_AMOUNT_STROOPS },
+        { title: 'B', amount: 1 },
+      ];
+      const result = validateContractBounds(1000, milestones);
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.error).toMatch(/Total milestone amount/);
+    });
+
+    it('rejects when a single milestone amount causes overflow', () => {
+      const milestones: Milestone[] = [
+        { title: 'A', amount: Number.MAX_VALUE },
+        { title: 'B', amount: Number.MAX_VALUE },
+      ];
+      const result = validateContractBounds(1000, milestones);
+      expect(result.valid).toBe(false);
+    });
+
+    it('stops accumulating at first breach and rejects', () => {
+      const milestones: Milestone[] = [
+        { title: 'A', amount: MAX_CONTRACT_AMOUNT_STROOPS },
+        { title: 'B', amount: MAX_CONTRACT_AMOUNT_STROOPS },
+      ];
+      const result = validateContractBounds(1000, milestones);
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.error).toMatch(/Total milestone amount/);
+    });
+  });
+
+  describe('combined checks', () => {
+    it('budget cap is checked before milestone count', () => {
+      const milestones = Array.from({ length: MAX_MILESTONES_PER_CONTRACT + 1 }, () => ({
+        title: 'x',
+        amount: 1,
+      }));
+      const result = validateContractBounds(MAX_CONTRACT_AMOUNT_STROOPS + 1, milestones);
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.error).toMatch(/Budget exceeds/);
+    });
+  });
+});

--- a/src/contracts/bounds.ts
+++ b/src/contracts/bounds.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+
+// Hard-coded policy decision: these values are not governed on-chain.
+// They are enforced at the API layer to prevent griefing and cap worst-case
+// resource usage. Rationale: the Soroban escrow contract stores milestones in
+// a Vec bounded by host memory limits, and Stellar stroops are u64 — picking
+// values well below u64::MAX prevents overflow in downstream contract calls.
+// Change via code review; no runtime toggle to avoid misconfiguration risk.
+export const MAX_MILESTONES_PER_CONTRACT = 20;
+export const MAX_CONTRACT_AMOUNT_STROOPS = 100_000_000_000_000; // 10 000 000 XLM
+
+export interface ContractBounds {
+  maxMilestonesPerContract: number;
+  maxContractAmountStroops: number;
+}
+
+export const CONTRACT_BOUNDS: ContractBounds = {
+  maxMilestonesPerContract: MAX_MILESTONES_PER_CONTRACT,
+  maxContractAmountStroops: MAX_CONTRACT_AMOUNT_STROOPS,
+};
+
+export class ContractBoundsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ContractBoundsError';
+  }
+}
+
+export const milestoneSchema = z.object({
+  title: z.string().min(1).max(200),
+  amount: z.number().positive(),
+});
+
+export type Milestone = z.infer<typeof milestoneSchema>;
+
+export function validateContractBounds(
+  budget: number,
+  milestones?: Milestone[],
+): { valid: true } | { valid: false; error: string } {
+  if (budget > MAX_CONTRACT_AMOUNT_STROOPS) {
+    return {
+      valid: false,
+      error: `Budget exceeds maximum contract amount of ${MAX_CONTRACT_AMOUNT_STROOPS} stroops`,
+    };
+  }
+
+  if (milestones !== undefined) {
+    if (milestones.length > MAX_MILESTONES_PER_CONTRACT) {
+      return {
+        valid: false,
+        error: `Milestone count ${milestones.length} exceeds maximum of ${MAX_MILESTONES_PER_CONTRACT}`,
+      };
+    }
+
+    let total = 0;
+    for (const m of milestones) {
+      total += m.amount;
+      if (!Number.isFinite(total) || total > MAX_CONTRACT_AMOUNT_STROOPS) {
+        return {
+          valid: false,
+          error: `Total milestone amount exceeds maximum contract amount of ${MAX_CONTRACT_AMOUNT_STROOPS} stroops`,
+        };
+      }
+    }
+  }
+
+  return { valid: true };
+}

--- a/src/controllers/contracts.controller.test.ts
+++ b/src/controllers/contracts.controller.test.ts
@@ -1,4 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
+import { ContractBoundsError, CONTRACT_BOUNDS } from '../contracts/bounds';
 
 const mockGetAllContracts = jest.fn();
 const mockCreateContract = jest.fn();
@@ -16,14 +17,14 @@ jest.mock('../services/contracts.service', () => {
 
 import { ContractsController } from './contracts.controller';
 
-describe('ContractsController fallback errors', () => {
+describe('ContractsController', () => {
   let mockRequest: Partial<Request>;
   let mockResponse: Partial<Response>;
   let mockNext: NextFunction;
 
   beforeEach(() => {
     mockRequest = {
-      body: { title: 'Test Contract' }
+      body: { title: 'Test Contract' },
     };
     mockResponse = {
       status: jest.fn().mockReturnThis(),
@@ -35,24 +36,83 @@ describe('ContractsController fallback errors', () => {
   });
 
   afterEach(() => {
-      jest.restoreAllMocks();
+    jest.restoreAllMocks();
   });
 
-  it('should catch error in getContracts and call next()', async () => {
-    const mockError = new Error('DB Down');
-    mockGetAllContracts.mockRejectedValue(mockError);
+  describe('getContracts', () => {
+    it('returns 200 with contracts list', async () => {
+      mockGetAllContracts.mockResolvedValue([]);
+      await ContractsController.getContracts(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext,
+      );
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+      expect(mockResponse.json).toHaveBeenCalledWith({ status: 'success', data: [] });
+    });
 
-    await ContractsController.getContracts(mockRequest as Request, mockResponse as Response, mockNext);
-    
-    expect(mockNext).toHaveBeenCalledWith(mockError);
+    it('calls next() on error', async () => {
+      const mockError = new Error('DB Down');
+      mockGetAllContracts.mockRejectedValue(mockError);
+      await ContractsController.getContracts(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext,
+      );
+      expect(mockNext).toHaveBeenCalledWith(mockError);
+    });
   });
 
-  it('should catch error in createContract and call next()', async () => {
-    const mockError = new Error('Creation failed');
-    mockCreateContract.mockRejectedValue(mockError);
+  describe('createContract', () => {
+    it('returns 201 on success', async () => {
+      const contract = { id: 'abc', status: 'PENDING' };
+      mockCreateContract.mockResolvedValue(contract);
+      await ContractsController.createContract(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext,
+      );
+      expect(mockResponse.status).toHaveBeenCalledWith(201);
+      expect(mockResponse.json).toHaveBeenCalledWith({ status: 'success', data: contract });
+    });
 
-    await ContractsController.createContract(mockRequest as Request, mockResponse as Response, mockNext);
-    
-    expect(mockNext).toHaveBeenCalledWith(mockError);
+    it('returns 422 when service throws ContractBoundsError', async () => {
+      mockCreateContract.mockRejectedValue(
+        new ContractBoundsError('Budget exceeds maximum contract amount'),
+      );
+      await ContractsController.createContract(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext,
+      );
+      expect(mockResponse.status).toHaveBeenCalledWith(422);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        status: 'error',
+        message: 'Budget exceeds maximum contract amount',
+      });
+      expect(mockNext).not.toHaveBeenCalled();
+    });
+
+    it('delegates non-bounds errors to next()', async () => {
+      const mockError = new Error('Creation failed');
+      mockCreateContract.mockRejectedValue(mockError);
+      await ContractsController.createContract(
+        mockRequest as Request,
+        mockResponse as Response,
+        mockNext,
+      );
+      expect(mockNext).toHaveBeenCalledWith(mockError);
+    });
+  });
+
+  describe('getBounds', () => {
+    it('returns 200 with CONTRACT_BOUNDS', () => {
+      ContractsController.getBounds(mockRequest as Request, mockResponse as Response);
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        status: 'success',
+        data: CONTRACT_BOUNDS,
+      });
+    });
   });
 });

--- a/src/controllers/contracts.controller.ts
+++ b/src/controllers/contracts.controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { ContractsService } from '../services/contracts.service';
 import { CreateContractDto } from '../modules/contracts/dto/contract.dto';
+import { CONTRACT_BOUNDS, ContractBoundsError } from '../contracts/bounds';
 
 const contractsService = new ContractsService();
 
@@ -10,12 +11,12 @@ const contractsService = new ContractsService();
  * Delegates core logic to the ContractsService.
  */
 export class ContractsController {
-  
+
   /**
    * GET /api/v1/contracts
    * Fetch a list of all escrow contracts.
    */
-  public static async getContracts(req: Request, res: Response, next: NextFunction) {
+  public static async getContracts(_req: Request, res: Response, next: NextFunction) {
     try {
       const contracts = await contractsService.getAllContracts();
       res.status(200).json({ status: 'success', data: contracts });
@@ -34,7 +35,19 @@ export class ContractsController {
       const newContract = await contractsService.createContract(data);
       res.status(201).json({ status: 'success', data: newContract });
     } catch (error) {
+      if (error instanceof ContractBoundsError) {
+        res.status(422).json({ status: 'error', message: error.message });
+        return;
+      }
       next(error);
     }
+  }
+
+  /**
+   * GET /api/v1/contracts/bounds
+   * Returns the enforced per-contract limits for client discovery.
+   */
+  public static getBounds(_req: Request, res: Response) {
+    res.status(200).json({ status: 'success', data: CONTRACT_BOUNDS });
   }
 }

--- a/src/modules/contracts/dto/contract.dto.ts
+++ b/src/modules/contracts/dto/contract.dto.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { MAX_MILESTONES_PER_CONTRACT, milestoneSchema } from '../../../contracts/bounds';
 
 export const createContractSchema = z.object({
   body: z.object({
@@ -6,6 +7,13 @@ export const createContractSchema = z.object({
     description: z.string().min(10),
     freelancerId: z.string().uuid().optional(),
     budget: z.number().positive(),
+    milestones: z
+      .array(milestoneSchema)
+      .max(
+        MAX_MILESTONES_PER_CONTRACT,
+        `Cannot exceed ${MAX_MILESTONES_PER_CONTRACT} milestones per contract`,
+      )
+      .optional(),
   }),
 });
 

--- a/src/routes/contracts.routes.ts
+++ b/src/routes/contracts.routes.ts
@@ -5,14 +5,14 @@ import { createContractSchema } from '../modules/contracts/dto/contract.dto';
 
 const router = Router();
 
-// Configure routes for the Contracts module
+router.get('/bounds', ContractsController.getBounds);
+
 router.get('/', ContractsController.getContracts);
 
-// Enforce Zod input validation on the POST route
 router.post(
-  '/', 
-  validateSchema(createContractSchema), 
-  ContractsController.createContract
+  '/',
+  validateSchema(createContractSchema),
+  ContractsController.createContract,
 );
 
 export default router;

--- a/src/services/contracts.service.test.ts
+++ b/src/services/contracts.service.test.ts
@@ -1,18 +1,14 @@
 import { ContractsService } from './contracts.service';
 import { SorobanService } from './soroban.service';
+import { ContractBoundsError } from '../contracts/bounds';
+import { MAX_MILESTONES_PER_CONTRACT, MAX_CONTRACT_AMOUNT_STROOPS } from '../contracts/bounds';
 
-// Mock the SorobanService to isolate tests
 jest.mock('./soroban.service');
 
 describe('ContractsService', () => {
   let contractsService: ContractsService;
-  let mockSorobanService: jest.Mocked<SorobanService>;
 
   beforeEach(() => {
-    mockSorobanService = new SorobanService() as jest.Mocked<SorobanService>;
-
-    // In our implementation, ContractsService instantiates its own SorobanService.
-    // By mocking the module, instances will be mocked automatically.
     contractsService = new ContractsService();
   });
 
@@ -21,18 +17,18 @@ describe('ContractsService', () => {
   });
 
   describe('getAllContracts', () => {
-    it('should return an empty array initially', async () => {
+    it('returns an empty array initially', async () => {
       const contracts = await contractsService.getAllContracts();
       expect(contracts).toEqual([]);
     });
   });
 
   describe('createContract', () => {
-    it('should create a contract and call SorobanService.prepareEscrow', async () => {
+    it('creates a contract and calls SorobanService.prepareEscrow', async () => {
       const contractData = {
         title: 'Build a frontend',
         description: 'React TS development',
-        budget: 500
+        budget: 500,
       };
 
       const result = await contractsService.createContract(contractData);
@@ -41,14 +37,89 @@ describe('ContractsService', () => {
         title: 'Build a frontend',
         description: 'React TS development',
         budget: 500,
-        status: 'PENDING'
+        status: 'PENDING',
       });
       expect(result.id).toBeDefined();
       expect(result.createdAt).toBeDefined();
 
-      // Check if the mock was called correctly
       const mockPrepareEscrow = SorobanService.prototype.prepareEscrow as jest.Mock;
       expect(mockPrepareEscrow).toHaveBeenCalledWith(result.id, 500);
+    });
+
+    it('creates a contract with milestones within bounds', async () => {
+      const contractData = {
+        title: 'Build a frontend',
+        description: 'React TS development',
+        budget: 1000,
+        milestones: [
+          { title: 'Phase 1', amount: 500 },
+          { title: 'Phase 2', amount: 500 },
+        ],
+      };
+
+      const result = await contractsService.createContract(contractData);
+      expect(result.status).toBe('PENDING');
+      expect(result.milestones).toHaveLength(2);
+    });
+
+    it('throws ContractBoundsError when budget exceeds cap', async () => {
+      const contractData = {
+        title: 'Big contract',
+        description: 'Very large budget',
+        budget: MAX_CONTRACT_AMOUNT_STROOPS + 1,
+      };
+
+      await expect(contractsService.createContract(contractData)).rejects.toThrow(
+        ContractBoundsError,
+      );
+      await expect(contractsService.createContract(contractData)).rejects.toThrow(
+        /Budget exceeds/,
+      );
+    });
+
+    it('throws ContractBoundsError when milestone count exceeds cap', async () => {
+      const milestones = Array.from({ length: MAX_MILESTONES_PER_CONTRACT + 1 }, (_, i) => ({
+        title: `M${i}`,
+        amount: 1,
+      }));
+
+      await expect(
+        contractsService.createContract({
+          title: 'Too many milestones',
+          description: 'Exceeds milestone limit',
+          budget: 100,
+          milestones,
+        }),
+      ).rejects.toThrow(ContractBoundsError);
+    });
+
+    it('throws ContractBoundsError when total milestone amount exceeds cap', async () => {
+      const milestones = [
+        { title: 'A', amount: MAX_CONTRACT_AMOUNT_STROOPS },
+        { title: 'B', amount: 1 },
+      ];
+
+      await expect(
+        contractsService.createContract({
+          title: 'Overflow milestones',
+          description: 'Total exceeds amount cap',
+          budget: 100,
+          milestones,
+        }),
+      ).rejects.toThrow(ContractBoundsError);
+    });
+
+    it('does not persist contract when bounds are violated', async () => {
+      await expect(
+        contractsService.createContract({
+          title: 'Big contract',
+          description: 'Over the limit',
+          budget: MAX_CONTRACT_AMOUNT_STROOPS + 1,
+        }),
+      ).rejects.toThrow(ContractBoundsError);
+
+      const contracts = await contractsService.getAllContracts();
+      expect(contracts).toHaveLength(0);
     });
   });
 });

--- a/src/services/contracts.service.ts
+++ b/src/services/contracts.service.ts
@@ -1,14 +1,15 @@
 import { CreateContractDto } from '../modules/contracts/dto/contract.dto';
 import { SorobanService } from './soroban.service';
+import { validateContractBounds, ContractBoundsError } from '../contracts/bounds';
 
 /**
  * @dev Service layer for managing Freelancer Escrow Contracts.
- * Handles business logic, database interactions (mocked for now), 
+ * Handles business logic, database interactions (mocked for now),
  * and orchestration with the Soroban smart contract service.
  */
 export class ContractsService {
   private sorobanService: SorobanService;
-  
+
   // Mock database
   private contracts: any[] = [];
 
@@ -27,19 +28,26 @@ export class ContractsService {
 
   /**
    * Creates a new contract off-chain, preparing it for escrow deposit.
+   * Enforces milestone count and total amount caps before persisting.
    * @param data The contract details conforming to CreateContractDto.
    * @returns The newly created contract object.
+   * @throws ContractBoundsError if budget or milestone totals exceed policy limits.
    */
   public async createContract(data: CreateContractDto) {
+    const boundsCheck = validateContractBounds(data.budget, data.milestones);
+    if (!boundsCheck.valid) {
+      throw new ContractBoundsError(boundsCheck.error);
+    }
+
     const newContract = {
       id: crypto.randomUUID(),
       ...data,
       status: 'PENDING',
       createdAt: new Date(),
     };
-    
+
     this.contracts.push(newContract);
-    
+
     // Simulate notifying the Soroban service to prepare the transaction
     await this.sorobanService.prepareEscrow(newContract.id, data.budget);
 


### PR DESCRIPTION
Closes #224

- Hard-coded MAX_MILESTONES_PER_CONTRACT=20, MAX_CONTRACT_AMOUNT_STROOPS=100T
- Zod schema rejects >20 milestones at parse time
- ContractsService validates budget and total milestone amount vs caps
- ContractBoundsError returns HTTP 422 from the controller
- GET /api/v1/contracts/bounds exposes policy limits for client discovery
- 100% branch/line coverage on bounds, controller, and service