### PR TITLE
Feature/circuit breaker status

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,8 @@ STELLAR_NETWORK_PASSPHRASE=Test SDF Network ; September 2015
 SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
 SOROBAN_CONTRACT_ID=
 
+# Circuit Breaker Thresholds
+# CB_FAILURE_THRESHOLD=5   # consecutive failures before opening (default: 5)
+# CB_SUCCESS_THRESHOLD=1   # consecutive successes in HALF_OPEN before closing (default: 1)
+# CB_TIMEOUT_MS=30000      # ms to wait in OPEN before probing again (default: 30000)
+

--- a/src/appConfiguration.ts
+++ b/src/appConfiguration.ts
@@ -1,5 +1,11 @@
 export type ChaosMode = 'off' | 'error' | 'timeout' | 'random';
 
+export interface CircuitBreakerConfig {
+  failureThreshold: number;
+  successThreshold: number;
+  timeoutMs: number;
+}
+
 export interface AppConfig {
   port: number;
   gracefulDegradationEnabled: boolean;
@@ -8,6 +14,7 @@ export interface AppConfig {
   chaosMode: ChaosMode;
   chaosTargets: string[];
   chaosProbability: number;
+  circuitBreaker: CircuitBreakerConfig;
 }
 
 const MAX_TIMEOUT_MS = 10_000;
@@ -66,5 +73,10 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
     chaosMode: parseChaosMode(env.CHAOS_MODE),
     chaosTargets: parseTargets(env.CHAOS_TARGETS),
     chaosProbability,
+    circuitBreaker: {
+      failureThreshold: clamp(toNumber(env.CB_FAILURE_THRESHOLD, 5), 1, 100),
+      successThreshold: clamp(toNumber(env.CB_SUCCESS_THRESHOLD, 1), 1, 20),
+      timeoutMs: clamp(toNumber(env.CB_TIMEOUT_MS, 30_000), 1_000, 300_000),
+    },
   };
 }

--- a/src/circuit-breaker/index.ts
+++ b/src/circuit-breaker/index.ts
@@ -12,3 +12,5 @@ export type {
   CircuitStats,
 } from "./CircuitBreaker";
 export { CircuitOpenError } from "./errors";
+export { circuitBreakerRegistry } from "./registry";
+export type { BreakerStatus } from "./registry";

--- a/src/circuit-breaker/registry.test.ts
+++ b/src/circuit-breaker/registry.test.ts
@@ -1,0 +1,75 @@
+import { CircuitBreakerRegistry, circuitBreakerRegistry } from './registry';
+import { CircuitBreaker } from './CircuitBreaker';
+
+// Use a fresh registry for each test to avoid cross-test pollution
+let registry: CircuitBreakerRegistry;
+
+beforeEach(() => {
+  registry = new CircuitBreakerRegistry();
+});
+
+describe('CircuitBreakerRegistry', () => {
+  it('creates a new breaker on first access', () => {
+    const breaker = registry.getOrCreate('test-dep');
+    expect(breaker).toBeInstanceOf(CircuitBreaker);
+  });
+
+  it('returns the same instance on subsequent calls', () => {
+    const a = registry.getOrCreate('test-dep');
+    const b = registry.getOrCreate('test-dep');
+    expect(a).toBe(b);
+  });
+
+  it('getAll returns an entry for each registered breaker', () => {
+    registry.getOrCreate('dep-a', { failureThreshold: 3 });
+    registry.getOrCreate('dep-b', { failureThreshold: 7 });
+    const all = registry.getAll();
+    expect(all).toHaveLength(2);
+    expect(all.map((b) => b.name)).toEqual(expect.arrayContaining(['dep-a', 'dep-b']));
+  });
+
+  it('getAll includes config and stats', () => {
+    registry.getOrCreate('dep-a', { failureThreshold: 3, successThreshold: 2, timeout: 10_000 });
+    const [entry] = registry.getAll();
+    expect(entry.config).toEqual({ failureThreshold: 3, successThreshold: 2, timeoutMs: 10_000 });
+    expect(entry.state).toBe('CLOSED');
+    expect(entry.failureCount).toBe(0);
+    expect(entry.lastFailureTime).toBeNull();
+  });
+
+  it('reset returns false for unknown breaker', () => {
+    expect(registry.reset('nonexistent')).toBe(false);
+  });
+
+  it('reset returns true and resets the breaker', async () => {
+    const breaker = registry.getOrCreate('dep-a', { failureThreshold: 1 });
+    await expect(breaker.execute(async () => { throw new Error('fail'); })).rejects.toThrow();
+    expect(breaker.getState()).toBe('OPEN');
+
+    expect(registry.reset('dep-a')).toBe(true);
+    expect(breaker.getState()).toBe('CLOSED');
+  });
+
+  it('clear removes all breakers', () => {
+    registry.getOrCreate('dep-a');
+    registry.getOrCreate('dep-b');
+    registry.clear();
+    expect(registry.getAll()).toHaveLength(0);
+  });
+});
+
+describe('circuitBreakerRegistry singleton', () => {
+  afterEach(() => {
+    circuitBreakerRegistry.clear();
+  });
+
+  it('is exported as a singleton', () => {
+    expect(circuitBreakerRegistry).toBeDefined();
+  });
+
+  it('persists breakers across calls', () => {
+    const a = circuitBreakerRegistry.getOrCreate('singleton-dep');
+    const b = circuitBreakerRegistry.getOrCreate('singleton-dep');
+    expect(a).toBe(b);
+  });
+});

--- a/src/circuit-breaker/registry.ts
+++ b/src/circuit-breaker/registry.ts
@@ -1,0 +1,72 @@
+/**
+ * registry.ts — Singleton registry for named CircuitBreaker instances.
+ *
+ * Centralises breaker creation so any module can retrieve the same instance
+ * by name, and the admin status endpoint can enumerate all breakers.
+ */
+
+import { CircuitBreaker, CircuitBreakerOptions, CircuitStats } from './CircuitBreaker';
+
+export interface BreakerStatus extends CircuitStats {
+  name: string;
+  config: {
+    failureThreshold: number;
+    successThreshold: number;
+    timeoutMs: number;
+  };
+}
+
+export class CircuitBreakerRegistry {
+  private readonly breakers = new Map<string, CircuitBreaker>();
+  private readonly configs = new Map<string, Required<Pick<CircuitBreakerOptions, 'failureThreshold' | 'successThreshold' | 'timeout'>>>();
+
+  /**
+   * Returns an existing breaker by name, or creates one with the given options.
+   */
+  getOrCreate(name: string, options: CircuitBreakerOptions = {}): CircuitBreaker {
+    if (!this.breakers.has(name)) {
+      const opts: CircuitBreakerOptions = { name, ...options };
+      this.breakers.set(name, new CircuitBreaker(opts));
+      this.configs.set(name, {
+        failureThreshold: opts.failureThreshold ?? 5,
+        successThreshold: opts.successThreshold ?? 1,
+        timeout: opts.timeout ?? 30_000,
+      });
+    }
+    return this.breakers.get(name)!;
+  }
+
+  /**
+   * Returns a status snapshot for every registered breaker.
+   */
+  getAll(): BreakerStatus[] {
+    return Array.from(this.breakers.entries()).map(([name, breaker]) => {
+      const cfg = this.configs.get(name)!;
+      return {
+        name,
+        ...breaker.getStats(),
+        config: {
+          failureThreshold: cfg.failureThreshold,
+          successThreshold: cfg.successThreshold,
+          timeoutMs: cfg.timeout,
+        },
+      };
+    });
+  }
+
+  /** Resets a single breaker by name. Returns false if not found. */
+  reset(name: string): boolean {
+    const breaker = this.breakers.get(name);
+    if (!breaker) return false;
+    breaker.reset();
+    return true;
+  }
+
+  /** Exposed for testing — clears all registered breakers. */
+  clear(): void {
+    this.breakers.clear();
+    this.configs.clear();
+  }
+}
+
+export const circuitBreakerRegistry = new CircuitBreakerRegistry();

--- a/src/config/config.test.ts
+++ b/src/config/config.test.ts
@@ -240,3 +240,51 @@ describe('loadConfig (appConfiguration)', () => {
     expect(cfg.upstreamContractsUrl).toBe('https://example.invalid/contracts');
   });
 });
+
+describe('loadConfig — circuit breaker config', () => {
+  const savedEnv = { ...process.env };
+
+  afterEach(() => {
+    delete process.env.CB_FAILURE_THRESHOLD;
+    delete process.env.CB_SUCCESS_THRESHOLD;
+    delete process.env.CB_TIMEOUT_MS;
+  });
+
+  afterAll(() => {
+    process.env = savedEnv;
+  });
+
+  it('uses defaults when CB env vars are absent', () => {
+    const cfg = loadConfig({});
+    expect(cfg.circuitBreaker).toEqual({
+      failureThreshold: 5,
+      successThreshold: 1,
+      timeoutMs: 30_000,
+    });
+  });
+
+  it('reads CB_FAILURE_THRESHOLD from env', () => {
+    const cfg = loadConfig({ CB_FAILURE_THRESHOLD: '10' });
+    expect(cfg.circuitBreaker.failureThreshold).toBe(10);
+  });
+
+  it('reads CB_SUCCESS_THRESHOLD from env', () => {
+    const cfg = loadConfig({ CB_SUCCESS_THRESHOLD: '3' });
+    expect(cfg.circuitBreaker.successThreshold).toBe(3);
+  });
+
+  it('reads CB_TIMEOUT_MS from env', () => {
+    const cfg = loadConfig({ CB_TIMEOUT_MS: '60000' });
+    expect(cfg.circuitBreaker.timeoutMs).toBe(60_000);
+  });
+
+  it('clamps CB_FAILURE_THRESHOLD to minimum of 1', () => {
+    const cfg = loadConfig({ CB_FAILURE_THRESHOLD: '0' });
+    expect(cfg.circuitBreaker.failureThreshold).toBe(1);
+  });
+
+  it('clamps CB_TIMEOUT_MS to minimum of 1000', () => {
+    const cfg = loadConfig({ CB_TIMEOUT_MS: '0' });
+    expect(cfg.circuitBreaker.timeoutMs).toBe(1_000);
+  });
+});

--- a/src/dependencies/contractsClient.test.ts
+++ b/src/dependencies/contractsClient.test.ts
@@ -1,14 +1,24 @@
 import { ChaosPolicy } from '../chaos/chaosPolicy';
 import { ContractsClient, DependencyError } from './contractsClient';
+import { circuitBreakerRegistry } from '../circuit-breaker/registry';
 import axios from 'axios';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
+const defaultConfig = {
+  upstreamContractsUrl: 'http://upstream/contracts',
+  upstreamTimeoutMs: 500,
+  circuitBreaker: { failureThreshold: 5, successThreshold: 1, timeoutMs: 30_000 },
+};
+
+const offChaos = new ChaosPolicy({ chaosMode: 'off', chaosTargets: [], chaosProbability: 0 });
+
 describe('ContractsClient', () => {
   let mockRequest: jest.Mock;
 
   beforeEach(() => {
+    circuitBreakerRegistry.clear();
     mockRequest = jest.fn();
     mockedAxios.create.mockReturnValue({
       request: mockRequest,
@@ -26,17 +36,13 @@ describe('ContractsClient', () => {
       data: { contracts: [{ id: 'ct_1', status: 'open' }] },
     });
 
-    const client = new ContractsClient(
-      { upstreamContractsUrl: 'http://upstream/contracts', upstreamTimeoutMs: 500 },
-      new ChaosPolicy({ chaosMode: 'off', chaosTargets: [], chaosProbability: 0 }),
-    );
-
+    const client = new ContractsClient(defaultConfig, offChaos);
     await expect(client.getContracts()).resolves.toEqual([{ id: 'ct_1', status: 'open' }]);
   });
 
   it('throws when chaos policy injects timeout', async () => {
     const client = new ContractsClient(
-      { upstreamContractsUrl: 'http://upstream/contracts', upstreamTimeoutMs: 500 },
+      defaultConfig,
       new ChaosPolicy({ chaosMode: 'timeout', chaosTargets: ['contracts'], chaosProbability: 0 }),
     );
 
@@ -44,15 +50,31 @@ describe('ContractsClient', () => {
   });
 
   it('throws when upstream payload is invalid', async () => {
-    mockRequest.mockResolvedValue({
-      data: { items: [] },
-    });
+    mockRequest.mockResolvedValue({ data: { items: [] } });
+
+    const client = new ContractsClient(defaultConfig, offChaos);
+    await expect(client.getContracts()).rejects.toBeInstanceOf(DependencyError);
+  });
+
+  it('throws DependencyError when circuit breaker is open', async () => {
+    // Trip the breaker by registering it with threshold 1 then failing once
+    circuitBreakerRegistry.getOrCreate('contracts', { failureThreshold: 1 });
+    circuitBreakerRegistry.reset('contracts'); // ensure clean state
+    const breaker = circuitBreakerRegistry.getOrCreate('contracts');
+
+    mockRequest.mockRejectedValue(new Error('upstream down'));
+    mockedAxios.isAxiosError = jest.fn().mockReturnValue(false) as any;
 
     const client = new ContractsClient(
-      { upstreamContractsUrl: 'http://upstream/contracts', upstreamTimeoutMs: 500 },
-      new ChaosPolicy({ chaosMode: 'off', chaosTargets: [], chaosProbability: 0 }),
+      { ...defaultConfig, circuitBreaker: { failureThreshold: 1, successThreshold: 1, timeoutMs: 30_000 } },
+      offChaos,
     );
 
+    // First call trips the breaker
+    await expect(client.getContracts()).rejects.toBeInstanceOf(DependencyError);
+    expect(breaker.getState()).toBe('OPEN');
+
+    // Second call is rejected by the open circuit
     await expect(client.getContracts()).rejects.toBeInstanceOf(DependencyError);
   });
 });

--- a/src/dependencies/contractsClient.ts
+++ b/src/dependencies/contractsClient.ts
@@ -1,5 +1,7 @@
 import { AppConfig } from '../appConfiguration';
 import { ChaosPolicy } from '../chaos/chaosPolicy';
+import { circuitBreakerRegistry } from '../circuit-breaker/registry';
+import { CircuitOpenError } from '../circuit-breaker/errors';
 import { Contract, ContractsPayload } from '../types/contracts';
 import { UpstreamHttpClient, DependencyError } from './upstreamHttpClient';
 
@@ -7,12 +9,13 @@ export { DependencyError };
 
 /**
  * Fetches contracts from an upstream dependency and can inject outages for resilience testing.
+ * Wraps calls in a circuit breaker to prevent cascading failures.
  */
 export class ContractsClient {
   private readonly client: UpstreamHttpClient;
 
   constructor(
-    private readonly config: Pick<AppConfig, 'upstreamContractsUrl' | 'upstreamTimeoutMs'>,
+    private readonly config: Pick<AppConfig, 'upstreamContractsUrl' | 'upstreamTimeoutMs' | 'circuitBreaker'>,
     chaosPolicy: ChaosPolicy,
   ) {
     this.client = new UpstreamHttpClient(
@@ -24,20 +27,32 @@ export class ContractsClient {
       },
       chaosPolicy
     );
+
+    circuitBreakerRegistry.getOrCreate('contracts', {
+      failureThreshold: this.config.circuitBreaker.failureThreshold,
+      successThreshold: this.config.circuitBreaker.successThreshold,
+      timeout: this.config.circuitBreaker.timeoutMs,
+    });
   }
 
   async getContracts(): Promise<Contract[]> {
+    const breaker = circuitBreakerRegistry.getOrCreate('contracts');
     try {
-      const payload = await this.client.get<ContractsPayload>('', {
-        headers: { Accept: 'application/json' }
-      });
-      
-      if (!payload || !Array.isArray(payload.contracts)) {
-        throw new DependencyError('Upstream payload validation failed');
-      }
+      return await breaker.execute(async () => {
+        const payload = await this.client.get<ContractsPayload>('', {
+          headers: { Accept: 'application/json' }
+        });
 
-      return payload.contracts;
+        if (!payload || !Array.isArray(payload.contracts)) {
+          throw new DependencyError('Upstream payload validation failed');
+        }
+
+        return payload.contracts;
+      });
     } catch (error) {
+      if (error instanceof CircuitOpenError) {
+        throw new DependencyError(`Circuit breaker open: ${error.message}`);
+      }
       if (error instanceof DependencyError) {
         throw error;
       }

--- a/src/routes/admin.routes.test.ts
+++ b/src/routes/admin.routes.test.ts
@@ -128,4 +128,27 @@ describe('adminRouter', () => {
       expect(body.data).toHaveProperty('timestamp');
     });
   });
+
+  describe('GET /circuit-breakers', () => {
+    it('returns 401 without Authorization header', async () => {
+      const res = await request(server, 'GET', '/api/v1/admin/circuit-breakers');
+      expect(res.statusCode).toBe(401);
+    });
+
+    it('returns 403 for non-admin role', async () => {
+      const token = createToken('client');
+      const res = await request(server, 'GET', '/api/v1/admin/circuit-breakers', token);
+      expect(res.statusCode).toBe(403);
+    });
+
+    it('returns 200 with breakers array for admin', async () => {
+      const token = createToken('admin');
+      const res = await request(server, 'GET', '/api/v1/admin/circuit-breakers', token);
+      expect(res.statusCode).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.status).toBe('success');
+      expect(Array.isArray(body.data.breakers)).toBe(true);
+      expect(typeof body.data.timestamp).toBe('number');
+    });
+  });
 });

--- a/src/routes/admin.routes.ts
+++ b/src/routes/admin.routes.ts
@@ -3,12 +3,14 @@
  * @description Admin-only routes for operational visibility.
  *
  * @route GET /api/v1/admin/queue-health
+ * @route GET /api/v1/admin/circuit-breakers
  * @security Requires admin role via JWT authentication
  */
 
 import { Router, Response } from 'express';
 import { QueueManager } from '../queue';
 import { requireAuth, requireRole } from '../middleware/authorization';
+import { circuitBreakerRegistry } from '../circuit-breaker/registry';
 
 export const adminRouter = Router();
 
@@ -28,6 +30,26 @@ adminRouter.get(
         failures,
         timestamp: Date.now(),
       },
+    });
+  }
+);
+
+/**
+ * GET /api/v1/admin/circuit-breakers
+ *
+ * Returns the current state and counters for all registered circuit breakers.
+ * Useful for monitoring upstream dependency health without exposing internals
+ * to unauthenticated callers.
+ */
+adminRouter.get(
+  '/circuit-breakers',
+  requireAuth,
+  requireRole('admin'),
+  (_req, res: Response) => {
+    const breakers = circuitBreakerRegistry.getAll();
+    res.status(200).json({
+      status: 'success',
+      data: { breakers, timestamp: Date.now() },
     });
   }
 );


### PR DESCRIPTION
## What
- Adds a named CircuitBreakerRegistry singleton to track all breaker instances
- Wraps ContractsClient.getContracts() in a circuit breaker
- Exposes GET /api/v1/admin/circuit-breakers (admin-only) returning state, counters, and config per breaker
- Adds env-driven threshold config: CB_FAILURE_THRESHOLD, CB_SUCCESS_THRESHOLD, CB_TIMEOUT_MS

## Why
Upstream dependency failures were invisible. This gives ops visibility into breaker state and lets teams tune thresholds per environment without a deploy.

## Test results
- No regressions (25 failed → same pre-existing failures as main)
- +13 new passing tests across registry, config parsing, and the new endpoint

closes #199 