### PR TITLE
feat: add audit log repository abstraction with sqlite backend

### DIFF
--- a/docs/backend/audit-log.md
+++ b/docs/backend/audit-log.md
@@ -11,7 +11,9 @@ The TalentTrust audit log provides **immutable, tamper-evident recording** of al
 ```
 src/audit/
 ├── types.ts                       — Core interfaces and type definitions
-├── store.ts                       — Append-only, hash-chained in-memory store
+├── repository.ts                  — Repository interface + backend selection
+├── store.ts                       — In-memory repository implementation
+├── sqliteRepository.ts            — Durable SQLite repository implementation
 ├── service.ts                     — Application-level facade with convenience wrappers
 ├── redact.ts                      — Deterministic redaction rules (headers, body, email)
 ├── middleware.ts                  — Express middleware (attaches audit helper to res.locals)
@@ -179,6 +181,11 @@ Verify the hash chain. Returns `200` if valid, `409` if corruption is detected.
 
 Retrieve a single entry by UUID. Returns `404` if not found.
 
+### `GET /api/v1/audit/export`
+
+Stream entries as newline-delimited JSON (`application/x-ndjson`) for export use cases.
+This endpoint uses repository streaming to avoid loading all rows in memory.
+
 ---
 
 ## Automatic Audit Logging for Protected Endpoints
@@ -320,7 +327,9 @@ Numbers, booleans, and `null`/`undefined` pass through unmodified.
 
 ### Production Hardening Checklist
 
-- [ ] Replace in-memory store with a write-once database (PostgreSQL with no `UPDATE`/`DELETE` grants, or an append-only table with row-level security)
+- [x] Repository pattern implemented with pluggable backends (`memory`, `sqlite`)
+- [x] Durable SQLite backend available via `AUDIT_STORAGE_BACKEND=sqlite`
+- [ ] For production, use a write-once policy (no `UPDATE`/`DELETE` grants) and strict file/database access controls
 - [ ] Gate `/api/v1/audit` endpoints behind JWT authentication + `auditor` role check
 - [ ] Rate-limit the `/integrity` endpoint (it scans the full log)
 - [ ] Run `verifyIntegrity()` on a scheduled job and alert on failure

--- a/src/audit/audit.test.ts
+++ b/src/audit/audit.test.ts
@@ -383,6 +383,15 @@ describe('AuditService', () => {
     expect(service.query({ actor: 'alice' })).toHaveLength(1);
   });
 
+  it('stream() yields entries without preloading all records', () => {
+    service.log(makeInput({ actor: 'alice' }));
+    service.log(makeInput({ actor: 'bob' }));
+
+    const entries = Array.from(service.stream({ limit: 1 }));
+    expect(entries).toHaveLength(1);
+    expect(entries[0].actor).toBe('alice');
+  });
+
   it('getById() returns correct entry', () => {
     const entry = service.log(makeInput());
     expect(service.getById(entry.id)).toBe(entry);
@@ -567,6 +576,22 @@ describe('auditRouter (singleton, real router)', () => {
   it('GET /api/v1/audit/integrity returns 200 for empty log', async () => {
     const app = buildTestApp();
     await request(app).get('/api/v1/audit/integrity').expect(200);
+  });
+
+  it('GET /api/v1/audit/export streams NDJSON output', async () => {
+    const app = buildTestApp();
+    singletonStore.append(makeInput({ actor: 'stream-user-1' }));
+    singletonStore.append(makeInput({ actor: 'stream-user-2' }));
+
+    const res = await request(app)
+      .get('/api/v1/audit/export?limit=1')
+      .expect(200);
+
+    expect(res.headers['content-type']).toContain('application/x-ndjson');
+    const lines = res.text.trim().split('\n');
+    expect(lines).toHaveLength(1);
+    const first = JSON.parse(lines[0]) as { actor: string };
+    expect(first.actor).toBe('stream-user-1');
   });
 });
 

--- a/src/audit/repository.ts
+++ b/src/audit/repository.ts
@@ -1,0 +1,37 @@
+import path from 'path';
+import Database from 'better-sqlite3';
+import type { AuditEntry, AuditQuery, CreateAuditEntryInput, IntegrityReport } from './types';
+import { AuditStore, auditStore } from './store';
+import { SqliteAuditRepository } from './sqliteRepository';
+
+export interface AuditLogRepository {
+  append(input: CreateAuditEntryInput): AuditEntry;
+  getById(id: string): AuditEntry | undefined;
+  query(query?: AuditQuery): AuditEntry[];
+  /**
+   * Streams entries without materialising the full result set in memory.
+   */
+  stream(query?: AuditQuery): IterableIterator<AuditEntry>;
+  count(): number;
+  verifyIntegrity(): IntegrityReport;
+}
+
+export function createDefaultAuditRepository(): AuditLogRepository {
+  const backend = process.env['AUDIT_STORAGE_BACKEND'] ?? 'memory';
+
+  if (backend === 'memory') {
+    return auditStore;
+  }
+
+  if (backend === 'sqlite') {
+    const dbPath =
+      process.env['AUDIT_DB_PATH'] ??
+      (process.env['NODE_ENV'] === 'test'
+        ? ':memory:'
+        : path.join(process.cwd(), 'talenttrust-audit.db'));
+    const db = new Database(dbPath);
+    return new SqliteAuditRepository(db);
+  }
+
+  throw new Error(`Unsupported AUDIT_STORAGE_BACKEND: ${backend}`);
+}

--- a/src/audit/router.ts
+++ b/src/audit/router.ts
@@ -74,6 +74,46 @@ auditRouter.get('/', (req: Request, res: Response): void => {
 });
 
 /**
+ * GET /api/v1/audit/export
+ * Streams NDJSON audit entries for export tooling.
+ */
+auditRouter.get('/export', (req: Request, res: Response): void => {
+  const {
+    action, severity, actor, resource, resourceId, from, to,
+  } = req.query as Record<string, string | undefined>;
+
+  const limit = Math.min(parseInt(req.query['limit'] as string ?? '100', 10) || 100, 1000);
+  const offset = Math.max(parseInt(req.query['offset'] as string ?? '0', 10) || 0, 0);
+
+  if (action && !VALID_ACTIONS.has(action as AuditAction)) {
+    res.status(400).json({ error: `Invalid action: ${action}` });
+    return;
+  }
+  if (severity && !VALID_SEVERITIES.has(severity as AuditSeverity)) {
+    res.status(400).json({ error: `Invalid severity: ${severity}` });
+    return;
+  }
+
+  const query: AuditQuery = {
+    ...(action && { action: action as AuditAction }),
+    ...(severity && { severity: severity as AuditSeverity }),
+    ...(actor && { actor }),
+    ...(resource && { resource }),
+    ...(resourceId && { resourceId }),
+    ...(from && { from }),
+    ...(to && { to }),
+    limit,
+    offset,
+  };
+
+  res.setHeader('Content-Type', 'application/x-ndjson; charset=utf-8');
+  for (const entry of auditService.stream(query)) {
+    res.write(`${JSON.stringify(entry)}\n`);
+  }
+  res.end();
+});
+
+/**
  * GET /api/v1/audit/integrity
  * Verify the tamper-evident hash chain.
  * Returns 200 if valid, 409 if corruption is detected.

--- a/src/audit/service.ts
+++ b/src/audit/service.ts
@@ -16,7 +16,7 @@
 
 import type { AuditEntry, AuditQuery, AuditSeverity, CreateAuditEntryInput, IntegrityReport } from './types';
 import type { AuditAction } from './types';
-import { auditStore, AuditStore } from './store';
+import { createDefaultAuditRepository, type AuditLogRepository } from './repository';
 
 export interface AuditServiceOptions {
   /** Reserved for future use. */
@@ -44,7 +44,7 @@ export interface AuditServiceOptions {
  */
 export class AuditService {
   constructor(
-    private readonly store: AuditStore = auditStore,
+    private readonly repository: AuditLogRepository = createDefaultAuditRepository(),
     private readonly options: AuditServiceOptions = {},
   ) {}
 
@@ -57,7 +57,7 @@ export class AuditService {
    */
   log(input: CreateAuditEntryInput): AuditEntry {
     try {
-      return this.store.append(input);
+      return this.repository.append(input);
     } catch (err) {
       console.error('[AuditService] Failed to persist audit entry:', err);
       throw err;
@@ -159,21 +159,28 @@ export class AuditService {
    * @returns Matching entries in insertion order.
    */
   query(query: AuditQuery = {}): AuditEntry[] {
-    return this.store.query(query);
+    return this.repository.query(query);
+  }
+
+  /**
+   * Streams audit entries for export use cases without loading all rows.
+   */
+  stream(query: AuditQuery = {}): IterableIterator<AuditEntry> {
+    return this.repository.stream(query);
   }
 
   /**
    * Retrieves a single audit entry by ID.
    */
   getById(id: string): AuditEntry | undefined {
-    return this.store.getById(id);
+    return this.repository.getById(id);
   }
 
   /**
    * Returns the total number of audit entries.
    */
   count(): number {
-    return this.store.count();
+    return this.repository.count();
   }
 
   /**
@@ -183,7 +190,7 @@ export class AuditService {
    * @returns IntegrityReport — escalate immediately if valid === false.
    */
   verifyIntegrity(): IntegrityReport {
-    return this.store.verifyIntegrity();
+    return this.repository.verifyIntegrity();
   }
 }
 

--- a/src/audit/sqliteRepository.test.ts
+++ b/src/audit/sqliteRepository.test.ts
@@ -1,0 +1,81 @@
+import Database from 'better-sqlite3';
+import { SqliteAuditRepository } from './sqliteRepository';
+import type { CreateAuditEntryInput } from './types';
+
+function makeInput(overrides: Partial<CreateAuditEntryInput> = {}): CreateAuditEntryInput {
+  return {
+    action: 'CONTRACT_CREATED',
+    severity: 'INFO',
+    actor: 'user-1',
+    resource: 'contract',
+    resourceId: 'contract-1',
+    metadata: { key: 'value' },
+    ...overrides,
+  };
+}
+
+describe('SqliteAuditRepository', () => {
+  let db: Database.Database;
+  let repository: SqliteAuditRepository;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    repository = new SqliteAuditRepository(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it('appends and reads entries', () => {
+    const created = repository.append(makeInput());
+    const found = repository.getById(created.id);
+
+    expect(found?.id).toBe(created.id);
+    expect(repository.count()).toBe(1);
+  });
+
+  it('builds a valid hash chain', () => {
+    const first = repository.append(makeInput());
+    const second = repository.append(makeInput({ action: 'CONTRACT_UPDATED' }));
+
+    expect(second.previousHash).toBe(first.hash);
+    expect(repository.verifyIntegrity().valid).toBe(true);
+  });
+
+  it('queries with filters and pagination', () => {
+    repository.append(makeInput({ actor: 'alice' }));
+    repository.append(makeInput({ actor: 'bob', action: 'AUTH_FAILED', severity: 'WARNING' }));
+
+    const filtered = repository.query({ actor: 'alice' });
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].actor).toBe('alice');
+
+    const paged = repository.query({ limit: 1, offset: 1 });
+    expect(paged).toHaveLength(1);
+  });
+
+  it('streams entries incrementally', () => {
+    repository.append(makeInput({ resourceId: 'c-1' }));
+    repository.append(makeInput({ resourceId: 'c-2' }));
+    repository.append(makeInput({ resourceId: 'c-3' }));
+
+    const stream = repository.stream({ limit: 2 });
+    const first = stream.next();
+    const second = stream.next();
+    const third = stream.next();
+
+    expect(first.value?.resourceId).toBe('c-1');
+    expect(second.value?.resourceId).toBe('c-2');
+    expect(third.done).toBe(true);
+  });
+
+  it('detects tampering during integrity verification', () => {
+    const created = repository.append(makeInput());
+    db.prepare('UPDATE audit_log_entries SET hash = ? WHERE id = ?').run('bad'.padEnd(64, '0'), created.id);
+
+    const report = repository.verifyIntegrity();
+    expect(report.valid).toBe(false);
+    expect(report.firstCorruptedId).toBe(created.id);
+  });
+});

--- a/src/audit/sqliteRepository.ts
+++ b/src/audit/sqliteRepository.ts
@@ -1,0 +1,253 @@
+import { randomUUID } from 'crypto';
+import type Database from 'better-sqlite3';
+import { computeEntryHash, GENESIS_HASH } from './store';
+import type { AuditEntry, AuditQuery, CreateAuditEntryInput, IntegrityReport } from './types';
+import type { AuditLogRepository } from './repository';
+
+interface AuditRow {
+  id: string;
+  timestamp: string;
+  action: AuditEntry['action'];
+  severity: AuditEntry['severity'];
+  actor: string;
+  resource: string;
+  resource_id: string;
+  metadata_json: string;
+  ip_address: string | null;
+  correlation_id: string | null;
+  hash: string;
+  previous_hash: string;
+}
+
+function toAuditEntry(row: AuditRow): AuditEntry {
+  return Object.freeze({
+    id: row.id,
+    timestamp: row.timestamp,
+    action: row.action,
+    severity: row.severity,
+    actor: row.actor,
+    resource: row.resource,
+    resourceId: row.resource_id,
+    metadata: Object.freeze(JSON.parse(row.metadata_json) as Record<string, unknown>),
+    ipAddress: row.ip_address ?? undefined,
+    correlationId: row.correlation_id ?? undefined,
+    hash: row.hash,
+    previousHash: row.previous_hash,
+  });
+}
+
+export class SqliteAuditRepository implements AuditLogRepository {
+  constructor(private readonly db: Database.Database) {
+    this.initSchema();
+  }
+
+  append(input: CreateAuditEntryInput): AuditEntry {
+    const insert = this.db.transaction((payload: CreateAuditEntryInput): AuditEntry => {
+      const previousHashRow = this.db
+        .prepare<[], { hash: string }>(
+          'SELECT hash FROM audit_log_entries ORDER BY seq DESC LIMIT 1'
+        )
+        .get();
+
+      const partial: Omit<AuditEntry, 'hash'> = {
+        id: randomUUID(),
+        timestamp: new Date().toISOString(),
+        action: payload.action,
+        severity: payload.severity,
+        actor: payload.actor,
+        resource: payload.resource,
+        resourceId: payload.resourceId,
+        metadata: Object.freeze({ ...payload.metadata }),
+        ipAddress: payload.ipAddress,
+        correlationId: payload.correlationId,
+        previousHash: previousHashRow?.hash ?? GENESIS_HASH,
+      };
+
+      const entry: AuditEntry = Object.freeze({
+        ...partial,
+        hash: computeEntryHash(partial),
+      });
+
+      this.db
+        .prepare<
+          [string, string, string, string, string, string, string, string, string | null, string | null, string, string]
+        >(
+          `INSERT INTO audit_log_entries
+           (id, timestamp, action, severity, actor, resource, resource_id, metadata_json, ip_address, correlation_id, hash, previous_hash)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run(
+          entry.id,
+          entry.timestamp,
+          entry.action,
+          entry.severity,
+          entry.actor,
+          entry.resource,
+          entry.resourceId,
+          JSON.stringify(entry.metadata),
+          entry.ipAddress ?? null,
+          entry.correlationId ?? null,
+          entry.hash,
+          entry.previousHash
+        );
+
+      return entry;
+    });
+
+    return insert(input);
+  }
+
+  getById(id: string): AuditEntry | undefined {
+    const row = this.db
+      .prepare<[string], AuditRow>(
+        `SELECT id, timestamp, action, severity, actor, resource, resource_id, metadata_json, ip_address, correlation_id, hash, previous_hash
+         FROM audit_log_entries
+         WHERE id = ?`
+      )
+      .get(id);
+
+    return row ? toAuditEntry(row) : undefined;
+  }
+
+  query(query: AuditQuery = {}): AuditEntry[] {
+    const { sql, params } = this.buildQuerySql(query);
+    const rows = this.db.prepare<typeof params, AuditRow>(sql).all(...params);
+    return rows.map(toAuditEntry);
+  }
+
+  *stream(query: AuditQuery = {}): IterableIterator<AuditEntry> {
+    const { sql, params } = this.buildQuerySql(query);
+    const cursor = this.db.prepare<typeof params, AuditRow>(sql).iterate(...params);
+    for (const row of cursor) {
+      yield toAuditEntry(row);
+    }
+  }
+
+  count(): number {
+    const row = this.db
+      .prepare<[], { total: number }>('SELECT COUNT(*) AS total FROM audit_log_entries')
+      .get();
+    return row?.total ?? 0;
+  }
+
+  verifyIntegrity(): IntegrityReport {
+    const checkedAt = new Date().toISOString();
+    const rows = this.db
+      .prepare<[], AuditRow>(
+        `SELECT id, timestamp, action, severity, actor, resource, resource_id, metadata_json, ip_address, correlation_id, hash, previous_hash
+         FROM audit_log_entries
+         ORDER BY seq ASC`
+      )
+      .all();
+
+    if (rows.length === 0) {
+      return { valid: true, totalEntries: 0, checkedAt };
+    }
+
+    let previousHash = GENESIS_HASH;
+    for (let index = 0; index < rows.length; index += 1) {
+      const entry = toAuditEntry(rows[index]);
+
+      if (entry.previousHash !== previousHash) {
+        return {
+          valid: false,
+          totalEntries: rows.length,
+          firstCorruptedIndex: index,
+          firstCorruptedId: entry.id,
+          checkedAt,
+        };
+      }
+
+      const { hash, ...rest } = entry;
+      const expectedHash = computeEntryHash(rest);
+      if (hash !== expectedHash) {
+        return {
+          valid: false,
+          totalEntries: rows.length,
+          firstCorruptedIndex: index,
+          firstCorruptedId: entry.id,
+          checkedAt,
+        };
+      }
+
+      previousHash = entry.hash;
+    }
+
+    return { valid: true, totalEntries: rows.length, checkedAt };
+  }
+
+  private initSchema(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS audit_log_entries (
+        seq            INTEGER PRIMARY KEY AUTOINCREMENT,
+        id             TEXT    NOT NULL UNIQUE,
+        timestamp      TEXT    NOT NULL,
+        action         TEXT    NOT NULL,
+        severity       TEXT    NOT NULL,
+        actor          TEXT    NOT NULL,
+        resource       TEXT    NOT NULL,
+        resource_id    TEXT    NOT NULL,
+        metadata_json  TEXT    NOT NULL,
+        ip_address     TEXT,
+        correlation_id TEXT,
+        hash           TEXT    NOT NULL,
+        previous_hash  TEXT    NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_log_entries(timestamp);
+      CREATE INDEX IF NOT EXISTS idx_audit_action ON audit_log_entries(action);
+      CREATE INDEX IF NOT EXISTS idx_audit_severity ON audit_log_entries(severity);
+      CREATE INDEX IF NOT EXISTS idx_audit_actor ON audit_log_entries(actor);
+      CREATE INDEX IF NOT EXISTS idx_audit_resource ON audit_log_entries(resource, resource_id);
+    `);
+  }
+
+  private buildQuerySql(query: AuditQuery): { sql: string; params: unknown[] } {
+    const where: string[] = [];
+    const params: unknown[] = [];
+
+    if (query.action) {
+      where.push('action = ?');
+      params.push(query.action);
+    }
+    if (query.severity) {
+      where.push('severity = ?');
+      params.push(query.severity);
+    }
+    if (query.actor) {
+      where.push('actor = ?');
+      params.push(query.actor);
+    }
+    if (query.resource) {
+      where.push('resource = ?');
+      params.push(query.resource);
+    }
+    if (query.resourceId) {
+      where.push('resource_id = ?');
+      params.push(query.resourceId);
+    }
+    if (query.from) {
+      where.push('timestamp >= ?');
+      params.push(query.from);
+    }
+    if (query.to) {
+      where.push('timestamp <= ?');
+      params.push(query.to);
+    }
+
+    const limit = Math.min(query.limit ?? 100, 1000);
+    const offset = Math.max(query.offset ?? 0, 0);
+
+    const whereClause = where.length > 0 ? `WHERE ${where.join(' AND ')}` : '';
+    const sql = `
+      SELECT id, timestamp, action, severity, actor, resource, resource_id, metadata_json, ip_address, correlation_id, hash, previous_hash
+      FROM audit_log_entries
+      ${whereClause}
+      ORDER BY seq ASC
+      LIMIT ? OFFSET ?
+    `;
+
+    params.push(limit, offset);
+    return { sql, params };
+  }
+}

--- a/src/audit/store.ts
+++ b/src/audit/store.ts
@@ -16,6 +16,7 @@
 
 import { createHash, randomUUID } from 'crypto';
 import type { AuditEntry, AuditQuery, CreateAuditEntryInput, IntegrityReport } from './types';
+import type { AuditLogRepository } from './repository';
 
 /** Sentinel hash used as the previousHash of the very first entry. */
 export const GENESIS_HASH = 'GENESIS';
@@ -54,7 +55,7 @@ export function computeEntryHash(
  * const report = store.verifyIntegrity();
  * ```
  */
-export class AuditStore {
+export class AuditStore implements AuditLogRepository {
   /** Internal append-only log. Never mutate directly. */
   private readonly log: AuditEntry[] = [];
 
@@ -137,6 +138,13 @@ export class AuditStore {
     });
 
     return results.slice(offset, offset + limit);
+  }
+
+  *stream(query: AuditQuery = {}): IterableIterator<AuditEntry> {
+    const rows = this.query(query);
+    for (const row of rows) {
+      yield row;
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- introduce an `AuditLogRepository` abstraction with pluggable storage backends
- add a durable SQLite audit repository implementation with append-only semantics, hash-chain verification, and indexed queries
- keep the in-memory repository implementation for local/test use while routing `AuditService` through the new abstraction
- add streaming reads (`stream()`) and expose `GET /api/v1/audit/export` as NDJSON for large exports without loading all rows in memory
- add repository and router/service tests and update audit documentation

## Test plan
- [x] `npm test -- src/audit/sqliteRepository.test.ts src/audit/audit.test.ts`
- [ ] `npm run test:ci` *(currently failing due unrelated existing repo-wide TypeScript/test issues)*

Closes #176