### PR TITLE
feat: return structured validation error details with safe envelope

### DIFF
--- a/src/middleware/validate.middleware.test.ts
+++ b/src/middleware/validate.middleware.test.ts
@@ -45,10 +45,20 @@ describe('Validate Middleware', () => {
     await middleware(mockRequest as Request, mockResponse as Response, mockNext);
 
     expect(mockResponse.status).toHaveBeenCalledWith(400);
-    expect(mockResponse.json).toHaveBeenCalledWith(expect.objectContaining({
-      status: 'error',
-      message: 'Validation failed',
-    }));
+    expect(mockResponse.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'error',
+        code: 'validation_error',
+        message: 'Validation failed',
+        details: expect.arrayContaining([
+          expect.objectContaining({
+            path: expect.any(Array),
+            message: expect.any(String),
+            code: expect.any(String),
+          }),
+        ]),
+      }),
+    );
   });
 
   it('should pass non-Zod errors to next()', async () => {

--- a/src/middleware/validate.middleware.ts
+++ b/src/middleware/validate.middleware.ts
@@ -1,14 +1,27 @@
 import { Request, Response, NextFunction } from 'express';
 import { ZodTypeAny, ZodError } from 'zod';
 
-/**
- * @dev Validation middleware using Zod.
- * Validates the incoming Request against a provided Zod schema.
- * Prevents injection attacks and ensures payload conformity.
- * 
- * @param schema The Zod schema to validate against (body, query, params).
- * @returns An Express middleware function.
- */
+export interface ValidationErrorDetail {
+  path: string[];
+  message: string;
+  code: string;
+}
+
+export interface ValidationErrorResponse {
+  status: 'error';
+  code: string;
+  message: string;
+  details: ValidationErrorDetail[];
+}
+
+const mapZodErrorToDetails = (error: ZodError): ValidationErrorDetail[] => {
+  return error.issues.map((issue) => ({
+    path: issue.path.map((p) => String(p)),
+    message: issue.message,
+    code: issue.code,
+  }));
+};
+
 export const validateSchema = (schema: ZodTypeAny) => {
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -20,11 +33,13 @@ export const validateSchema = (schema: ZodTypeAny) => {
       next();
     } catch (error) {
       if (error instanceof ZodError) {
-        return res.status(400).json({
+        const response: ValidationErrorResponse = {
           status: 'error',
+          code: 'validation_error',
           message: 'Validation failed',
-          errors: error.issues,
-        });
+          details: mapZodErrorToDetails(error),
+        };
+        return res.status(400).json(response);
       }
       next(error);
     }


### PR DESCRIPTION
Backend: Add request validation error detail mapping with field-level paths 

closing #179 
