### PR TITLE
feat: add ETag support for contract metadata reads

### DIFF
--- a/docs/backend/contract-metadata-api.md
+++ b/docs/backend/contract-metadata-api.md
@@ -123,6 +123,7 @@ Retrieve paginated metadata records for a contract.
 - `400`: Invalid query parameters
 - `401`: Authentication required
 - `403`: Access denied to this contract
+- `304`: Not Modified (when `If-None-Match` matches current representation)
 
 ---
 
@@ -157,6 +158,25 @@ Retrieve a specific metadata record.
 - `401`: Authentication required
 - `403`: Access denied to this contract
 - `404`: Metadata not found
+- `304`: Not Modified (when `If-None-Match` matches current representation)
+
+---
+
+## HTTP Caching with ETag
+
+Read-heavy metadata endpoints return an `ETag` header:
+
+- `GET /contracts/{contractId}/metadata`
+- `GET /contracts/{contractId}/metadata/{id}`
+
+Clients can send `If-None-Match` with a previously received ETag. If unchanged,
+the API returns `304 Not Modified` with no response body.
+
+Security notes:
+
+- ETags are generated from a SHA-256 hash of the response representation and a scoped resource key.
+- Sensitive values are masked before hashing for unauthorized users, preventing raw sensitive data exposure through cache validators.
+- ETag generation does not include direct plaintext metadata secrets.
 
 ---
 

--- a/src/modules/contractMetadata/contractMetadata.controller.test.ts
+++ b/src/modules/contractMetadata/contractMetadata.controller.test.ts
@@ -1,0 +1,127 @@
+import { ContractMetadataController } from './contractMetadata.controller';
+import { contractMetadataService } from './contractMetadata.service';
+import { AuthenticatedRequest } from '../../middleware/auth';
+
+jest.mock('./contractMetadata.service', () => ({
+  contractMetadataService: {
+    list: jest.fn(),
+    getById: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn()
+  }
+}));
+
+function createMockResponse() {
+  const res: any = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  res.send = jest.fn().mockReturnValue(res);
+  res.end = jest.fn().mockReturnValue(res);
+  res.setHeader = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+describe('ContractMetadataController ETag support', () => {
+  const controller = new ContractMetadataController();
+  const mockedService = contractMetadataService as jest.Mocked<typeof contractMetadataService>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns ETag for list and responds 304 when If-None-Match matches', async () => {
+    const payload = {
+      records: [
+        {
+          id: 'meta-1',
+          contract_id: 'contract-1',
+          key: 'k',
+          value: 'v',
+          data_type: 'string' as const,
+          is_sensitive: false,
+          created_by: 'demo-user-id',
+          updated_by: undefined,
+          created_at: '2026-01-01T00:00:00.000Z',
+          updated_at: '2026-01-01T00:00:00.000Z'
+        }
+      ],
+      total: 1,
+      page: 1,
+      limit: 20
+    };
+
+    mockedService.list.mockResolvedValue(payload);
+
+    const req1 = {
+      user: { id: 'demo-user-id', role: 'user' },
+      params: { contractId: 'contract-1' },
+      query: {}
+    } as unknown as AuthenticatedRequest;
+    const res1 = createMockResponse();
+
+    await controller.list(req1, res1);
+
+    expect(res1.setHeader).toHaveBeenCalledWith('ETag', expect.any(String));
+    expect(res1.json).toHaveBeenCalledWith(payload);
+
+    const etag = res1.setHeader.mock.calls[0][1] as string;
+
+    const req2 = {
+      user: { id: 'demo-user-id', role: 'user' },
+      params: { contractId: 'contract-1' },
+      query: {},
+      headers: { 'if-none-match': etag }
+    } as unknown as AuthenticatedRequest;
+    const res2 = createMockResponse();
+
+    await controller.list(req2, res2);
+
+    expect(res2.status).toHaveBeenCalledWith(304);
+    expect(res2.end).toHaveBeenCalled();
+    expect(res2.json).not.toHaveBeenCalled();
+  });
+
+  it('returns ETag for getById and responds 304 when If-None-Match matches', async () => {
+    const payload = {
+      id: 'meta-1',
+      contract_id: 'contract-1',
+      key: 'k',
+      value: 'v',
+      data_type: 'string' as const,
+      is_sensitive: false,
+      created_by: 'demo-user-id',
+      updated_by: undefined,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z'
+    };
+
+    mockedService.getById.mockResolvedValue(payload);
+
+    const req1 = {
+      user: { id: 'demo-user-id', role: 'user' },
+      params: { id: 'meta-1' },
+      headers: {}
+    } as unknown as AuthenticatedRequest;
+    const res1 = createMockResponse();
+
+    await controller.getById(req1, res1);
+
+    expect(res1.setHeader).toHaveBeenCalledWith('ETag', expect.any(String));
+    expect(res1.json).toHaveBeenCalledWith(payload);
+
+    const etag = res1.setHeader.mock.calls[0][1] as string;
+    const req2 = {
+      user: { id: 'demo-user-id', role: 'user' },
+      params: { id: 'meta-1' },
+      headers: { 'if-none-match': etag }
+    } as unknown as AuthenticatedRequest;
+    const res2 = createMockResponse();
+
+    await controller.getById(req2, res2);
+
+    expect(res2.status).toHaveBeenCalledWith(304);
+    expect(res2.end).toHaveBeenCalled();
+    expect(res2.json).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/contractMetadata/contractMetadata.controller.ts
+++ b/src/modules/contractMetadata/contractMetadata.controller.ts
@@ -3,6 +3,7 @@ import { AuthenticatedRequest } from '../../middleware/auth';
 import { contractMetadataService } from './contractMetadata.service';
 import { CreateContractMetadataRequest, UpdateContractMetadataRequest } from './contractMetadata.types';
 import { parsePaginationQuery } from '../../utils/pagination';
+import { buildEtag, isIfNoneMatchSatisfied } from '../../utils/etag';
 
 /**
  * Controller layer for contract metadata operations
@@ -80,6 +81,13 @@ export class ContractMetadataController {
         req.user
       );
 
+      const etag = buildEtag(`contract-metadata:list:${contractId}`, result);
+      res.setHeader('ETag', etag);
+      if (isIfNoneMatchSatisfied(req.headers?.['if-none-match'], etag)) {
+        res.status(304).end();
+        return;
+      }
+
       res.json(result);
     } catch {
       res.status(500).json({ error: 'Internal server error' });
@@ -104,6 +112,13 @@ export class ContractMetadataController {
 
       if (!result) {
         res.status(404).json({ error: 'Metadata not found' });
+        return;
+      }
+
+      const etag = buildEtag(`contract-metadata:item:${id}`, result);
+      res.setHeader('ETag', etag);
+      if (isIfNoneMatchSatisfied(req.headers?.['if-none-match'], etag)) {
+        res.status(304).end();
         return;
       }
 

--- a/src/utils/etag.test.ts
+++ b/src/utils/etag.test.ts
@@ -1,0 +1,38 @@
+import { buildEtag, isIfNoneMatchSatisfied } from './etag';
+
+describe('etag utils', () => {
+  it('builds stable etags for the same scope and payload', () => {
+    const payload = { records: [{ id: '1', value: '***REDACTED***' }], total: 1 };
+    const tag1 = buildEtag('contract-metadata:list:contract-1', payload);
+    const tag2 = buildEtag('contract-metadata:list:contract-1', payload);
+
+    expect(tag1).toBe(tag2);
+    expect(tag1.startsWith('"')).toBe(true);
+    expect(tag1.endsWith('"')).toBe(true);
+  });
+
+  it('changes etag when payload changes', () => {
+    const tag1 = buildEtag('contract-metadata:item:meta-1', { value: 'v1' });
+    const tag2 = buildEtag('contract-metadata:item:meta-1', { value: 'v2' });
+
+    expect(tag1).not.toBe(tag2);
+  });
+
+  it('matches If-None-Match for exact and weak tags', () => {
+    const etag = buildEtag('scope', { ok: true });
+    expect(isIfNoneMatchSatisfied(etag, etag)).toBe(true);
+    expect(isIfNoneMatchSatisfied(`W/${etag}`, etag)).toBe(true);
+    expect(isIfNoneMatchSatisfied(`"other", W/${etag}`, etag)).toBe(true);
+  });
+
+  it('supports wildcard If-None-Match', () => {
+    const etag = buildEtag('scope', { ok: true });
+    expect(isIfNoneMatchSatisfied('*', etag)).toBe(true);
+  });
+
+  it('returns false when If-None-Match does not match', () => {
+    const etag = buildEtag('scope', { ok: true });
+    expect(isIfNoneMatchSatisfied('"different"', etag)).toBe(false);
+    expect(isIfNoneMatchSatisfied(undefined, etag)).toBe(false);
+  });
+});

--- a/src/utils/etag.ts
+++ b/src/utils/etag.ts
@@ -1,0 +1,41 @@
+import { createHash } from 'crypto';
+
+function normalizeEtag(tag: string): string {
+  const trimmed = tag.trim();
+  if (trimmed.startsWith('W/')) {
+    return trimmed.slice(2);
+  }
+  return trimmed;
+}
+
+export function buildEtag(scope: string, payload: unknown): string {
+  const serializedPayload = JSON.stringify(payload);
+  const digest = createHash('sha256')
+    .update(scope)
+    .update(':')
+    .update(serializedPayload)
+    .digest('base64url');
+
+  return `"${digest}"`;
+}
+
+export function isIfNoneMatchSatisfied(
+  ifNoneMatchHeader: string | string[] | undefined,
+  etag: string
+): boolean {
+  if (!ifNoneMatchHeader) {
+    return false;
+  }
+
+  const rawValue = Array.isArray(ifNoneMatchHeader)
+    ? ifNoneMatchHeader.join(',')
+    : ifNoneMatchHeader;
+
+  const candidateTags = rawValue.split(',').map((value) => value.trim());
+  if (candidateTags.includes('*')) {
+    return true;
+  }
+
+  const normalizedTarget = normalizeEtag(etag);
+  return candidateTags.some((candidate) => normalizeEtag(candidate) === normalizedTarget);
+}


### PR DESCRIPTION
## Summary
- add ETag generation for contract metadata read-heavy endpoints (`list` and `getById`)
- honor `If-None-Match` and return `304 Not Modified` when the representation has not changed
- implement a stable and secure ETag utility using SHA-256 over scoped response payloads
- add tests for ETag generation and controller-level `304` behavior
- document ETag/304 semantics and security considerations in the contract metadata API docs

## Test plan
- [x] `npm test -- src/utils/etag.test.ts src/modules/contractMetadata/contractMetadata.controller.test.ts`
- [ ] `npm run test:ci` *(currently failing due unrelated pre-existing repo-wide TypeScript/test issues)*

Closes #162