### PR TITLE
feat: add HMAC signing for outbound webhooks

### DIFF
--- a/docs/webhook-signature-verification.md
+++ b/docs/webhook-signature-verification.md
@@ -1,0 +1,320 @@
+# Webhook Signature Verification
+
+This document explains how to verify webhook signatures sent by the Talenttrust Backend using HMAC-SHA256 signing.
+
+## Overview
+
+All outbound webhooks from the Talenttrust Backend are signed using HMAC-SHA256 when a webhook secret is configured. This ensures the authenticity and integrity of webhook payloads.
+
+## Headers
+
+When HMAC signing is enabled, the following headers are included with each webhook request:
+
+- `X-Signature`: The HMAC signature prefixed with `sha256=`
+- `X-Timestamp`: Unix timestamp (milliseconds) when the signature was generated
+- `Content-Type`: Always set to `application/json`
+
+## Signature Generation Process
+
+The signature is generated using the following process:
+
+1. **Canonical String Creation**: Create a string in the format `{timestamp}.{payload}`
+   - `timestamp`: Unix timestamp in milliseconds
+   - `payload`: The JSON stringified webhook payload
+
+2. **HMAC Calculation**: Calculate HMAC-SHA256 using the webhook secret
+   - Input: Canonical string
+   - Key: Webhook secret
+   - Output: Hex-encoded HMAC digest
+
+3. **Header Format**: The signature is sent as `sha256={hex_digest}`
+
+## Verification Steps
+
+To verify a webhook signature:
+
+### 1. Extract Headers
+
+```javascript
+const signature = request.headers['x-signature'];
+const timestamp = parseInt(request.headers['x-timestamp']);
+```
+
+### 2. Verify Timestamp
+
+Check that the timestamp is not too old (recommended: 5 minutes):
+
+```javascript
+const now = Date.now();
+const maxAge = 5 * 60 * 1000; // 5 minutes
+
+if (now - timestamp > maxAge) {
+  throw new Error('Webhook timestamp is too old');
+}
+```
+
+### 3. Recreate Signature
+
+Create the canonical string and generate the expected signature:
+
+```javascript
+import { createHmac } from 'crypto';
+
+function verifySignature(payload, signature, timestamp, secret) {
+  // Remove the sha256= prefix
+  const receivedSignature = signature.replace('sha256=', '');
+  
+  // Create canonical string
+  const canonicalString = `${timestamp}.${JSON.stringify(payload)}`;
+  
+  // Generate expected signature
+  const hmac = createHmac('sha256', secret);
+  hmac.update(canonicalString);
+  const expectedSignature = hmac.digest('hex');
+  
+  // Compare signatures (use constant-time comparison)
+  return constantTimeCompare(receivedSignature, expectedSignature);
+}
+
+function constantTimeCompare(a, b) {
+  if (a.length !== b.length) {
+    return false;
+  }
+  
+  let result = 0;
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  
+  return result === 0;
+}
+```
+
+### 4. Complete Verification Example
+
+```javascript
+import express from 'express';
+import { createHmac } from 'crypto';
+
+const app = express();
+app.use(express.json());
+
+const WEBHOOK_SECRET = 'your-webhook-secret-here';
+
+function verifyWebhook(payload, signature, timestamp, secret) {
+  // Check timestamp age
+  const now = Date.now();
+  const maxAge = 5 * 60 * 1000; // 5 minutes
+  
+  if (now - timestamp > maxAge) {
+    return false;
+  }
+  
+  // Remove prefix and recreate signature
+  const receivedSignature = signature.replace('sha256=', '');
+  const canonicalString = `${timestamp}.${JSON.stringify(payload)}`;
+  
+  const hmac = createHmac('sha256', secret);
+  hmac.update(canonicalString);
+  const expectedSignature = hmac.digest('hex');
+  
+  // Constant-time comparison
+  return constantTimeCompare(receivedSignature, expectedSignature);
+}
+
+function constantTimeCompare(a, b) {
+  if (a.length !== b.length) return false;
+  
+  let result = 0;
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  
+  return result === 0;
+}
+
+app.post('/webhook', (req, res) => {
+  try {
+    const signature = req.headers['x-signature'];
+    const timestamp = parseInt(req.headers['x-timestamp']);
+    
+    if (!signature || !timestamp) {
+      return res.status(400).json({ error: 'Missing signature headers' });
+    }
+    
+    const isValid = verifyWebhook(req.body, signature, timestamp, WEBHOOK_SECRET);
+    
+    if (!isValid) {
+      return res.status(401).json({ error: 'Invalid webhook signature' });
+    }
+    
+    // Process valid webhook
+    console.log('Webhook verified successfully:', req.body);
+    res.status(200).json({ received: true });
+    
+  } catch (error) {
+    console.error('Webhook verification error:', error);
+    res.status(500).json({ error: 'Webhook processing failed' });
+  }
+});
+```
+
+## Security Best Practices
+
+1. **Never expose webhook secrets in logs or error messages**
+2. **Use constant-time comparison to prevent timing attacks**
+3. **Implement timestamp validation to prevent replay attacks**
+4. **Store webhook secrets securely (environment variables, secret management)**
+5. **Rotate webhook secrets periodically**
+6. **Monitor for failed signature verifications**
+
+## Language-Specific Examples
+
+### Python
+
+```python
+import hmac
+import hashlib
+import time
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+WEBHOOK_SECRET = 'your-webhook-secret-here'
+
+def verify_signature(payload, signature, timestamp, secret):
+    # Check timestamp age (5 minutes)
+    if time.time() * 1000 - timestamp > 5 * 60 * 1000:
+        return False
+    
+    # Remove sha256= prefix
+    received_signature = signature.replace('sha256=', '')
+    
+    # Create canonical string
+    canonical_string = f"{timestamp}.{payload}"
+    
+    # Generate expected signature
+    expected_signature = hmac.new(
+        secret.encode(),
+        canonical_string.encode(),
+        hashlib.sha256
+    ).hexdigest()
+    
+    # Constant-time comparison
+    return hmac.compare_digest(received_signature, expected_signature)
+
+@app.route('/webhook', methods=['POST'])
+def webhook():
+    signature = request.headers.get('X-Signature')
+    timestamp = int(request.headers.get('X-Timestamp', 0))
+    
+    if not signature or not timestamp:
+        return jsonify({'error': 'Missing signature headers'}), 400
+    
+    payload = request.get_data(as_text=True)
+    
+    if not verify_signature(payload, signature, timestamp, WEBHOOK_SECRET):
+        return jsonify({'error': 'Invalid webhook signature'}), 401
+    
+    # Process valid webhook
+    return jsonify({'received': True}), 200
+```
+
+### Ruby
+
+```ruby
+require 'openssl'
+require 'json'
+require 'sinatra'
+
+WEBHOOK_SECRET = 'your-webhook-secret-here'
+
+def verify_signature(payload, signature, timestamp, secret)
+  # Check timestamp age (5 minutes)
+  return false if (Time.now.to_f * 1000 - timestamp) > 5 * 60 * 1000
+  
+  # Remove sha256= prefix
+  received_signature = signature.sub('sha256=', '')
+  
+  # Create canonical string
+  canonical_string = "#{timestamp}.#{payload}"
+  
+  # Generate expected signature
+  expected_signature = OpenSSL::HMAC.hexdigest(
+    'sha256',
+    secret,
+    canonical_string
+  )
+  
+  # Constant-time comparison
+  OpenSSL.secure_compare(received_signature, expected_signature)
+end
+
+post '/webhook' do
+  signature = request.env['HTTP_X_SIGNATURE']
+  timestamp = request.env['HTTP_X_TIMESTAMP']&.to_i
+  
+  if signature.nil? || timestamp.nil?
+    halt 400, { error: 'Missing signature headers' }.to_json
+  end
+  
+  payload = request.body.read
+  
+  unless verify_signature(payload, signature, timestamp, WEBHOOK_SECRET)
+    halt 401, { error: 'Invalid webhook signature' }.to_json
+  end
+  
+  # Process valid webhook
+  content_type :json
+  { received: true }.to_json
+end
+```
+
+## Testing
+
+You can test webhook signature verification using our utility functions:
+
+```javascript
+import { createWebhookSignature, verifySignature } from './utils/webhook-signing.util';
+
+// Test signature creation and verification
+const payload = { event: 'user.created', data: { id: '123' } };
+const secret = 'test-secret';
+
+const { signature, timestamp } = createWebhookSignature(payload, secret);
+const isValid = verifySignature(payload, signature, timestamp, secret);
+
+console.log('Signature valid:', isValid); // Should be true
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"Invalid webhook signature"**
+   - Check that you're using the correct webhook secret
+   - Ensure you're parsing the JSON payload exactly as sent
+   - Verify you're removing the `sha256=` prefix before comparison
+
+2. **"Webhook timestamp is too old"**
+   - Check server clock synchronization
+   - Ensure you're using milliseconds, not seconds
+   - Consider adjusting the maximum age threshold
+
+3. **"Missing signature headers"**
+   - Ensure webhook secret is configured in Talenttrust Backend
+   - Check that headers are being forwarded correctly by proxies/load balancers
+
+### Debugging Steps
+
+1. Log the canonical string being used for signature generation
+2. Compare the expected and received signatures character by character
+3. Verify the payload JSON matches exactly (including whitespace)
+4. Check that timestamps are in milliseconds
+
+## Support
+
+If you encounter issues with webhook signature verification, please:
+
+1. Check this documentation for common solutions
+2. Verify your implementation against the examples provided
+3. Contact support with details about your implementation and specific error messages

--- a/src/services/webhook.service.test.ts
+++ b/src/services/webhook.service.test.ts
@@ -1,10 +1,18 @@
 import { WebhookService } from './webhook.service';
 import axios from 'axios';
+import { createWebhookSignature } from '../utils/webhook-signing.util';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
+jest.mock('../utils/webhook-signing.util');
+const mockedCreateWebhookSignature = createWebhookSignature as jest.MockedFunction<typeof createWebhookSignature>;
+
 describe('WebhookService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('moves a repeatedly failing delivery to the DLQ after max retries (fake timers)', async () => {
     jest.useFakeTimers();
     try {
@@ -31,5 +39,132 @@ describe('WebhookService', () => {
     } finally {
       jest.useRealTimers();
     }
+  });
+
+  it('sends webhook without signature when no secret is provided', async () => {
+    mockedAxios.post.mockResolvedValue({ status: 200 });
+
+    const service = new WebhookService();
+    const payload = {
+      id: '123',
+      url: 'http://test.com',
+      data: { event: 'test', data: {} },
+      retryCount: 0,
+    };
+
+    await service.send(payload);
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      'http://test.com',
+      { event: 'test', data: {} },
+      {
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }
+    );
+  });
+
+  it('sends webhook with HMAC signature when secret is provided', async () => {
+    const mockSignature = 'sha256=abcdef1234567890';
+    const mockTimestamp = 1640995200000;
+    
+    mockedCreateWebhookSignature.mockReturnValue({
+      signature: 'abcdef1234567890',
+      timestamp: mockTimestamp
+    });
+    
+    mockedAxios.post.mockResolvedValue({ status: 200 });
+
+    const service = new WebhookService();
+    const payload = {
+      id: '123',
+      url: 'http://test.com',
+      data: { event: 'test', data: {} },
+      retryCount: 0,
+      webhookSecret: 'test-secret'
+    };
+
+    await service.send(payload);
+
+    expect(mockedCreateWebhookSignature).toHaveBeenCalledWith(
+      { event: 'test', data: {} },
+      'test-secret'
+    );
+
+    expect(mockedAxios.post).toHaveBeenCalledWith(
+      'http://test.com',
+      { event: 'test', data: {} },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Signature': mockSignature,
+          'X-Timestamp': mockTimestamp.toString()
+        }
+      }
+    );
+  });
+
+  it('handles webhook delivery failure with HMAC signing', async () => {
+    const mockSignature = 'sha256=abcdef1234567890';
+    const mockTimestamp = 1640995200000;
+    
+    mockedCreateWebhookSignature.mockReturnValue({
+      signature: 'abcdef1234567890',
+      timestamp: mockTimestamp
+    });
+    
+    mockedAxios.post.mockRejectedValue(new Error('Network Error'));
+
+    const service = new WebhookService();
+    const payload = {
+      id: '123',
+      url: 'http://test.com',
+      data: { event: 'test', data: {} },
+      retryCount: 0,
+      webhookSecret: 'test-secret'
+    };
+
+    jest.useFakeTimers();
+    try {
+      const sendOp = service.send(payload);
+
+      // Run the first retry
+      await jest.runOnlyPendingTimersAsync();
+
+      await sendOp;
+
+      expect(mockedCreateWebhookSignature).toHaveBeenCalledTimes(2); // Initial + 1 retry
+      expect(mockedAxios.post).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('moves webhook with HMAC signing to DLQ after max retries', async () => {
+    const mockSignature = 'sha256=abcdef1234567890';
+    const mockTimestamp = 1640995200000;
+    
+    mockedCreateWebhookSignature.mockReturnValue({
+      signature: 'abcdef1234567890',
+      timestamp: mockTimestamp
+    });
+    
+    mockedAxios.post.mockRejectedValue(new Error('Network Error'));
+
+    const service = new WebhookService();
+    const payload = {
+      id: '123',
+      url: 'http://test.com',
+      data: { event: 'test', data: {} },
+      retryCount: 4, // Start with 4 retries (will fail on 5th attempt)
+      webhookSecret: 'test-secret'
+    };
+
+    await service.send(payload);
+
+    expect(service.getDLQ().length).toBe(1);
+    expect(service.getDLQ()[0].id).toBe('123');
+    expect(service.getDLQ()[0].webhookSecret).toBe('test-secret');
   });
 });

--- a/src/services/webhook.service.ts
+++ b/src/services/webhook.service.ts
@@ -1,10 +1,12 @@
 import axios from 'axios';
+import { createWebhookSignature } from '../utils/webhook-signing.util';
 
 export interface WebhookPayload {
   id: string;
   url: string;
   data: unknown;
   retryCount: number;
+  webhookSecret?: string;
 }
 
 interface DLQEntry extends WebhookPayload {
@@ -19,13 +21,26 @@ export class WebhookService {
   private dlq: DLQEntry[] = []; // In production, this would be a DB table or Redis list
 
   /**
-   * Sends a webhook with exponential backoff
+   * Sends a webhook with exponential backoff and HMAC signing
    */
   async send(payload: WebhookPayload): Promise<void> {
     try {
-      await axios.post(payload.url, payload.data, {
-        headers: { 'Content-Type': 'application/json' }
-      });
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json'
+      };
+
+      // Add HMAC signature if webhook secret is provided
+      if (payload.webhookSecret) {
+        const { signature, timestamp } = createWebhookSignature(
+          payload.data,
+          payload.webhookSecret
+        );
+        
+        headers['X-Signature'] = `sha256=${signature}`;
+        headers['X-Timestamp'] = timestamp.toString();
+      }
+
+      await axios.post(payload.url, payload.data, { headers });
       console.log(`Webhook ${payload.id} delivered successfully.`);
     } catch (error: any) {
       if (payload.retryCount < MAX_RETRIES) {

--- a/src/types/webhook.types.ts
+++ b/src/types/webhook.types.ts
@@ -4,6 +4,7 @@ export interface WebhookPayload {
   event: string;
   data: any;
   retryCount: number;
+  webhookSecret?: string;
 }
 
 export interface DLQEntry extends WebhookPayload {

--- a/src/utils/webhook-signing.util.test.ts
+++ b/src/utils/webhook-signing.util.test.ts
@@ -1,0 +1,189 @@
+import {
+  generateSignature,
+  createWebhookSignature,
+  verifySignature
+} from './webhook-signing.util';
+
+describe('Webhook Signing Utility', () => {
+  const secret = 'test-webhook-secret';
+  const payload = { event: 'user.created', data: { id: '123', email: 'test@example.com' } };
+
+  describe('generateSignature', () => {
+    it('should generate a consistent HMAC signature for the same input', () => {
+      const timestamp = 1640995200000; // Fixed timestamp for testing
+      const signature1 = generateSignature(payload, secret, timestamp);
+      const signature2 = generateSignature(payload, secret, timestamp);
+      
+      expect(signature1).toBe(signature2);
+      expect(signature1).toMatch(/^[a-f0-9]{64}$/); // 64 character hex string
+    });
+
+    it('should generate different signatures for different timestamps', () => {
+      const timestamp1 = 1640995200000;
+      const timestamp2 = 1640995201000;
+      const signature1 = generateSignature(payload, secret, timestamp1);
+      const signature2 = generateSignature(payload, secret, timestamp2);
+      
+      expect(signature1).not.toBe(signature2);
+    });
+
+    it('should generate different signatures for different secrets', () => {
+      const timestamp = 1640995200000;
+      const secret1 = 'secret1';
+      const secret2 = 'secret2';
+      const signature1 = generateSignature(payload, secret1, timestamp);
+      const signature2 = generateSignature(payload, secret2, timestamp);
+      
+      expect(signature1).not.toBe(signature2);
+    });
+
+    it('should generate different signatures for different payloads', () => {
+      const timestamp = 1640995200000;
+      const payload1 = { event: 'user.created' };
+      const payload2 = { event: 'user.updated' };
+      const signature1 = generateSignature(payload1, secret, timestamp);
+      const signature2 = generateSignature(payload2, secret, timestamp);
+      
+      expect(signature1).not.toBe(signature2);
+    });
+  });
+
+  describe('createWebhookSignature', () => {
+    it('should create a signature with current timestamp', () => {
+      const beforeTime = Date.now();
+      const result = createWebhookSignature(payload, secret);
+      const afterTime = Date.now();
+      
+      expect(result).toHaveProperty('signature');
+      expect(result).toHaveProperty('timestamp');
+      expect(result.timestamp).toBeGreaterThanOrEqual(beforeTime);
+      expect(result.timestamp).toBeLessThanOrEqual(afterTime);
+      expect(result.signature).toMatch(/^[a-f0-9]{64}$/);
+    });
+  });
+
+  describe('verifySignature', () => {
+    it('should verify a valid signature', () => {
+      const timestamp = Date.now();
+      const signature = generateSignature(payload, secret, timestamp);
+      
+      const isValid = verifySignature(payload, signature, timestamp, secret);
+      expect(isValid).toBe(true);
+    });
+
+    it('should reject an invalid signature', () => {
+      const timestamp = Date.now();
+      const invalidSignature = 'invalid-signature';
+      
+      const isValid = verifySignature(payload, invalidSignature, timestamp, secret);
+      expect(isValid).toBe(false);
+    });
+
+    it('should reject a signature with wrong secret', () => {
+      const timestamp = Date.now();
+      const signature = generateSignature(payload, secret, timestamp);
+      const wrongSecret = 'wrong-secret';
+      
+      const isValid = verifySignature(payload, signature, timestamp, wrongSecret);
+      expect(isValid).toBe(false);
+    });
+
+    it('should reject a signature with modified payload', () => {
+      const timestamp = Date.now();
+      const signature = generateSignature(payload, secret, timestamp);
+      const modifiedPayload = { ...payload, data: { id: '456' } };
+      
+      const isValid = verifySignature(modifiedPayload, signature, timestamp, secret);
+      expect(isValid).toBe(false);
+    });
+
+    it('should reject an old timestamp (more than 5 minutes)', () => {
+      const oldTimestamp = Date.now() - (6 * 60 * 1000); // 6 minutes ago
+      const signature = generateSignature(payload, secret, oldTimestamp);
+      
+      const isValid = verifySignature(payload, signature, oldTimestamp, secret);
+      expect(isValid).toBe(false);
+    });
+
+    it('should accept a recent timestamp (less than 5 minutes)', () => {
+      const recentTimestamp = Date.now() - (4 * 60 * 1000); // 4 minutes ago
+      const signature = generateSignature(payload, secret, recentTimestamp);
+      
+      const isValid = verifySignature(payload, signature, recentTimestamp, secret);
+      expect(isValid).toBe(true);
+    });
+
+    it('should handle edge case of exactly 5 minutes', () => {
+      const exactly5Minutes = Date.now() - (5 * 60 * 1000); // Exactly 5 minutes ago
+      const signature = generateSignature(payload, secret, exactly5Minutes);
+      
+      const isValid = verifySignature(payload, signature, exactly5Minutes, secret);
+      expect(isValid).toBe(false); // Should be rejected as it's exactly 5 minutes
+    });
+  });
+
+  describe('Integration Tests', () => {
+    it('should work end-to-end: create signature and verify it', () => {
+      const { signature, timestamp } = createWebhookSignature(payload, secret);
+      
+      const isValid = verifySignature(payload, signature, timestamp, secret);
+      expect(isValid).toBe(true);
+    });
+
+    it('should handle complex nested payloads', () => {
+      const complexPayload = {
+        event: 'order.completed',
+        data: {
+          orderId: '12345',
+          items: [
+            { id: 1, name: 'Product A', price: 29.99 },
+            { id: 2, name: 'Product B', price: 49.99 }
+          ],
+          customer: {
+            id: 'cust-123',
+            email: 'customer@example.com',
+            address: {
+              street: '123 Main St',
+              city: 'Anytown',
+              country: 'US'
+            }
+          },
+          metadata: {
+            source: 'web',
+            utm: { campaign: 'spring-sale' }
+          }
+        }
+      };
+
+      const { signature, timestamp } = createWebhookSignature(complexPayload, secret);
+      
+      const isValid = verifySignature(complexPayload, signature, timestamp, secret);
+      expect(isValid).toBe(true);
+    });
+
+    it('should handle empty payload', () => {
+      const emptyPayload = {};
+      const { signature, timestamp } = createWebhookSignature(emptyPayload, secret);
+      
+      const isValid = verifySignature(emptyPayload, signature, timestamp, secret);
+      expect(isValid).toBe(true);
+    });
+
+    it('should handle null and undefined values in payload', () => {
+      const payloadWithNulls = {
+        event: 'test.event',
+        data: {
+          id: '123',
+          name: null,
+          description: undefined,
+          active: true
+        }
+      };
+
+      const { signature, timestamp } = createWebhookSignature(payloadWithNulls, secret);
+      
+      const isValid = verifySignature(payloadWithNulls, signature, timestamp, secret);
+      expect(isValid).toBe(true);
+    });
+  });
+});

--- a/src/utils/webhook-signing.util.ts
+++ b/src/utils/webhook-signing.util.ts
@@ -1,0 +1,95 @@
+import { createHmac } from 'crypto';
+
+export interface WebhookSignature {
+  signature: string;
+  timestamp: number;
+}
+
+/**
+ * Generates an HMAC signature for webhook payloads
+ * @param payload The webhook payload to sign
+ * @param secret The secret key used for signing
+ * @param timestamp The timestamp to include in the signature
+ * @returns The HMAC signature
+ */
+export function generateSignature(
+  payload: unknown,
+  secret: string,
+  timestamp: number
+): string {
+  // Create the canonical string: timestamp + JSON.stringify(payload)
+  const canonicalString = `${timestamp}.${JSON.stringify(payload)}`;
+  
+  // Generate HMAC-SHA256 signature
+  const hmac = createHmac('sha256', secret);
+  hmac.update(canonicalString);
+  
+  return hmac.digest('hex');
+}
+
+/**
+ * Creates webhook signature headers
+ * @param payload The webhook payload to sign
+ * @param secret The secret key used for signing
+ * @returns Object containing signature and timestamp
+ */
+export function createWebhookSignature(
+  payload: unknown,
+  secret: string
+): WebhookSignature {
+  const timestamp = Date.now();
+  const signature = generateSignature(payload, secret, timestamp);
+  
+  return {
+    signature,
+    timestamp
+  };
+}
+
+/**
+ * Verifies a webhook signature
+ * @param payload The webhook payload that was received
+ * @param signature The signature from the X-Signature header
+ * @param timestamp The timestamp from the X-Timestamp header
+ * @param secret The secret key used for verification
+ * @returns True if the signature is valid, false otherwise
+ */
+export function verifySignature(
+  payload: unknown,
+  signature: string,
+  timestamp: number,
+  secret: string
+): boolean {
+  // Check if timestamp is too old (5 minutes)
+  const now = Date.now();
+  const maxAge = 5 * 60 * 1000; // 5 minutes in milliseconds
+  
+  if (now - timestamp > maxAge) {
+    return false;
+  }
+  
+  // Generate expected signature
+  const expectedSignature = generateSignature(payload, secret, timestamp);
+  
+  // Compare signatures using constant-time comparison
+  return constantTimeCompare(signature, expectedSignature);
+}
+
+/**
+ * Constant-time comparison to prevent timing attacks
+ * @param a First string to compare
+ * @param b Second string to compare
+ * @returns True if strings are equal, false otherwise
+ */
+function constantTimeCompare(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  
+  let result = 0;
+  for (let i = 0; i < a.length; i++) {
+    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  
+  return result === 0;
+}


### PR DESCRIPTION
- Implement HMAC-SHA256 signing utility with timestamp validation
- Add X-Signature and X-Timestamp headers to webhook requests
- Create comprehensive tests for signing and verification
- Add documentation for webhook signature verification
- Support optional webhookSecret in WebhookPayload interface
- Ensure secrets are not exposed in logs
- Include constant-time comparison for security

Fixes #166
closes#166