### PR TITLE
feat(db): add transactional migrations with checksum verification

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,0 +1,42 @@
+# Database Migration Authoring
+
+`src/db/database.ts` opens SQLite and immediately calls `runMigrations()` before
+the application serves requests. The migration runner records every applied
+migration in `schema_version` with its version, name, checksum, and timestamp.
+
+## Rules
+
+- Append new migrations to `MIGRATIONS` in `src/db/migrations.ts`.
+- Use contiguous versions starting at `1`; do not reorder migrations.
+- Never edit the `name` or `up` body of a migration after it has been merged or
+  applied. Add a new migration instead.
+- Keep migrations deterministic and free of secrets, environment-specific data,
+  network calls, or user input.
+- Write migrations so they are safe to run once in production and easy to test
+  against an empty SQLite database.
+
+## Checksum Verification
+
+On startup, the runner verifies that every applied migration still matches the
+recorded checksum. If a migration is missing, renamed, reordered, or edited, the
+process fails fast instead of applying more schema changes on an untrusted
+history.
+
+Older databases whose `schema_version` table lacks checksums are upgraded by
+adding the checksum column and backfilling checksums for known applied
+migrations. After that, any mismatch aborts startup.
+
+## Transaction Behavior
+
+Each pending migration runs inside a single SQLite transaction together with its
+`schema_version` insert. If the migration throws, all DDL/DML from that migration
+is rolled back and the migration is not recorded.
+
+## Security Notes
+
+- Migration SQL is static application code, not request input.
+- Application authentication, signature verification, and authorization happen
+  outside the migration layer.
+- Do not log secrets from migrations; schema changes should not contain secret
+  values.
+- Idempotency is provided by the `schema_version` table and checksum checks.

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -5,8 +5,9 @@
  * environment variable (default: talenttrust.db).  Pass ':memory:' during
  * tests to use an ephemeral, isolated in-memory database.
  *
- * Runs schema migrations synchronously on first open so the tables are
- * guaranteed to exist before the application serves any requests.
+ * Runs schema migrations synchronously on first open so applied migration
+ * checksums are verified and tables are guaranteed to exist before the
+ * application serves any requests.
  *
  * Security notes:
  *  - All SQL statements in repositories use prepared statements / parameter

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -1,5 +1,10 @@
 import Database from "better-sqlite3";
-import { Migration, runMigrations, getLatestSchemaVersion } from "./migrations";
+import {
+  Migration,
+  computeMigrationChecksum,
+  runMigrations,
+  getLatestSchemaVersion,
+} from "./migrations";
 
 describe("runMigrations", () => {
   let db: Database.Database;
@@ -12,16 +17,17 @@ describe("runMigrations", () => {
     db.close();
   });
 
-  it("creates schema_version records for applied migrations", () => {
+  it("creates schema_version records with checksums for clean apply", () => {
     runMigrations(db);
 
     const rows = db
-      .prepare<[], { version: number }>(
-        "SELECT version FROM schema_version ORDER BY version ASC"
+      .prepare<[], { version: number; checksum: string }>(
+        "SELECT version, checksum FROM schema_version ORDER BY version ASC"
       )
       .all();
 
     expect(rows.map((row) => row.version)).toEqual([1, 2]);
+    expect(rows.every((row) => /^[a-f0-9]{64}$/.test(row.checksum))).toBe(true);
   });
 
   it("is idempotent when run multiple times", () => {
@@ -76,7 +82,128 @@ describe("runMigrations", () => {
     expect(row?.version).toBe(2);
   });
 
-  it("rolls back a failed migration and does not record it", () => {
+  it("backfills checksums for existing schema_version rows that predate checksum tracking", () => {
+    const migrations: Migration[] = [
+      {
+        version: 1,
+        name: "create_legacy_table",
+        up: (migrationDb) => {
+          migrationDb.exec("CREATE TABLE legacy (id INTEGER PRIMARY KEY);");
+        },
+      },
+    ];
+
+    db.exec(`
+      CREATE TABLE schema_version (
+        version     INTEGER PRIMARY KEY,
+        name        TEXT    NOT NULL,
+        applied_at  TEXT    NOT NULL
+      );
+
+      INSERT INTO schema_version (version, name, applied_at)
+      VALUES (1, 'create_legacy_table', '2026-05-27T00:00:00.000Z');
+    `);
+
+    runMigrations(db, migrations);
+
+    const row = db
+      .prepare<[], { checksum: string }>(
+        "SELECT checksum FROM schema_version WHERE version = 1"
+      )
+      .get();
+
+    expect(row?.checksum).toBe(computeMigrationChecksum(migrations[0]!));
+  });
+
+  it("aborts when an applied migration checksum no longer matches", () => {
+    const originalMigrations: Migration[] = [
+      {
+        version: 1,
+        name: "create_demo_table",
+        up: (migrationDb) => {
+          migrationDb.exec("CREATE TABLE demo (id INTEGER PRIMARY KEY);");
+        },
+      },
+    ];
+    const tamperedMigrations: Migration[] = [
+      {
+        version: 1,
+        name: "create_demo_table",
+        up: (migrationDb) => {
+          migrationDb.exec("CREATE TABLE demo (id INTEGER PRIMARY KEY, name TEXT);");
+        },
+      },
+    ];
+
+    runMigrations(db, originalMigrations);
+
+    expect(() => runMigrations(db, tamperedMigrations)).toThrow(
+      "Applied migration 1 checksum mismatch"
+    );
+  });
+
+  it("aborts when an applied migration name no longer matches", () => {
+    const originalMigrations: Migration[] = [
+      {
+        version: 1,
+        name: "create_demo_table",
+        up: (migrationDb) => {
+          migrationDb.exec("CREATE TABLE demo (id INTEGER PRIMARY KEY);");
+        },
+      },
+    ];
+    const renamedMigrations: Migration[] = [
+      {
+        ...originalMigrations[0]!,
+        name: "renamed_demo_table",
+      },
+    ];
+
+    runMigrations(db, originalMigrations);
+
+    expect(() => runMigrations(db, renamedMigrations)).toThrow(
+      "Applied migration 1 name mismatch"
+    );
+  });
+
+  it("aborts when applied migrations are missing from the migration list", () => {
+    const migrations: Migration[] = [
+      {
+        version: 1,
+        name: "create_demo_table",
+        up: (migrationDb) => {
+          migrationDb.exec("CREATE TABLE demo (id INTEGER PRIMARY KEY);");
+        },
+      },
+    ];
+
+    runMigrations(db, migrations);
+
+    expect(() => runMigrations(db, [])).toThrow(
+      "Applied migration 1 (create_demo_table) is not present"
+    );
+  });
+
+  it("rejects reordered migration lists before applying them", () => {
+    const reorderedMigrations: Migration[] = [
+      {
+        version: 2,
+        name: "second",
+        up: () => undefined,
+      },
+      {
+        version: 1,
+        name: "first",
+        up: () => undefined,
+      },
+    ];
+
+    expect(() => runMigrations(db, reorderedMigrations)).toThrow(
+      "Invalid migration sequence: expected version 1, got 2"
+    );
+  });
+
+  it("rolls back a failed mid-migration write and does not record it", () => {
     const testMigrations: Migration[] = [
       {
         version: 1,

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -1,9 +1,16 @@
+import { createHash } from "crypto";
 import Database from "better-sqlite3";
 
 export interface Migration {
   version: number;
   name: string;
   up: (db: Database.Database) => void;
+}
+
+interface AppliedMigration {
+  version: number;
+  name: string;
+  checksum: string | null;
 }
 
 const MIGRATIONS: Migration[] = [
@@ -65,34 +72,110 @@ function ensureMigrationTable(db: Database.Database): void {
     CREATE TABLE IF NOT EXISTS schema_version (
       version     INTEGER PRIMARY KEY,
       name        TEXT    NOT NULL,
+      checksum    TEXT,
       applied_at  TEXT    NOT NULL
     );
   `);
+
+  const columns = db.pragma("table_info(schema_version)") as Array<{ name: string }>;
+  const hasChecksum = columns.some((column) => column.name === "checksum");
+
+  if (!hasChecksum) {
+    db.exec("ALTER TABLE schema_version ADD COLUMN checksum TEXT");
+  }
 }
 
-function getAppliedVersions(db: Database.Database): Set<number> {
+function getAppliedMigrations(db: Database.Database): Map<number, AppliedMigration> {
   const rows = db
-    .prepare<[], { version: number }>(
-      "SELECT version FROM schema_version ORDER BY version ASC"
+    .prepare<[], AppliedMigration>(
+      "SELECT version, name, checksum FROM schema_version ORDER BY version ASC"
     )
     .all();
 
-  return new Set(rows.map((row) => row.version));
+  return new Map(rows.map((row) => [row.version, row]));
 }
 
 function assertMigrationsAreValid(migrations: Migration[]): void {
-  const sortedVersions = [...migrations.map((m) => m.version)].sort((a, b) => a - b);
-
-  for (let index = 0; index < sortedVersions.length; index += 1) {
+  for (let index = 0; index < migrations.length; index += 1) {
     const expectedVersion = index + 1;
-    if (sortedVersions[index] !== expectedVersion) {
+    const migration = migrations[index];
+
+    if (migration?.version !== expectedVersion) {
       throw new Error(
-        `Invalid migration sequence: expected version ${expectedVersion}, got ${sortedVersions[index]}`
+        `Invalid migration sequence: expected version ${expectedVersion}, got ${migration?.version}`
       );
     }
   }
 }
 
+/**
+ * Computes the immutable fingerprint stored for an applied migration.
+ *
+ * @param migration - Migration definition from the ordered migration list.
+ * @returns A SHA-256 checksum over version, name, and implementation body.
+ *
+ * @remarks
+ * Migration checksums intentionally include `up.toString()` so edits to an
+ * already-applied migration fail fast on the next database open. Add a new
+ * migration instead of changing an existing one.
+ */
+export function computeMigrationChecksum(migration: Migration): string {
+  return createHash("sha256")
+    .update(`${migration.version}\n${migration.name}\n${migration.up.toString()}`)
+    .digest("hex");
+}
+
+function verifyAppliedMigrations(
+  db: Database.Database,
+  appliedMigrations: Map<number, AppliedMigration>,
+  migrations: Migration[]
+): void {
+  const migrationsByVersion = new Map(migrations.map((migration) => [migration.version, migration]));
+
+  for (const applied of appliedMigrations.values()) {
+    const migration = migrationsByVersion.get(applied.version);
+
+    if (!migration) {
+      throw new Error(
+        `Applied migration ${applied.version} (${applied.name}) is not present in the migration list`
+      );
+    }
+
+    const expectedChecksum = computeMigrationChecksum(migration);
+
+    if (applied.name !== migration.name) {
+      throw new Error(
+        `Applied migration ${applied.version} name mismatch: expected ${migration.name}, got ${applied.name}`
+      );
+    }
+
+    if (applied.checksum === null) {
+      db.prepare<[string, number]>(
+        "UPDATE schema_version SET checksum = ? WHERE version = ?"
+      ).run(expectedChecksum, applied.version);
+      applied.checksum = expectedChecksum;
+    }
+
+    if (applied.checksum !== expectedChecksum) {
+      throw new Error(
+        `Applied migration ${applied.version} checksum mismatch; refusing to start`
+      );
+    }
+  }
+}
+
+/**
+ * Applies pending database migrations after verifying applied checksums.
+ *
+ * @param db - Open SQLite database handle.
+ * @param migrations - Ordered migration definitions, primarily overridden by tests.
+ *
+ * @remarks
+ * The database open path calls this synchronously before serving requests.
+ * Applied migrations are verified before pending migrations run. Each pending
+ * migration and its `schema_version` insert happen inside one SQLite
+ * transaction, so partial DDL/DML is rolled back if the migration throws.
+ */
 export function runMigrations(
   db: Database.Database,
   migrations: Migration[] = MIGRATIONS
@@ -100,13 +183,15 @@ export function runMigrations(
   assertMigrationsAreValid(migrations);
   ensureMigrationTable(db);
 
-  const appliedVersions = getAppliedVersions(db);
-  const insertApplied = db.prepare<[number, string, string]>(
-    "INSERT INTO schema_version (version, name, applied_at) VALUES (?, ?, ?)"
+  const appliedMigrations = getAppliedMigrations(db);
+  verifyAppliedMigrations(db, appliedMigrations, migrations);
+
+  const insertApplied = db.prepare<[number, string, string, string]>(
+    "INSERT INTO schema_version (version, name, checksum, applied_at) VALUES (?, ?, ?, ?)"
   );
 
   for (const migration of migrations) {
-    if (appliedVersions.has(migration.version)) {
+    if (appliedMigrations.has(migration.version)) {
       continue;
     }
 
@@ -115,6 +200,7 @@ export function runMigrations(
       insertApplied.run(
         migration.version,
         migration.name,
+        computeMigrationChecksum(migration),
         new Date().toISOString()
       );
     });


### PR DESCRIPTION
Closes #268

## Summary
- Added SHA-256 checksum tracking for applied DB migrations.
- Verifies applied migration version/name/checksum on startup and aborts on mismatch.
- Keeps each pending migration plus its `schema_version` insert inside one SQLite transaction.
- Backfills checksums for older `schema_version` rows without checksum data.
- Added migration authoring rules in `docs/migrations.md`.

## Tests
- `npm.cmd test -- --runInBand src/db/migrations.test.ts src/db/database.test.ts`
  - 2 suites passed, 19 tests passed
- `npm.cmd run build`
  - passed
- `npm.cmd test -- --runInBand`
  - 92 suites passed, 1104 tests passed
- `npm.cmd run test:ci`
  - passed with coverage
  - `src/db/migrations.ts`: 100% line coverage
  - `src/db/database.ts`: 100% line coverage

## Security Notes
- Migration checksums detect tampered, renamed, removed, or reordered applied migrations before new schema changes run.
- Migration SQL remains static application code, not request input.
- No secrets are introduced; docs explicitly require migrations to avoid secrets and environment-specific data.
- Startup path in `database.ts` verifies migration history before serving requests.## Summary
- Added SHA-256 checksum tracking for applied DB migrations.
- Verifies applied migration version/name/checksum on startup and aborts on mismatch.
- Keeps each pending migration plus its `schema_version` insert inside one SQLite transaction.
- Backfills checksums for older `schema_version` rows without checksum data.
- Added migration authoring rules in `docs/migrations.md`.

## Tests
- `npm.cmd test -- --runInBand src/db/migrations.test.ts src/db/database.test.ts`
  - 2 suites passed, 19 tests passed
- `npm.cmd run build`
  - passed
- `npm.cmd test -- --runInBand`
  - 92 suites passed, 1104 tests passed
- `npm.cmd run test:ci`
  - passed with coverage
  - `src/db/migrations.ts`: 100% line coverage
  - `src/db/database.ts`: 100% line coverage

## Security Notes
- Migration checksums detect tampered, renamed, removed, or reordered applied migrations before new schema changes run.
- Migration SQL remains static application code, not request input.
- No secrets are introduced; docs explicitly require migrations to avoid secrets and environment-specific data.
- Startup path in `database.ts` verifies migration history before serving requests.