### PR TITLE
feat(errors): enforce safe API error policy

### DIFF
--- a/.deployment-state.json
+++ b/.deployment-state.json
@@ -1,5 +1,0 @@
-{
-  "activeColor": "green",
-  "lastSwitch": 1779951788037,
-  "previousColor": "blue"
-}

--- a/docs/API.md
+++ b/docs/API.md
@@ -79,6 +79,46 @@ Authorization: Bearer <token>
 - `demo-admin-token` - Admin user with full access
 - `demo-user-token` - Regular user with limited access
 
+## Error Responses
+
+All terminal API errors are serialized through the safe error message policy.
+Internal exception details, stack traces, file paths, SQL fragments, dependency
+hostnames, tokens, and secrets are logged only through redacted structured logs
+and are never returned to API clients.
+
+Every policy-managed error response uses this envelope:
+
+```json
+{
+  "error": {
+    "code": "machine_readable_code",
+    "message": "safe client-facing message",
+    "requestId": "request-correlation-id"
+  }
+}
+```
+
+Validation responses may include a `details` array with field-level Zod issue
+metadata. These details are also passed through the same safe-message filters.
+
+Common status/code mappings:
+
+| Status | Code | Message |
+|---:|---|---|
+| 400 | `invalid_json` | Malformed JSON payload |
+| 400 | `validation_error` | Request validation failed |
+| 401 | `unauthorized` | Authentication is required |
+| 403 | `forbidden` | You do not have permission to perform this action |
+| 404 | `not_found` | The requested resource was not found |
+| 409 | `conflict` | The request conflicts with the current state |
+| 413 | `payload_too_large` | Payload Too Large |
+| 415 | `unsupported_media_type` | Unsupported Media Type |
+| 500 | `internal_error` | An unexpected error occurred |
+| 503 | `dependency_unavailable` | A required service is temporarily unavailable |
+
+Use the returned `requestId` when contacting support; it ties the response to
+redacted server-side logs without exposing sensitive internals.
+
 ## Contracts API
 
 ### Overview

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,7 +15,6 @@ module.exports = {
     'occ.integration.test.ts',
     'deployment/integration.test.ts',
     'retention/integration.test.ts',
-    'errorMessagePolicy.integration.test.ts',
     'contractMetadata.integration.test.ts',
     'TransactionPoller.test.ts',
     'requestLogger.test.ts',

--- a/src/app.ts
+++ b/src/app.ts
@@ -49,6 +49,7 @@ export function attachTerminalHandlers(app: express.Application): void {
  * @returns Configured Express app instance (not yet listening).
  */
 export function createApp(options?: AppFactoryOptions): express.Application {
+  const includeTerminalHandlers = options?.includeTerminalHandlers ?? true;
   validateEnv();
   const app = express();
 
@@ -60,9 +61,9 @@ export function createApp(options?: AppFactoryOptions): express.Application {
   );
 
   // ── Middleware ────────────────────────────────────────────────────────────
+  app.use(requestIdMiddleware);
   app.use(createRequestLimitsMiddleware());
   app.use(express.json());
-  app.use(requestIdMiddleware);
   app.use(httpLoggerMiddleware);
   app.use(metricsService.trackHttpRequest.bind(metricsService));
 
@@ -79,11 +80,9 @@ export function createApp(options?: AppFactoryOptions): express.Application {
   app.use('/api/v1/dependency-scan', dependencyScanRouter);
   app.use('/api/v1/admin', adminRouter);
 
-  // ── 404 handler ──────────────────────────────────────────────────────────
-  app.use(notFoundHandler);
-
-  // ── Global error handler ─────────────────────────────────────────────────
-  app.use(errorHandler);
+  if (includeTerminalHandlers) {
+    attachTerminalHandlers(app);
+  }
 
   return app;
 }

--- a/src/errors/appError.ts
+++ b/src/errors/appError.ts
@@ -1,3 +1,4 @@
+import { ZodError } from 'zod';
 import { sanitizeErrorMessage, safeMessageForCode } from './safeErrors';
 
 export interface ErrorPayload {
@@ -5,7 +6,14 @@ export interface ErrorPayload {
     code: string;
     message: string;
     requestId: string;
+    details?: ValidationIssue[];
   };
+}
+
+export interface ValidationIssue {
+  path: string[];
+  message: string;
+  code: string;
 }
 
 /**
@@ -80,8 +88,29 @@ export class ValidationError extends AppError {
   }
 }
 
+function statusCodeFor(error: AppError): number {
+  if (Number.isInteger(error.statusCode) && error.statusCode >= 400 && error.statusCode <= 599) {
+    return error.statusCode;
+  }
+
+  return 500;
+}
+
+function mapZodErrorToDetails(error: ZodError): ValidationIssue[] {
+  return error.issues.map((issue) => ({
+    path: issue.path.map((part) => String(part)),
+    message: sanitizeErrorMessage(issue.message, 'validation_error'),
+    code: issue.code,
+  }));
+}
+
 /**
  * Normalizes thrown errors into a safe and consistent API response payload.
+ *
+ * @remarks This function is the single serialization boundary for terminal API
+ * error responses. Internal exception text is never returned for unknown errors,
+ * and AppError messages are filtered through the safe message policy before
+ * they are exposed.
  */
 export function mapErrorToPayload(
   error: unknown,
@@ -93,12 +122,26 @@ export function mapErrorToPayload(
       : safeMessageForCode(error.code);
 
     return {
-      statusCode: error.statusCode,
+      statusCode: statusCodeFor(error),
       payload: {
         error: {
           code: error.code,
           message,
           requestId,
+        },
+      },
+    };
+  }
+
+  if (error instanceof ZodError) {
+    return {
+      statusCode: 400,
+      payload: {
+        error: {
+          code: 'validation_error',
+          message: safeMessageForCode('validation_error'),
+          requestId,
+          details: mapZodErrorToDetails(error),
         },
       },
     };

--- a/src/errors/errorMessagePolicy.integration.test.ts
+++ b/src/errors/errorMessagePolicy.integration.test.ts
@@ -9,51 +9,90 @@
  *  - Machine codes are stable strings clients can rely on.
  */
 
+import type { Application } from 'express';
 import http from 'http';
-import { createApp } from '../app';
+import { Duplex } from 'stream';
+import { z } from 'zod';
+import { attachTerminalHandlers, createApp } from '../app';
+import { AppError } from './appError';
+import { validateSchema } from '../middleware/validate.middleware';
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-interface SimpleResponse {
-  statusCode: number;
-  headers: http.IncomingHttpHeaders;
-  body: string;
+interface InjectedResponse {
+  status: number;
+  body: any;
+  text: string;
 }
 
-function req(
-  server: http.Server,
+class MockSocket extends Duplex {
+  _read(): void {
+    // ServerResponse writes are intercepted in inject(); no socket reads needed.
+  }
+
+  _write(_chunk: Buffer, _encoding: BufferEncoding, callback: (error?: Error | null) => void): void {
+    callback();
+  }
+}
+
+function inject(
+  app: Application,
   method: string,
   path: string,
-  body?: string,
-  headers?: Record<string, string>,
-): Promise<SimpleResponse> {
+  body?: unknown,
+  headers: Record<string, string> = {},
+): Promise<InjectedResponse> {
   return new Promise((resolve, reject) => {
-    const addr = server.address() as { port: number };
-    const reqHeaders: Record<string, string> = { ...headers };
-    if (body) {
-      reqHeaders['Content-Type'] = 'application/json';
-      reqHeaders['Content-Length'] = String(Buffer.byteLength(body));
+    const socket = new MockSocket();
+    const req = new http.IncomingMessage(socket as any);
+    req.method = method;
+    req.url = path;
+    req.headers = { ...headers };
+
+    if (body !== undefined) {
+      const payload = typeof body === 'string' ? body : JSON.stringify(body);
+      req.headers['content-type'] = req.headers['content-type'] ?? 'application/json';
+      req.headers['content-length'] = String(Buffer.byteLength(payload));
+      req.push(payload);
     }
+    req.push(null);
 
-    const options: http.RequestOptions = {
-      hostname: '127.0.0.1',
-      port: addr.port,
-      path,
-      method,
-      headers: reqHeaders,
-    };
+    const res = new http.ServerResponse(req);
+    res.assignSocket(socket as any);
 
-    const r = http.request(options, (res) => {
-      let data = '';
-      res.on('data', (chunk) => (data += chunk));
-      res.on('end', () =>
-        resolve({ statusCode: res.statusCode ?? 0, headers: res.headers, body: data }),
-      );
-    });
+    const chunks: Buffer[] = [];
+    const originalWrite = res.write.bind(res);
+    const originalEnd = res.end.bind(res);
 
-    r.on('error', reject);
-    if (body) r.write(body);
-    r.end();
+    res.write = ((chunk: any, encoding?: any, cb?: any) => {
+      if (chunk !== undefined) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding));
+      }
+      return originalWrite(chunk, encoding, cb);
+    }) as typeof res.write;
+
+    res.end = ((chunk?: any, encoding?: any, cb?: any) => {
+      if (chunk !== undefined) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding));
+      }
+      const text = Buffer.concat(chunks).toString('utf8');
+      let parsed: any = {};
+      try {
+        parsed = text.length > 0 ? JSON.parse(text) : {};
+      } catch {
+        parsed = text;
+      }
+
+      resolve({
+        status: res.statusCode,
+        body: parsed,
+        text,
+      });
+
+      return originalEnd(chunk, encoding, cb);
+    }) as typeof res.end;
+
+    (app as any).handle(req as any, res as any, reject);
   });
 }
 
@@ -82,36 +121,58 @@ function assertNoForbiddenContent(body: string, context: string): void {
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 describe('Error message policy — integration', () => {
-  let server: http.Server;
+  let app: Application;
 
-  beforeAll((done) => {
-    server = createApp().listen(0, '127.0.0.1', done);
-  });
+  beforeAll(() => {
+    app = createApp({ includeTerminalHandlers: false });
 
-  afterAll((done) => {
-    server.close(done);
+    app.get('/__policy/unknown-error', (_req, _res, next) => {
+      next(new Error('SELECT token FROM users at /srv/app/src/private.ts:12:1'));
+    });
+
+    app.get('/__policy/app-error', (_req, _res, next) => {
+      next(new AppError(
+        503,
+        'dependency_unavailable',
+        'connect ECONNREFUSED 10.0.0.5:6379 for token=abc',
+      ));
+    });
+
+    app.post(
+      '/__policy/validation-error',
+      validateSchema(
+        z.object({
+          body: z.object({
+            contractId: z.string().uuid(),
+          }),
+        }),
+      ),
+      (_req, res) => res.status(204).end(),
+    );
+
+    attachTerminalHandlers(app);
   });
 
   // ── 404 responses ────────────────────────────────────────────────────────
 
   describe('404 — unknown routes', () => {
     it('returns the standardized envelope with not_found code', async () => {
-      const res = await req(server, 'GET', '/does-not-exist');
-      expect(res.statusCode).toBe(404);
-      const json = JSON.parse(res.body);
+      const res = await inject(app, 'GET', '/does-not-exist');
+      expect(res.status).toBe(404);
+      const json = res.body;
       expect(json.error.code).toBe('not_found');
       expect(json.error.message).toBe('The requested resource was not found');
       expect(json.error).toHaveProperty('requestId');
     });
 
     it('does not leak the probed route path', async () => {
-      const res = await req(server, 'GET', '/api/v1/secret-internal-path');
-      expect(res.body).not.toContain('/api/v1/secret-internal-path');
+      const res = await inject(app, 'GET', '/api/v1/secret-internal-path');
+      expect(JSON.stringify(res.body)).not.toContain('/api/v1/secret-internal-path');
     });
 
     it('contains no forbidden content', async () => {
-      const res = await req(server, 'GET', '/nope');
-      assertNoForbiddenContent(res.body, 'GET /nope');
+      const res = await inject(app, 'GET', '/nope');
+      assertNoForbiddenContent(JSON.stringify(res.body), 'GET /nope');
     });
   });
 
@@ -119,16 +180,71 @@ describe('Error message policy — integration', () => {
 
   describe('400 — malformed JSON', () => {
     it('returns invalid_json code with safe message', async () => {
-      const res = await req(server, 'POST', '/api/v1/contracts', '{bad json');
-      expect(res.statusCode).toBe(400);
-      const json = JSON.parse(res.body);
+      const res = await inject(app, 'POST', '/api/v1/contracts', '{bad json', {
+        'content-type': 'application/json',
+      });
+      expect(res.status).toBe(400);
+      const json = res.body;
       expect(json.error.code).toBe('invalid_json');
       expect(json.error.message).toBe('Malformed JSON payload');
     });
 
     it('contains no forbidden content', async () => {
-      const res = await req(server, 'POST', '/api/v1/contracts', '{{{{');
-      assertNoForbiddenContent(res.body, 'malformed JSON');
+      const res = await inject(app, 'POST', '/api/v1/contracts', '{{{{', {
+        'content-type': 'application/json',
+      });
+      assertNoForbiddenContent(JSON.stringify(res.body), 'malformed JSON');
+    });
+  });
+
+  // ── Central handler mapping ──────────────────────────────────────────────
+
+  describe('central policy mapping', () => {
+    it('maps unknown errors to a safe 500 response', async () => {
+      const res = await inject(app, 'GET', '/__policy/unknown-error');
+      expect(res.status).toBe(500);
+      const json = res.body;
+      expect(json.error).toEqual(
+        expect.objectContaining({
+          code: 'internal_error',
+          message: 'An unexpected error occurred',
+          requestId: expect.any(String),
+        }),
+      );
+      expect(JSON.stringify(res.body)).not.toContain('SELECT token');
+      expect(JSON.stringify(res.body)).not.toContain('/srv/app/src/private.ts');
+      assertNoForbiddenContent(JSON.stringify(res.body), 'unknown error');
+    });
+
+    it('maps AppError instances through the safe message policy', async () => {
+      const res = await inject(app, 'GET', '/__policy/app-error');
+      expect(res.status).toBe(503);
+      const json = res.body;
+      expect(json.error).toEqual(
+        expect.objectContaining({
+          code: 'dependency_unavailable',
+          message: 'A required service is temporarily unavailable',
+          requestId: expect.any(String),
+        }),
+      );
+      assertNoForbiddenContent(JSON.stringify(res.body), 'app error');
+    });
+
+    it('returns validation errors with a safe body and 400 status', async () => {
+      const res = await inject(app, 'POST', '/__policy/validation-error', {
+        contractId: 'not-a-uuid',
+      });
+      expect(res.status).toBe(400);
+      const json = res.body;
+      expect(json.error).toEqual(
+        expect.objectContaining({
+          code: 'validation_error',
+          message: 'Request validation failed',
+          requestId: expect.any(String),
+          details: expect.any(Array),
+        }),
+      );
+      assertNoForbiddenContent(JSON.stringify(res.body), 'validation error');
     });
   });
 
@@ -136,22 +252,22 @@ describe('Error message policy — integration', () => {
 
   describe('envelope shape', () => {
     it('every error response includes requestId', async () => {
-      const res = await req(server, 'GET', '/not-a-real-route');
-      const json = JSON.parse(res.body);
+      const res = await inject(app, 'GET', '/not-a-real-route');
+      const json = res.body;
       expect(typeof json.error.requestId).toBe('string');
       expect(json.error.requestId.length).toBeGreaterThan(0);
     });
 
     it('error code is always a non-empty string', async () => {
-      const res = await req(server, 'GET', '/not-a-real-route');
-      const json = JSON.parse(res.body);
+      const res = await inject(app, 'GET', '/not-a-real-route');
+      const json = res.body;
       expect(typeof json.error.code).toBe('string');
       expect(json.error.code.length).toBeGreaterThan(0);
     });
 
     it('error message is always a non-empty string', async () => {
-      const res = await req(server, 'GET', '/not-a-real-route');
-      const json = JSON.parse(res.body);
+      const res = await inject(app, 'GET', '/not-a-real-route');
+      const json = res.body;
       expect(typeof json.error.message).toBe('string');
       expect(json.error.message.length).toBeGreaterThan(0);
     });
@@ -161,13 +277,15 @@ describe('Error message policy — integration', () => {
 
   describe('machine code stability', () => {
     it('404 always returns not_found', async () => {
-      const res = await req(server, 'GET', '/missing');
-      expect(JSON.parse(res.body).error.code).toBe('not_found');
+      const res = await inject(app, 'GET', '/missing');
+      expect(res.body.error.code).toBe('not_found');
     });
 
     it('malformed JSON always returns invalid_json', async () => {
-      const res = await req(server, 'POST', '/api/v1/contracts', '{');
-      expect(JSON.parse(res.body).error.code).toBe('invalid_json');
+      const res = await inject(app, 'POST', '/api/v1/contracts', '{', {
+        'content-type': 'application/json',
+      });
+      expect(res.body.error.code).toBe('invalid_json');
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@
 
 import type { Request, Response, NextFunction } from 'express';
 import { createApp, attachTerminalHandlers } from './app';
+import { AppError } from './errors/appError';
 import { JobType, JobPayload, QueueManager } from './queue';
 import { authMiddleware, AuthenticatedRequest } from './middleware/auth';
 import { auditService } from './audit/service';
@@ -18,7 +19,7 @@ import { requireAuth, requireRole } from './middleware/authorization';
 
 const queueManager = QueueManager.getInstance();
 
-const app = createApp();
+const app = createApp({ includeTerminalHandlers: false });
 
 const auditExportLimiter = createRateLimiter({
   ...rateLimitConfig.auditExport,
@@ -62,7 +63,7 @@ function requireAdmin(req: AuthenticatedRequest, res: Response, next: NextFuncti
   next();
 }
 
-app.post('/api/v1/jobs', async (req: Request, res: Response) => {
+app.post('/api/v1/jobs', async (req: Request, res: Response, next: NextFunction) => {
   try {
     const { type, payload, options } = req.body as {
       type?: string;
@@ -75,7 +76,7 @@ app.post('/api/v1/jobs', async (req: Request, res: Response) => {
     }
 
     if (!Object.values(JobType).includes(type as JobType)) {
-      return res.status(400).json({ error: `Invalid job type: ${type}` });
+      return res.status(400).json({ error: 'Invalid job type' });
     }
 
     const result = await queueManager.addJob(type as JobType, payload as JobPayload, options);
@@ -87,8 +88,8 @@ app.post('/api/v1/jobs', async (req: Request, res: Response) => {
       deduplicated: (result as any).deduplicated,
     });
   } catch (error) {
-    console.error('Failed to enqueue job', error);
-    return res.status(500).json({ error: 'An unexpected error occurred' });
+    next(error);
+    return;
   }
 });
 
@@ -96,7 +97,7 @@ app.get(
   '/api/v1/jobs/dlq',
   authMiddleware,
   requireAdmin,
-  async (req: AuthenticatedRequest, res: Response) => {
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
     try {
       const typeQuery = (req as any).query['type'];
       const limitQuery = (req as any).query['limit'];
@@ -104,7 +105,7 @@ app.get(
 
       const jobType = typeof typeQuery === 'string' ? typeQuery : undefined;
       if (jobType && !Object.values(JobType).includes(jobType as JobType)) {
-        return res.status(400).json({ error: `Invalid job type: ${jobType}` });
+        return res.status(400).json({ error: 'Invalid job type' });
       }
 
       const limit = Math.min(
@@ -137,8 +138,8 @@ app.get(
 
       return res.status(200).json({ entries, limit, offset, count: entries.length });
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unknown error';
-      return res.status(500).json({ error: `Failed to get DLQ entries: ${message}` });
+      next(error);
+      return;
     }
   },
 );
@@ -147,7 +148,7 @@ app.post(
   '/api/v1/jobs/dlq/reprocess',
   authMiddleware,
   requireAdmin,
-  async (req: AuthenticatedRequest, res: Response) => {
+  async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
     try {
       const { type, jobId, reason } = (req as any).body as {
         type?: string;
@@ -162,7 +163,7 @@ app.post(
       }
 
       if (!Object.values(JobType).includes(type as JobType)) {
-        return res.status(400).json({ error: `Invalid job type: ${type}` });
+        return res.status(400).json({ error: 'Invalid job type' });
       }
 
       const replayResult = await queueManager.reprocessFailedJob(type as JobType, jobId);
@@ -190,24 +191,27 @@ app.post(
       const message = error instanceof Error ? error.message : 'Unknown error';
 
       if (message.startsWith('Failed job not found')) {
-        return res.status(404).json({ error: message });
+        next(new AppError(404, 'not_found', 'The requested resource was not found'));
+        return;
       }
 
       if (message.includes('not in failed state')) {
-        return res.status(409).json({ error: message });
+        next(new AppError(409, 'conflict', 'The request conflicts with the current state'));
+        return;
       }
 
-      return res.status(500).json({ error: `Failed to reprocess DLQ job: ${message}` });
+      next(error);
+      return;
     }
   },
 );
 
-app.get('/api/v1/jobs/:type/:jobId', async (req: Request, res: Response) => {
+app.get('/api/v1/jobs/:type/:jobId', async (req: Request, res: Response, next: NextFunction) => {
   try {
     const { type, jobId } = req.params;
 
     if (!Object.values(JobType).includes(type as JobType)) {
-      return res.status(400).json({ error: `Invalid job type: ${type}` });
+      return res.status(400).json({ error: 'Invalid job type' });
     }
 
     const status = await queueManager.getJobStatus(type as JobType, jobId);
@@ -218,8 +222,8 @@ app.get('/api/v1/jobs/:type/:jobId', async (req: Request, res: Response) => {
 
     return res.json(status);
   } catch (error) {
-    console.error('Failed to get job status', error);
-    return res.status(500).json({ error: 'An unexpected error occurred' });
+    next(error);
+    return;
   }
 });
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -88,11 +88,6 @@ const SENSITIVE_KEYS = new Set([
   'webhook_secret',
 ]);
 
-const redactionPaths = SENSITIVE_KEYS.flatMap(key => [
-  key,
-  `*.${key}`,
-]);
-
 function sanitize(obj: Record<string, unknown>): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(obj)) {

--- a/src/middleware/errorHandlers.ts
+++ b/src/middleware/errorHandlers.ts
@@ -1,5 +1,23 @@
 import { NextFunction, Request, Response } from 'express';
 import { AppError, mapErrorToPayload } from '../errors/appError';
+import { containsUnsafeContent } from '../errors/safeErrors';
+import { logger } from '../logger';
+
+function isBodyParserSyntaxError(error: unknown): boolean {
+  return error instanceof SyntaxError && 'status' in error;
+}
+
+function redactedErrorMessage(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return typeof error === 'string' && !containsUnsafeContent(error) ? error : '[REDACTED]';
+  }
+
+  return containsUnsafeContent(error.message) ? '[REDACTED]' : error.message;
+}
+
+function errorName(error: unknown): string {
+  return error instanceof Error ? error.name : typeof error;
+}
 
 /**
  * Handles unknown routes with a structured 404 response.
@@ -10,6 +28,10 @@ export function notFoundHandler(req: Request, _res: Response, next: NextFunction
 
 /**
  * Maps all errors to a consistent API envelope and status code.
+ *
+ * @remarks This middleware must be registered last. It preserves internal
+ * diagnostics in redacted structured logs while serializing every client
+ * response through `mapErrorToPayload`.
  */
 export function errorHandler(error: unknown, req: Request, res: Response, _next: NextFunction): void {
   if (res.headersSent) {
@@ -21,13 +43,30 @@ export function errorHandler(error: unknown, req: Request, res: Response, _next:
   }
 
   const requestId = typeof res.locals.requestId === 'string' ? res.locals.requestId : 'unknown';
+  const correlationId =
+    typeof res.locals.correlationId === 'string' ? res.locals.correlationId : undefined;
 
-  if (error instanceof SyntaxError && 'status' in error) {
-    const mapped = mapErrorToPayload(new AppError(400, 'invalid_json', 'Malformed JSON payload'), requestId);
-    res.status(mapped.statusCode).json(mapped.payload);
-    return;
-  }
+  const errorForPolicy = isBodyParserSyntaxError(error)
+    ? new AppError(400, 'invalid_json', 'Malformed JSON payload')
+    : error;
+  const mapped = mapErrorToPayload(errorForPolicy, requestId);
 
-  const mapped = mapErrorToPayload(error, requestId);
+  const log = res.locals.log && typeof res.locals.log.error === 'function'
+    ? res.locals.log
+    : logger;
+
+  log.error('API request failed', {
+    err: {
+      type: errorName(error),
+      message: redactedErrorMessage(error),
+    },
+    method: req.method,
+    path: req.path,
+    statusCode: mapped.statusCode,
+    errorCode: mapped.payload.error.code,
+    requestId,
+    ...(correlationId !== undefined && { correlationId }),
+  });
+
   res.status(mapped.statusCode).json(mapped.payload);
 }


### PR DESCRIPTION
# Enforce Safe API Error Responses

## Summary

This PR centralizes API error serialization so internal exception details are not returned to clients. All terminal Express errors are mapped through the safe error message policy, with request IDs included for support correlation and redacted structured logs retained for diagnostics.

## Changes

- Added centralized terminal error handling for unknown errors, application errors, malformed JSON, and validation failures
- Ensured request IDs are available even when JSON parsing fails
- Fixed terminal handler registration order so all API routes are protected by the final error middleware
- Replaced caught internal error responses in job and DLQ flows with policy-managed errors
- Added integration coverage for unknown errors, application errors, validation errors, malformed JSON, and 404 responses
- Documented the standardized safe error response envelope and status/code mappings

## Testing

- `npx jest --runTestsByPath src/errors/errorMessagePolicy.integration.test.ts src/errors/appError.test.ts src/errors/safeErrors.test.ts --runInBand --silent`
- `npx eslint src/app.ts src/index.ts src/errors/appError.ts src/errors/errorMessagePolicy.integration.test.ts src/middleware/errorHandlers.ts src/logger.ts`

Note: full build/lint is currently blocked by an unrelated pre-existing syntax error in `src/webhookDelivery.ts`.

Closes #273 