### PR TITLE
feat: add sqlite schema migrations and versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ The backend uses an embedded **SQLite** database (via `better-sqlite3`) — no e
 | -------------------- | ---------------- | ----------------------------------------------------------- |
 | `DB_PATH`            | `talenttrust.db` | Path to the SQLite file. Use `:memory:` for ephemeral mode. |
 
-Schema migrations run automatically on startup. See [`docs/backend/database.md`](docs/backend/database.md) for full documentation: schema, repository API, configuration, and security notes.
+Schema migrations run automatically on startup and record applied versions in `schema_version`. See [`docs/backend/database.md`](docs/backend/database.md) for full documentation: schema, versioning, rollback guidance, repository API, configuration, and security notes.
 
 ## Circuit Breaker
 

--- a/docs/backend/database.md
+++ b/docs/backend/database.md
@@ -47,6 +47,7 @@ Set `DB_PATH=:memory:` to use an **in-memory** database (data is lost on process
 | `freelancer_id` | TEXT    | NOT NULL, REFERENCES users(id)                                           |
 | `amount`        | INTEGER | NOT NULL, CHECK >= 0 (stored in stroops; 1 XLM = 10,000,000 stroops)     |
 | `status`        | TEXT    | NOT NULL, CHECK IN ('draft','active','completed','disputed','cancelled') |
+| `version`       | INTEGER | NOT NULL, default `0`, CHECK >= 0 (optimistic concurrency control)        |
 | `created_at`    | TEXT    | NOT NULL (ISO-8601)                                                      |
 
 **Indexes**: `idx_contracts_client_id`, `idx_contracts_freelancer_id`, `idx_contracts_status`.
@@ -90,7 +91,25 @@ const repo = new UserRepository(getDb());
 
 ## Migrations
 
-Schema is applied automatically via `runMigrations()` inside `database.ts` on every startup. All statements use `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` so re-runs are **idempotent**.
+Schema migrations run automatically on startup via `runMigrations()` in `src/db/migrations.ts`.
+
+### Versioning model
+
+- `schema_version` table tracks each applied migration version (`INTEGER PRIMARY KEY`) and timestamp.
+- Migrations are ordered, immutable, and sequential (`1..N`).
+- Startup applies only missing versions, making reruns idempotent and safe for repeated deploys.
+
+### Safety guarantees
+
+- Each migration runs inside a SQLite transaction.
+- If a migration throws, SQLite rolls back that migration's partial changes.
+- Failed migrations are not recorded in `schema_version`, so recovery is deterministic.
+
+### Rollback plan
+
+- For urgent rollback to previous app code, restore a DB snapshot made before deployment.
+- Because migrations are additive and idempotent, redeploying the fixed build safely resumes from the last applied version.
+- Keep migration files immutable; create a new migration to correct prior schema changes instead of editing old ones.
 
 ---
 

--- a/src/db/database.test.ts
+++ b/src/db/database.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { getDb, closeDb } from "./database";
+import { getLatestSchemaVersion } from "./migrations";
 
 afterEach(() => {
   closeDb();
@@ -42,6 +43,23 @@ describe("getDb", () => {
       )
       .get() as { name: string } | undefined;
     expect(row?.name).toBe("users");
+  });
+
+  it("creates a schema_version table and applies latest version", () => {
+    const db = getDb(":memory:");
+    const row = db
+      .prepare<[], { name: string }>(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='schema_version'",
+      )
+      .get();
+    expect(row?.name).toBe("schema_version");
+
+    const versionRow = db
+      .prepare<[], { version: number }>(
+        "SELECT MAX(version) AS version FROM schema_version",
+      )
+      .get();
+    expect(versionRow?.version).toBe(getLatestSchemaVersion());
   });
 
   it("creates an index on contracts.client_id", () => {

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -17,6 +17,7 @@
 
 import Database from "better-sqlite3";
 import path from "path";
+import { runMigrations } from "./migrations";
 
 let instance: Database.Database | null = null;
 
@@ -53,54 +54,3 @@ export function closeDb(): void {
   }
 }
 
-/**
- * Runs all DDL migrations against the provided database connection.
- * Each statement uses IF NOT EXISTS so re-runs are idempotent.
- *
- * @param db - An open better-sqlite3 Database instance.
- */
-function runMigrations(db: Database.Database): void {
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS users (
-      id          TEXT    PRIMARY KEY,
-      username    TEXT    NOT NULL UNIQUE,
-      email       TEXT    NOT NULL UNIQUE,
-      role        TEXT    NOT NULL DEFAULT 'client'
-                          CHECK (role IN ('client', 'freelancer', 'both')),
-      created_at  TEXT    NOT NULL
-    );
-
-    CREATE TABLE IF NOT EXISTS contracts (
-      id            TEXT    PRIMARY KEY,
-      title         TEXT    NOT NULL,
-      client_id     TEXT    NOT NULL REFERENCES users(id),
-      freelancer_id TEXT    NOT NULL REFERENCES users(id),
-      amount        INTEGER NOT NULL CHECK (amount >= 0),
-      status        TEXT    NOT NULL DEFAULT 'draft'
-                            CHECK (status IN (
-                              'draft', 'active', 'completed', 'disputed', 'cancelled'
-                            )),
-      version       INTEGER NOT NULL DEFAULT 0 CHECK (version >= 0),
-      created_at    TEXT    NOT NULL
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_contracts_client_id
-      ON contracts(client_id);
-
-    CREATE INDEX IF NOT EXISTS idx_contracts_freelancer_id
-      ON contracts(freelancer_id);
-
-    CREATE INDEX IF NOT EXISTS idx_contracts_status
-      ON contracts(status);
-  `);
-
-  // Migration guard: add version column to existing databases that pre-date OCC.
-  // PRAGMA table_info returns one row per column; if 'version' is absent we add it.
-  const columns = db.pragma("table_info(contracts)") as Array<{ name: string }>;
-  const hasVersion = columns.some((col) => col.name === "version");
-  if (!hasVersion) {
-    db.exec(
-      "ALTER TABLE contracts ADD COLUMN version INTEGER NOT NULL DEFAULT 0"
-    );
-  }
-}

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -1,0 +1,113 @@
+import Database from "better-sqlite3";
+import { Migration, runMigrations, getLatestSchemaVersion } from "./migrations";
+
+describe("runMigrations", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("creates schema_version records for applied migrations", () => {
+    runMigrations(db);
+
+    const rows = db
+      .prepare<[], { version: number }>(
+        "SELECT version FROM schema_version ORDER BY version ASC"
+      )
+      .all();
+
+    expect(rows.map((row) => row.version)).toEqual([1, 2]);
+  });
+
+  it("is idempotent when run multiple times", () => {
+    runMigrations(db);
+    runMigrations(db);
+
+    const row = db
+      .prepare<[], { total: number }>(
+        "SELECT COUNT(*) AS total FROM schema_version"
+      )
+      .get();
+
+    expect(row?.total).toBe(getLatestSchemaVersion());
+  });
+
+  it("supports existing databases by applying only missing versions", () => {
+    db.exec(`
+      CREATE TABLE users (
+        id          TEXT    PRIMARY KEY,
+        username    TEXT    NOT NULL UNIQUE,
+        email       TEXT    NOT NULL UNIQUE,
+        role        TEXT    NOT NULL DEFAULT 'client'
+                            CHECK (role IN ('client', 'freelancer', 'both')),
+        created_at  TEXT    NOT NULL
+      );
+
+      CREATE TABLE contracts (
+        id            TEXT    PRIMARY KEY,
+        title         TEXT    NOT NULL,
+        client_id     TEXT    NOT NULL REFERENCES users(id),
+        freelancer_id TEXT    NOT NULL REFERENCES users(id),
+        amount        INTEGER NOT NULL CHECK (amount >= 0),
+        status        TEXT    NOT NULL DEFAULT 'draft'
+                              CHECK (status IN (
+                                'draft', 'active', 'completed', 'disputed', 'cancelled'
+                              )),
+        created_at    TEXT    NOT NULL
+      );
+    `);
+
+    runMigrations(db);
+
+    const columns = db.pragma("table_info(contracts)") as Array<{ name: string }>;
+    expect(columns.some((column) => column.name === "version")).toBe(true);
+
+    const row = db
+      .prepare<[number], { version: number }>(
+        "SELECT version FROM schema_version WHERE version = ?"
+      )
+      .get(2);
+
+    expect(row?.version).toBe(2);
+  });
+
+  it("rolls back a failed migration and does not record it", () => {
+    const testMigrations: Migration[] = [
+      {
+        version: 1,
+        name: "create_demo_table",
+        up: (migrationDb) => {
+          migrationDb.exec("CREATE TABLE demo (id INTEGER PRIMARY KEY);");
+        },
+      },
+      {
+        version: 2,
+        name: "fail_after_partial_write",
+        up: (migrationDb) => {
+          migrationDb.exec("INSERT INTO demo (id) VALUES (1);");
+          throw new Error("migration failed");
+        },
+      },
+    ];
+
+    expect(() => runMigrations(db, testMigrations)).toThrow("migration failed");
+
+    const versions = db
+      .prepare<[], { version: number }>(
+        "SELECT version FROM schema_version ORDER BY version ASC"
+      )
+      .all()
+      .map((row) => row.version);
+    expect(versions).toEqual([1]);
+
+    const row = db
+      .prepare<[], { total: number }>("SELECT COUNT(*) AS total FROM demo")
+      .get();
+    expect(row?.total).toBe(0);
+  });
+});

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -1,0 +1,128 @@
+import Database from "better-sqlite3";
+
+export interface Migration {
+  version: number;
+  name: string;
+  up: (db: Database.Database) => void;
+}
+
+const MIGRATIONS: Migration[] = [
+  {
+    version: 1,
+    name: "create_users_and_contracts_schema",
+    up: (db) => {
+      db.exec(`
+        CREATE TABLE IF NOT EXISTS users (
+          id          TEXT    PRIMARY KEY,
+          username    TEXT    NOT NULL UNIQUE,
+          email       TEXT    NOT NULL UNIQUE,
+          role        TEXT    NOT NULL DEFAULT 'client'
+                              CHECK (role IN ('client', 'freelancer', 'both')),
+          created_at  TEXT    NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS contracts (
+          id            TEXT    PRIMARY KEY,
+          title         TEXT    NOT NULL,
+          client_id     TEXT    NOT NULL REFERENCES users(id),
+          freelancer_id TEXT    NOT NULL REFERENCES users(id),
+          amount        INTEGER NOT NULL CHECK (amount >= 0),
+          status        TEXT    NOT NULL DEFAULT 'draft'
+                                CHECK (status IN (
+                                  'draft', 'active', 'completed', 'disputed', 'cancelled'
+                                )),
+          created_at    TEXT    NOT NULL
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_contracts_client_id
+          ON contracts(client_id);
+
+        CREATE INDEX IF NOT EXISTS idx_contracts_freelancer_id
+          ON contracts(freelancer_id);
+
+        CREATE INDEX IF NOT EXISTS idx_contracts_status
+          ON contracts(status);
+      `);
+    },
+  },
+  {
+    version: 2,
+    name: "add_contract_version_column",
+    up: (db) => {
+      const columns = db.pragma("table_info(contracts)") as Array<{ name: string }>;
+      const hasVersion = columns.some((col) => col.name === "version");
+      if (!hasVersion) {
+        db.exec(
+          "ALTER TABLE contracts ADD COLUMN version INTEGER NOT NULL DEFAULT 0 CHECK (version >= 0)"
+        );
+      }
+    },
+  },
+];
+
+function ensureMigrationTable(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS schema_version (
+      version     INTEGER PRIMARY KEY,
+      name        TEXT    NOT NULL,
+      applied_at  TEXT    NOT NULL
+    );
+  `);
+}
+
+function getAppliedVersions(db: Database.Database): Set<number> {
+  const rows = db
+    .prepare<[], { version: number }>(
+      "SELECT version FROM schema_version ORDER BY version ASC"
+    )
+    .all();
+
+  return new Set(rows.map((row) => row.version));
+}
+
+function assertMigrationsAreValid(migrations: Migration[]): void {
+  const sortedVersions = [...migrations.map((m) => m.version)].sort((a, b) => a - b);
+
+  for (let index = 0; index < sortedVersions.length; index += 1) {
+    const expectedVersion = index + 1;
+    if (sortedVersions[index] !== expectedVersion) {
+      throw new Error(
+        `Invalid migration sequence: expected version ${expectedVersion}, got ${sortedVersions[index]}`
+      );
+    }
+  }
+}
+
+export function runMigrations(
+  db: Database.Database,
+  migrations: Migration[] = MIGRATIONS
+): void {
+  assertMigrationsAreValid(migrations);
+  ensureMigrationTable(db);
+
+  const appliedVersions = getAppliedVersions(db);
+  const insertApplied = db.prepare<[number, string, string]>(
+    "INSERT INTO schema_version (version, name, applied_at) VALUES (?, ?, ?)"
+  );
+
+  for (const migration of migrations) {
+    if (appliedVersions.has(migration.version)) {
+      continue;
+    }
+
+    const applyMigration = db.transaction(() => {
+      migration.up(db);
+      insertApplied.run(
+        migration.version,
+        migration.name,
+        new Date().toISOString()
+      );
+    });
+
+    applyMigration();
+  }
+}
+
+export function getLatestSchemaVersion(): number {
+  return MIGRATIONS[MIGRATIONS.length - 1]?.version ?? 0;
+}


### PR DESCRIPTION
## Summary
- introduce a versioned SQLite migration runner with a `schema_version` table and sequential migration validation
- execute each migration in a transaction to guarantee rollback safety on failure and idempotent reruns on deployment
- add migration-focused tests for applied-version tracking, idempotency, legacy-schema upgrade behavior, and rollback semantics
- update backend database docs/README to document schema versioning and rollback plan

## Test plan
- [x] `npm test -- src/db/database.test.ts src/db/migrations.test.ts`
- [ ] `npm run test:ci` *(currently failing due existing unrelated TypeScript errors in other modules)*
- [ ] `npm run build` *(currently failing due existing unrelated TypeScript errors in other modules)*

Closes #157