### PR TITLE
feat(queue): wire blockchain sync processor to real RPC block ingestion 

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,42 @@ Upstream RPC calls (Stellar/Soroban) are protected by a built-in circuit breaker
 
 Live state is available at `GET /api/v1/circuit-breaker/status`. See [`docs/backend/circuit-breaker.md`](docs/backend/circuit-breaker.md) for full reference.
 
+## Blockchain Sync
+
+The `blockchain-sync` background job ingests on-chain Soroban contract events
+into the local indexer. It scans a ledger range, fetches events from the
+Soroban RPC layer, and persists each event so downstream consumers (reputation,
+escrow flows) see the latest chain state.
+
+| Behaviour | Detail |
+| --------- | ------ |
+| **Real RPC ingestion** | Events are fetched via `SorobanRpcService.getEvents` (no more stubbed batches). |
+| **Idempotent persistence** | Each event is keyed by `contractId:eventId:ledger`; replayed or retried batches never double-write. |
+| **Circuit-breaker guarded** | Every RPC call runs through the shared breaker; an open circuit fast-fails the job. |
+| **Resumable** | Progress is checkpointed per batch via a cursor, so a restarted job resumes from the last synced ledger instead of re-scanning from zero. |
+| **Fail-and-retry** | RPC/timeout errors throw so the queue retries the job rather than silently reporting success. |
+| **SSRF-guarded** | `SOROBAN_RPC_URL` is validated against the SSRF allow-list before any egress. |
+
+Job payload (`BlockchainSyncPayload`):
+
+```jsonc
+{
+  "network": "soroban",   // or "stellar"
+  "startBlock": 1000,      // optional — resumes from the last cursor when omitted
+  "endBlock": 1100         // optional — defaults to the current chain head
+}
+```
+
+| Environment variable | Default | Description |
+| -------------------- | ------- | ----------- |
+| `SOROBAN_RPC_URL` | `https://soroban-testnet.stellar.org` | Soroban JSON-RPC endpoint (must be a public, SSRF-safe URL). |
+| `SOROBAN_CONTRACT_ID` | *(empty)* | When set, events are filtered to this contract. |
+
+When neither `startBlock` nor a stored cursor exists, the job starts from ledger
+`0`; when `endBlock` is omitted, the current chain head is discovered via
+`getLatestLedger`. If there is nothing new to sync, the job returns early
+without making event calls.
+
 ## New Features
 
 ### 1. Authentication Middleware (#55)

--- a/src/queue/processors/blockchain-processor.test.ts
+++ b/src/queue/processors/blockchain-processor.test.ts
@@ -1,84 +1,550 @@
 /**
  * Blockchain Processor Tests
- * 
- * Unit tests for blockchain synchronization processing.
+ *
+ * Covers RPC-backed event ingestion, idempotent replay, circuit-breaker
+ * behaviour, cursor-based resume, and input/SSRF validation. The RPC client and
+ * indexer are mocked so tests are deterministic and never touch the network.
  */
 
-import { processBlockchainSync } from './blockchain-processor';
+import * as StellarSdk from '@stellar/stellar-sdk';
+import { rpc } from '@stellar/stellar-sdk';
+
+import {
+  processBlockchainSync,
+  BlockchainSyncDeps,
+  BlockchainSyncStats,
+  EventSink,
+  RpcEventSource,
+} from './blockchain-processor';
 import { BlockchainSyncPayload } from '../types';
+import { SmartContractEvent, EventType } from '../../services/indexer';
+import { buildEventKey } from '../../contracts/dedupe';
+import { ContractEvent } from '../../contracts/types';
+import { CircuitBreaker } from '../../circuit-breaker/CircuitBreaker';
+import { CircuitOpenError } from '../../circuit-breaker/errors';
+import { InMemoryCursorRepository } from '../../contracts/cursor.repository';
+
+const SAFE_RPC_URL = 'https://soroban-testnet.stellar.org';
+
+/** Build a raw-ish RPC event. Topics/values stay as plain values for clarity. */
+function chainEvent(overrides: Partial<{
+  id: string;
+  ledger: number;
+  ledgerClosedAt: string;
+  txHash: string;
+  contractId: string;
+  topics: string[];
+  value: unknown;
+}> = {}): rpc.Api.EventResponse {
+  const raw = {
+    id: overrides.id ?? 'evt-1',
+    type: 'contract',
+    ledger: overrides.ledger ?? 1,
+    ledgerClosedAt: overrides.ledgerClosedAt ?? '2024-01-01T00:00:00Z',
+    pagingToken: 'pt',
+    inSuccessfulContractCall: true,
+    txHash: overrides.txHash ?? 'tx-1',
+    contractId: overrides.contractId ?? 'CCONTRACT',
+    topic: overrides.topics ?? ['escrow_created'],
+    value: 'value' in overrides ? overrides.value : { amount: 100 },
+  };
+  return raw as unknown as rpc.Api.EventResponse;
+}
+
+/** Wrap events in a getEvents response page. */
+function page(
+  events: rpc.Api.EventResponse[],
+  cursor = ''
+): rpc.Api.GetEventsResponse {
+  return {
+    latestLedger: 1000,
+    events,
+    cursor,
+  } as unknown as rpc.Api.GetEventsResponse;
+}
+
+/** Controllable RPC double that records every request it receives. */
+class FakeRpc implements RpcEventSource {
+  public latestLedger = 1000;
+  public calls: rpc.Server.GetEventsRequest[] = [];
+  public latestCalls = 0;
+
+  public getEventsImpl: (
+    req: rpc.Server.GetEventsRequest
+  ) => Promise<rpc.Api.GetEventsResponse> = async () => page([]);
+
+  public getLatestImpl?: () => Promise<rpc.Api.GetLatestLedgerResponse>;
+
+  async getEvents(
+    req: rpc.Server.GetEventsRequest
+  ): Promise<rpc.Api.GetEventsResponse> {
+    this.calls.push(req);
+    return this.getEventsImpl(req);
+  }
+
+  async getLatestLedger(): Promise<rpc.Api.GetLatestLedgerResponse> {
+    this.latestCalls += 1;
+    if (this.getLatestImpl) {
+      return this.getLatestImpl();
+    }
+    return {
+      id: 'ledger',
+      sequence: this.latestLedger,
+      protocolVersion: '22',
+    } as unknown as rpc.Api.GetLatestLedgerResponse;
+  }
+}
+
+/** Indexer double that records persisted events. */
+class RecordingIndexer implements EventSink {
+  public events: SmartContractEvent[] = [];
+
+  async processEvent(
+    event: SmartContractEvent
+  ): Promise<{ status: string; eventId: string }> {
+    this.events.push(event);
+    return { status: 'indexed', eventId: `ev-${this.events.length}` };
+  }
+}
+
+const silentLog = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+};
+
+function makeDeps(overrides: Partial<BlockchainSyncDeps> = {}): BlockchainSyncDeps {
+  return {
+    rpcSource: new FakeRpc(),
+    indexer: new RecordingIndexer(),
+    breaker: new CircuitBreaker({ name: 'test', failureThreshold: 3, timeout: 60_000 }),
+    cursors: new InMemoryCursorRepository(),
+    dedupeKeys: new Set<string>(),
+    rpcUrl: SAFE_RPC_URL,
+    contractId: undefined,
+    log: silentLog,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 describe('Blockchain Processor', () => {
-  describe('processBlockchainSync', () => {
-    it('should sync stellar blockchain', async () => {
-      const payload: BlockchainSyncPayload = {
-        network: 'stellar',
-        startBlock: 0,
-        endBlock: 50,
-      };
-
-      const result = await processBlockchainSync(payload);
-
-      expect(result.success).toBe(true);
-      expect(result.message).toContain('Blockchain sync completed');
-      expect(result.data).toHaveProperty('network', 'stellar');
-      expect(result.data).toHaveProperty('blocksProcessed');
-    });
-
-    it('should sync soroban blockchain', async () => {
-      const payload: BlockchainSyncPayload = {
-        network: 'soroban',
-        startBlock: 100,
-        endBlock: 200,
-      };
-
-      const result = await processBlockchainSync(payload);
-
-      expect(result.success).toBe(true);
-      expect(result.data).toHaveProperty('network', 'soroban');
-    });
-
-    it('should sync without explicit block range', async () => {
-      const payload: BlockchainSyncPayload = {
-        network: 'stellar',
-      };
-
-      const result = await processBlockchainSync(payload);
-      expect(result.success).toBe(true);
-    });
-
-    it('should reject invalid network', async () => {
-      const payload = {
-        network: 'ethereum',
-      } as unknown as BlockchainSyncPayload;
-
-      await expect(processBlockchainSync(payload)).rejects.toThrow(
-        'Invalid network'
+  describe('input validation', () => {
+    it('rejects unsupported networks', async () => {
+      const payload = { network: 'ethereum' } as unknown as BlockchainSyncPayload;
+      await expect(processBlockchainSync(payload, makeDeps())).rejects.toThrow(
+        'Invalid network: ethereum'
       );
     });
 
-    it('should reject invalid block range', async () => {
+    it('rejects an inverted block range', async () => {
       const payload: BlockchainSyncPayload = {
-        network: 'stellar',
+        network: 'soroban',
         startBlock: 100,
         endBlock: 50,
       };
-
-      await expect(processBlockchainSync(payload)).rejects.toThrow(
+      await expect(processBlockchainSync(payload, makeDeps())).rejects.toThrow(
         'Start block must be less than or equal to end block'
       );
     });
 
-    it('should process large block ranges', async () => {
-      const payload: BlockchainSyncPayload = {
-        network: 'stellar',
-        startBlock: 0,
-        endBlock: 1000,
-      };
+    it('rejects an RPC URL that fails the SSRF guard', async () => {
+      const deps = makeDeps({ rpcUrl: 'http://127.0.0.1:8000/rpc' });
+      await expect(
+        processBlockchainSync({ network: 'soroban', startBlock: 1, endBlock: 5 }, deps)
+      ).rejects.toThrow('SSRF protection');
+    });
+  });
 
-      const result = await processBlockchainSync(payload);
+  describe('event ingestion', () => {
+    it('persists fetched events and reports stats', async () => {
+      const rpcSource = new FakeRpc();
+      rpcSource.getEventsImpl = async () =>
+        page([
+          chainEvent({ id: 'a', ledger: 1, topics: ['escrow_created'] }),
+          chainEvent({ id: 'b', ledger: 2, topics: ['escrow_completed'] }),
+        ]);
+      const indexer = new RecordingIndexer();
+      const deps = makeDeps({ rpcSource, indexer });
+
+      const result = await processBlockchainSync(
+        { network: 'soroban', startBlock: 1, endBlock: 5 },
+        deps
+      );
 
       expect(result.success).toBe(true);
-      expect((result.data as any).blocksProcessed).toBeGreaterThan(0);
+      expect(result.message).toContain('Blockchain sync completed');
+      const stats = result.data as BlockchainSyncStats;
+      expect(stats.eventsIngested).toBe(2);
+      expect(stats.duplicatesSkipped).toBe(0);
+      expect(stats.blocksProcessed).toBe(5);
+      expect(stats.lastSyncedBlock).toBe(5);
+      expect(indexer.events).toHaveLength(2);
+      expect(indexer.events[0].eventType).toBe(EventType.EscrowCreated);
+      expect(indexer.events[1].eventType).toBe(EventType.EscrowCompleted);
+    });
+
+    it('preserves raw topics and value in the persisted payload', async () => {
+      const rpcSource = new FakeRpc();
+      rpcSource.getEventsImpl = async () =>
+        page([chainEvent({ id: 'a', ledger: 3, topics: ['custom_topic'], value: { x: 1 } })]);
+      const indexer = new RecordingIndexer();
+      const deps = makeDeps({ rpcSource, indexer });
+
+      await processBlockchainSync({ network: 'soroban', startBlock: 1, endBlock: 5 }, deps);
+
+      const persisted = indexer.events[0];
+      expect(persisted.eventType).toBe(EventType.EscrowCreated); // unknown topic -> default
+      expect(persisted.payload).toMatchObject({
+        topics: ['custom_topic'],
+        value: { x: 1 },
+        ledger: 3,
+      });
+    });
+
+    it('classifies dispute lifecycle topics', async () => {
+      const rpcSource = new FakeRpc();
+      rpcSource.getEventsImpl = async () =>
+        page([
+          chainEvent({ id: 'd1', ledger: 1, topics: ['dispute_initiated'] }),
+          chainEvent({ id: 'd2', ledger: 2, topics: ['dispute_resolved'] }),
+        ]);
+      const indexer = new RecordingIndexer();
+      const deps = makeDeps({ rpcSource, indexer });
+
+      await processBlockchainSync({ network: 'soroban', startBlock: 1, endBlock: 5 }, deps);
+
+      expect(indexer.events.map((e) => e.eventType)).toEqual([
+        EventType.DisputeInitiated,
+        EventType.DisputeResolved,
+      ]);
+    });
+
+    it('skips events that carry no contract id', async () => {
+      const rpcSource = new FakeRpc();
+      rpcSource.getEventsImpl = async () =>
+        page([
+          chainEvent({ id: 'a', ledger: 1, contractId: '' }),
+          chainEvent({ id: 'b', ledger: 2, contractId: 'CCONTRACT' }),
+        ]);
+      const indexer = new RecordingIndexer();
+      const deps = makeDeps({ rpcSource, indexer });
+
+      const result = await processBlockchainSync(
+        { network: 'soroban', startBlock: 1, endBlock: 5 },
+        deps
+      );
+
+      expect((result.data as BlockchainSyncStats).eventsIngested).toBe(1);
+      expect(indexer.events).toHaveLength(1);
+      expect(indexer.events[0].contractId).toBe('CCONTRACT');
+    });
+
+    it('passes the configured contract id as an RPC filter', async () => {
+      const rpcSource = new FakeRpc();
+      rpcSource.getEventsImpl = async () => page([]);
+      const deps = makeDeps({ rpcSource, contractId: 'CFILTERED' });
+
+      await processBlockchainSync({ network: 'soroban', startBlock: 1, endBlock: 5 }, deps);
+
+      expect(rpcSource.calls[0].filters).toEqual([
+        { type: 'contract', contractIds: ['CFILTERED'] },
+      ]);
+    });
+  });
+
+  describe('idempotency', () => {
+    it('skips duplicate events within a single batch', async () => {
+      const rpcSource = new FakeRpc();
+      rpcSource.getEventsImpl = async () =>
+        page([
+          chainEvent({ id: 'dup', ledger: 1 }),
+          chainEvent({ id: 'dup', ledger: 1 }),
+        ]);
+      const indexer = new RecordingIndexer();
+      const deps = makeDeps({ rpcSource, indexer });
+
+      const result = await processBlockchainSync(
+        { network: 'soroban', startBlock: 1, endBlock: 5 },
+        deps
+      );
+
+      const stats = result.data as BlockchainSyncStats;
+      expect(stats.eventsIngested).toBe(1);
+      expect(stats.duplicatesSkipped).toBe(1);
+      expect(indexer.events).toHaveLength(1);
+    });
+
+    it('does not double-write when the same batch is replayed', async () => {
+      const rpcSource = new FakeRpc();
+      rpcSource.getEventsImpl = async () =>
+        page([chainEvent({ id: 'a', ledger: 1 }), chainEvent({ id: 'b', ledger: 2 })]);
+      const indexer = new RecordingIndexer();
+      const dedupeKeys = new Set<string>();
+      const deps = makeDeps({ rpcSource, indexer, dedupeKeys });
+
+      const first = await processBlockchainSync(
+        { network: 'soroban', startBlock: 1, endBlock: 5 },
+        deps
+      );
+      const second = await processBlockchainSync(
+        { network: 'soroban', startBlock: 1, endBlock: 5 },
+        deps
+      );
+
+      expect((first.data as BlockchainSyncStats).eventsIngested).toBe(2);
+      expect((second.data as BlockchainSyncStats).eventsIngested).toBe(0);
+      expect((second.data as BlockchainSyncStats).duplicatesSkipped).toBe(2);
+      expect(indexer.events).toHaveLength(2); // never re-persisted
+    });
+
+    it('seeds the dedupe registry with the canonical event key', async () => {
+      const rpcSource = new FakeRpc();
+      rpcSource.getEventsImpl = async () =>
+        page([chainEvent({ id: 'a', ledger: 7, contractId: 'CCONTRACT' })]);
+      const dedupeKeys = new Set<string>();
+      const deps = makeDeps({ rpcSource, dedupeKeys });
+
+      await processBlockchainSync({ network: 'soroban', startBlock: 1, endBlock: 10 }, deps);
+
+      const expectedKey = buildEventKey({
+        contractId: 'CCONTRACT',
+        eventId: 'a',
+        sequence: 7,
+      } as ContractEvent);
+      expect(dedupeKeys.has(expectedKey)).toBe(true);
+    });
+  });
+
+  describe('resume / checkpointing', () => {
+    it('resumes from the ledger after the stored cursor', async () => {
+      const rpcSource = new FakeRpc();
+      rpcSource.getEventsImpl = async () => page([]);
+      const cursors = new InMemoryCursorRepository();
+      await cursors.updateCursor('soroban', 20);
+      const deps = makeDeps({ rpcSource, cursors });
+
+      await processBlockchainSync({ network: 'soroban', endBlock: 25 }, deps);
+
+      expect(rpcSource.calls[0].startLedger).toBe(21);
+    });
+
+    it('starts from zero when no cursor exists', async () => {
+      const rpcSource = new FakeRpc();
+      rpcSource.getEventsImpl = async () => page([]);
+      const deps = makeDeps({ rpcSource });
+
+      await processBlockchainSync({ network: 'soroban', endBlock: 5 }, deps);
+
+      expect(rpcSource.calls[0].startLedger).toBe(0);
+    });
+
+    it('checkpoints the last synced ledger after the batch', async () => {
+      const rpcSource = new FakeRpc();
+      rpcSource.getEventsImpl = async () => page([chainEvent({ ledger: 3 })]);
+      const cursors = new InMemoryCursorRepository();
+      const deps = makeDeps({ rpcSource, cursors });
+
+      await processBlockchainSync({ network: 'soroban', startBlock: 1, endBlock: 5 }, deps);
+
+      const cursor = await cursors.getCursor('soroban');
+      expect(cursor?.lastSequence).toBe(5);
+    });
+
+    it('uses a contract-scoped cursor source when a contract id is set', async () => {
+      const rpcSource = new FakeRpc();
+      rpcSource.getEventsImpl = async () => page([]);
+      const cursors = new InMemoryCursorRepository();
+      const deps = makeDeps({ rpcSource, cursors, contractId: 'CSCOPED' });
+
+      await processBlockchainSync({ network: 'soroban', startBlock: 1, endBlock: 5 }, deps);
+
+      expect(await cursors.getCursor('soroban:CSCOPED')).not.toBeNull();
+      expect(await cursors.getCursor('soroban')).toBeNull();
+    });
+
+    it('returns early for an empty range without calling getEvents', async () => {
+      const rpcSource = new FakeRpc();
+      rpcSource.latestLedger = 10;
+      const cursors = new InMemoryCursorRepository();
+      await cursors.updateCursor('soroban', 20);
+      const deps = makeDeps({ rpcSource, cursors });
+
+      const result = await processBlockchainSync({ network: 'soroban' }, deps);
+
+      expect(result.success).toBe(true);
+      expect(result.message).toContain('up to date');
+      expect((result.data as BlockchainSyncStats).blocksProcessed).toBe(0);
+      expect(rpcSource.calls).toHaveLength(0);
+    });
+  });
+
+  describe('chain head discovery', () => {
+    it('queries the latest ledger when no endBlock is supplied', async () => {
+      const rpcSource = new FakeRpc();
+      rpcSource.latestLedger = 4;
+      rpcSource.getEventsImpl = async () => page([chainEvent({ ledger: 2 })]);
+      const deps = makeDeps({ rpcSource });
+
+      const result = await processBlockchainSync({ network: 'soroban', startBlock: 0 }, deps);
+
+      expect(rpcSource.latestCalls).toBe(1);
+      expect((result.data as BlockchainSyncStats).endBlock).toBe(4);
+    });
+  });
+
+  describe('batching', () => {
+    it('scans large ranges across multiple batches', async () => {
+      const rpcSource = new FakeRpc();
+      rpcSource.getEventsImpl = async () => page([]);
+      const deps = makeDeps({ rpcSource });
+
+      const result = await processBlockchainSync(
+        { network: 'soroban', startBlock: 1, endBlock: 25 },
+        deps
+      );
+
+      expect((result.data as BlockchainSyncStats).blocksProcessed).toBe(25);
+      expect(rpcSource.calls.map((c) => c.startLedger)).toEqual([1, 11, 21]);
+    });
+
+    it('follows the paging cursor and stops at the window edge', async () => {
+      const rpcSource = new FakeRpc();
+      const responses = [
+        page([chainEvent({ id: 'p1', ledger: 1 })], 'cursor-1'),
+        page([chainEvent({ id: 'p2', ledger: 2 }), chainEvent({ id: 'over', ledger: 99 })], 'cursor-2'),
+      ];
+      let call = 0;
+      rpcSource.getEventsImpl = async () => responses[call++] ?? page([]);
+      const indexer = new RecordingIndexer();
+      const deps = makeDeps({ rpcSource, indexer });
+
+      const result = await processBlockchainSync(
+        { network: 'soroban', startBlock: 1, endBlock: 5 },
+        deps
+      );
+
+      // Two pages consumed; the ledger-99 event is outside the window and ignored.
+      expect(rpcSource.calls).toHaveLength(2);
+      expect(rpcSource.calls[1].cursor).toBe('cursor-1');
+      expect((result.data as BlockchainSyncStats).eventsIngested).toBe(2);
+      expect(indexer.events.map((e) => e.payload)).toEqual([
+        expect.objectContaining({ ledger: 1 }),
+        expect.objectContaining({ ledger: 2 }),
+      ]);
+    });
+  });
+
+  describe('xdr decoding', () => {
+    it('decodes real XDR topics, value, and Contract id', async () => {
+      const contractAddress = StellarSdk.StrKey.encodeContract(Buffer.alloc(32, 1));
+      const rawEvent = {
+        id: 'xdr-1',
+        type: 'contract',
+        ledger: 2,
+        ledgerClosedAt: '2024-02-02T00:00:00Z',
+        pagingToken: 'pt',
+        inSuccessfulContractCall: true,
+        txHash: 'tx-xdr',
+        contractId: new StellarSdk.Contract(contractAddress),
+        topic: [StellarSdk.xdr.ScVal.scvSymbol('escrow_completed')],
+        value: StellarSdk.xdr.ScVal.scvU32(42),
+      } as unknown as rpc.Api.EventResponse;
+
+      const rpcSource = new FakeRpc();
+      rpcSource.getEventsImpl = async () => page([rawEvent]);
+      const indexer = new RecordingIndexer();
+      const deps = makeDeps({ rpcSource, indexer });
+
+      await processBlockchainSync({ network: 'soroban', startBlock: 1, endBlock: 5 }, deps);
+
+      const persisted = indexer.events[0];
+      expect(persisted.contractId).toBe(contractAddress);
+      expect(persisted.eventType).toBe(EventType.EscrowCompleted);
+      expect(persisted.payload).toMatchObject({
+        topics: ['escrow_completed'],
+        value: 42,
+      });
+    });
+
+    it('tolerates a null event value', async () => {
+      const rpcSource = new FakeRpc();
+      rpcSource.getEventsImpl = async () =>
+        page([chainEvent({ id: 'n', ledger: 1, value: null })]);
+      const indexer = new RecordingIndexer();
+      const deps = makeDeps({ rpcSource, indexer });
+
+      await processBlockchainSync({ network: 'soroban', startBlock: 1, endBlock: 5 }, deps);
+
+      expect(indexer.events[0].payload).toMatchObject({ value: null });
+    });
+  });
+
+  describe('default dependency wiring', () => {
+    it('builds production deps from env when none are injected', async () => {
+      // Default deps are constructed before validation runs; an inverted range
+      // exercises that wiring without performing any network I/O.
+      await expect(
+        processBlockchainSync({ network: 'soroban', startBlock: 5, endBlock: 4 })
+      ).rejects.toThrow('Start block must be less than or equal to end block');
+    });
+  });
+
+  describe('circuit breaker and RPC failures', () => {
+    it('fails the job when the circuit is open', async () => {
+      const breaker = new CircuitBreaker({ name: 'rpc', failureThreshold: 1, timeout: 60_000 });
+      await expect(breaker.execute(() => Promise.reject(new Error('boom')))).rejects.toThrow();
+      expect(breaker.getState()).toBe('OPEN');
+
+      const rpcSource = new FakeRpc();
+      const deps = makeDeps({ rpcSource, breaker });
+
+      await expect(
+        processBlockchainSync({ network: 'soroban', startBlock: 1, endBlock: 5 }, deps)
+      ).rejects.toBeInstanceOf(CircuitOpenError);
+      // Breaker short-circuited before any real RPC call.
+      expect(rpcSource.calls).toHaveLength(0);
+    });
+
+    it('fails the job (for retry) when getEvents errors', async () => {
+      const rpcSource = new FakeRpc();
+      rpcSource.getEventsImpl = async () => {
+        throw new Error('rpc unavailable');
+      };
+      const deps = makeDeps({ rpcSource });
+
+      await expect(
+        processBlockchainSync({ network: 'soroban', startBlock: 1, endBlock: 5 }, deps)
+      ).rejects.toThrow('Soroban RPC getEvents failed: rpc unavailable');
+    });
+
+    it('fails the job when the chain-head lookup times out', async () => {
+      const rpcSource = new FakeRpc();
+      rpcSource.getLatestImpl = async () => {
+        throw new Error('timeout');
+      };
+      const deps = makeDeps({ rpcSource });
+
+      await expect(
+        processBlockchainSync({ network: 'soroban', startBlock: 0 }, deps)
+      ).rejects.toThrow('Soroban RPC getLatestLedger failed: timeout');
+    });
+
+    it('trips the breaker open after repeated RPC failures', async () => {
+      const breaker = new CircuitBreaker({ name: 'rpc', failureThreshold: 1, timeout: 60_000 });
+      const rpcSource = new FakeRpc();
+      rpcSource.getEventsImpl = async () => {
+        throw new Error('down');
+      };
+      const deps = makeDeps({ rpcSource, breaker });
+
+      await expect(
+        processBlockchainSync({ network: 'soroban', startBlock: 1, endBlock: 5 }, deps)
+      ).rejects.toThrow();
+      expect(breaker.getState()).toBe('OPEN');
     });
   });
 });

--- a/src/queue/processors/blockchain-processor.ts
+++ b/src/queue/processors/blockchain-processor.ts
@@ -1,85 +1,499 @@
 /**
  * Blockchain Synchronization Processor
- * 
- * Handles synchronization of blockchain data with local database.
- * Processes blocks in batches to avoid overwhelming the system.
+ *
+ * Ingests on-chain Soroban contract events into the local indexer. The job
+ * scans a ledger range, fetches events through the Stellar/Soroban RPC layer
+ * (guarded by a circuit breaker), and persists each event idempotently so that
+ * replayed or retried batches never double-write.
+ *
+ * Progress is checkpointed after every batch via a cursor, so a restarted job
+ * resumes from the last synced ledger instead of re-scanning from zero.
  */
+
+import { rpc, scValToNative, xdr } from '@stellar/stellar-sdk';
 
 import { BlockchainSyncPayload, JobResult } from '../types';
+import { SorobanRpcService } from '../../services/soroban/SorobanRpcService';
+import {
+  EventType,
+  SmartContractEvent,
+  indexerService,
+} from '../../services/indexer';
+import { buildEventKey } from '../../contracts/dedupe';
+import { ContractEvent } from '../../contracts/types';
+import { CircuitBreaker } from '../../circuit-breaker/CircuitBreaker';
+import { CircuitOpenError } from '../../circuit-breaker/errors';
+import {
+  CursorRepository,
+  InMemoryCursorRepository,
+} from '../../contracts/cursor.repository';
+import { isSafeUrl } from '../../utils/ssrf';
+import { validateEnv } from '../../config/env.schema';
+import { logger, Logger } from '../../logger';
+
+/** Number of ledgers fetched and checkpointed per iteration. */
+const BATCH_SIZE = 10;
+
+/** Max events requested per RPC page. */
+const EVENTS_PAGE_LIMIT = 100;
+
+/** Hard cap on pagination loops per batch to avoid runaway cursors. */
+const MAX_PAGES_PER_BATCH = 50;
+
+/** Networks this processor knows how to sync. */
+const SUPPORTED_NETWORKS: ReadonlyArray<BlockchainSyncPayload['network']> = [
+  'stellar',
+  'soroban',
+];
 
 /**
- * Process blockchain synchronization job
- * 
- * @param payload - Blockchain sync configuration
- * @returns Job result with sync statistics
- * @throws Error if sync fails
+ * Maps known on-chain topic symbols to the indexer's event taxonomy.
+ * Unrecognized topics fall through to {@link classifyEvent}'s default.
+ */
+const TOPIC_EVENT_TYPES: Readonly<Record<string, EventType>> = {
+  escrow_created: EventType.EscrowCreated,
+  created: EventType.EscrowCreated,
+  escrow_completed: EventType.EscrowCompleted,
+  completed: EventType.EscrowCompleted,
+  dispute_initiated: EventType.DisputeInitiated,
+  dispute_resolved: EventType.DisputeResolved,
+  resolved: EventType.DisputeResolved,
+};
+
+/**
+ * Minimal RPC surface the sync worker depends on. {@link SorobanRpcService}
+ * satisfies this interface; tests inject a lightweight mock.
+ */
+export interface RpcEventSource {
+  getEvents(
+    request: rpc.Server.GetEventsRequest
+  ): Promise<rpc.Api.GetEventsResponse>;
+  getLatestLedger(): Promise<rpc.Api.GetLatestLedgerResponse>;
+}
+
+/**
+ * Persistence sink for normalized events. The default
+ * {@link indexerService} singleton implements this.
+ */
+export interface EventSink {
+  processEvent(
+    event: SmartContractEvent
+  ): Promise<{ status: string; eventId: string }>;
+}
+
+/** Collaborators required to run a sync. Defaults wire the real Soroban stack. */
+export interface BlockchainSyncDeps {
+  rpcSource: RpcEventSource;
+  indexer: EventSink;
+  breaker: CircuitBreaker;
+  cursors: CursorRepository;
+  /** In-process registry of dedupe keys already persisted. */
+  dedupeKeys: Set<string>;
+  rpcUrl: string;
+  contractId?: string;
+  log: Pick<Logger, 'info' | 'warn' | 'error'>;
+}
+
+/** Statistics returned by a completed sync. */
+export interface BlockchainSyncStats {
+  network: string;
+  startBlock: number;
+  endBlock: number;
+  blocksProcessed: number;
+  eventsIngested: number;
+  duplicatesSkipped: number;
+  lastSyncedBlock: number;
+}
+
+/** Normalized, JSON-friendly view of a Soroban contract event. */
+interface NormalizedChainEvent {
+  id: string;
+  contractId: string;
+  ledger: number;
+  ledgerClosedAt: string;
+  topics: string[];
+  value: unknown;
+  txHash: string;
+}
+
+// Process-wide singletons so resume and dedupe survive across job runs.
+const sharedBreaker = new CircuitBreaker({
+  name: 'soroban-rpc',
+  failureThreshold: 3,
+  timeout: 30_000,
+});
+const sharedCursors: CursorRepository = new InMemoryCursorRepository();
+const sharedDedupeKeys = new Set<string>();
+
+/**
+ * Build the production dependency set from validated environment config.
+ * Only invoked when a caller does not supply its own deps (e.g. real jobs).
+ */
+function resolveDefaultDeps(): BlockchainSyncDeps {
+  const env = validateEnv();
+  return {
+    rpcSource: new SorobanRpcService(env.SOROBAN_RPC_URL),
+    indexer: indexerService,
+    breaker: sharedBreaker,
+    cursors: sharedCursors,
+    dedupeKeys: sharedDedupeKeys,
+    rpcUrl: env.SOROBAN_RPC_URL,
+    contractId: env.SOROBAN_CONTRACT_ID,
+    log: logger,
+  };
+}
+
+/**
+ * Process a blockchain synchronization job.
+ *
+ * Fetches Soroban contract events for the requested ledger range and persists
+ * them through the indexer. RPC failures (including an open circuit) are thrown
+ * so the queue retries the job rather than silently reporting success.
+ *
+ * @param payload - Network and optional block range to sync.
+ * @param deps - Injectable collaborators; defaults to the real Soroban stack.
+ * @returns Job result with sync statistics.
+ * @throws If the network/range is invalid, the RPC URL is unsafe, or RPC fails.
  */
 export async function processBlockchainSync(
-  payload: BlockchainSyncPayload
+  payload: BlockchainSyncPayload,
+  deps: BlockchainSyncDeps = resolveDefaultDeps()
 ): Promise<JobResult> {
-  // Validate network
-  const validNetworks = ['stellar', 'soroban'];
-  if (!validNetworks.includes(payload.network)) {
+  if (!SUPPORTED_NETWORKS.includes(payload.network)) {
     throw new Error(`Invalid network: ${payload.network}`);
   }
 
-  // Validate block range
-  if (payload.startBlock !== undefined && payload.endBlock !== undefined) {
-    if (payload.startBlock > payload.endBlock) {
-      throw new Error('Start block must be less than or equal to end block');
-    }
+  if (
+    payload.startBlock !== undefined &&
+    payload.endBlock !== undefined &&
+    payload.startBlock > payload.endBlock
+  ) {
+    throw new Error('Start block must be less than or equal to end block');
   }
 
-  console.log(`Syncing ${payload.network} blockchain`);
+  // SSRF guard: never egress to a private/internal or malformed RPC host.
+  if (!isSafeUrl(deps.rpcUrl)) {
+    throw new Error(
+      'SOROBAN_RPC_URL must be a public URL and cannot point to internal resources (SSRF protection)'
+    );
+  }
 
-  const syncResult = await syncBlockchainData(payload);
+  const sourceId = buildSourceId(payload.network, deps.contractId);
+  const startBlock = await resolveStartBlock(payload, sourceId, deps);
+  const endBlock = await resolveEndBlock(payload, deps);
+
+  // Nothing new on-chain since the last checkpoint — succeed without scanning.
+  if (startBlock > endBlock) {
+    deps.log.info('Blockchain sync already up to date', {
+      network: payload.network,
+      startBlock,
+      endBlock,
+    });
+    return {
+      success: true,
+      message: `Blockchain sync up to date for ${payload.network}`,
+      data: emptyStats(payload.network, startBlock, endBlock),
+    };
+  }
+
+  const stats = await ingestRange(
+    payload.network,
+    sourceId,
+    startBlock,
+    endBlock,
+    deps
+  );
+
+  deps.log.info('Blockchain sync completed', {
+    network: payload.network,
+    eventsIngested: stats.eventsIngested,
+    duplicatesSkipped: stats.duplicatesSkipped,
+    lastSyncedBlock: stats.lastSyncedBlock,
+  });
 
   return {
     success: true,
     message: `Blockchain sync completed for ${payload.network}`,
-    data: syncResult,
+    data: stats,
   };
 }
 
 /**
- * Sync blockchain data in batches
+ * Resolve the first ledger to scan. An explicit `startBlock` always wins;
+ * otherwise resume from the ledger after the last checkpointed one.
  */
-async function syncBlockchainData(payload: BlockchainSyncPayload) {
-  const startBlock = payload.startBlock || 0;
-  const endBlock = payload.endBlock || startBlock + 100;
-  const batchSize = 10;
+async function resolveStartBlock(
+  payload: BlockchainSyncPayload,
+  sourceId: string,
+  deps: BlockchainSyncDeps
+): Promise<number> {
+  if (payload.startBlock !== undefined) {
+    return payload.startBlock;
+  }
 
-  let processedBlocks = 0;
-  let transactions = 0;
+  const cursor = await deps.cursors.getCursor(sourceId);
+  if (cursor && cursor.lastSequence >= 0) {
+    return cursor.lastSequence + 1;
+  }
 
-  for (let block = startBlock; block <= endBlock; block += batchSize) {
-    const batchEnd = Math.min(block + batchSize - 1, endBlock);
-    
-    // Simulate fetching and processing blocks
-    await processBatch(payload.network, block, batchEnd);
-    
-    processedBlocks += batchEnd - block + 1;
-    transactions += Math.floor(Math.random() * 50) + 10;
+  return 0;
+}
+
+/**
+ * Resolve the last ledger to scan. Falls back to the current chain head so we
+ * never scan past settled ledgers when no explicit `endBlock` is given.
+ */
+async function resolveEndBlock(
+  payload: BlockchainSyncPayload,
+  deps: BlockchainSyncDeps
+): Promise<number> {
+  if (payload.endBlock !== undefined) {
+    return payload.endBlock;
+  }
+
+  try {
+    const latest = await deps.breaker.execute(() =>
+      deps.rpcSource.getLatestLedger()
+    );
+    return latest.sequence;
+  } catch (error) {
+    throw asRpcError('getLatestLedger', error);
+  }
+}
+
+/**
+ * Scan the ledger range batch-by-batch, ingesting events and checkpointing
+ * progress after each batch so a restart resumes cleanly.
+ */
+async function ingestRange(
+  network: string,
+  sourceId: string,
+  startBlock: number,
+  endBlock: number,
+  deps: BlockchainSyncDeps
+): Promise<BlockchainSyncStats> {
+  let blocksProcessed = 0;
+  let eventsIngested = 0;
+  let duplicatesSkipped = 0;
+  let lastSyncedBlock = startBlock - 1;
+
+  for (let batchStart = startBlock; batchStart <= endBlock; batchStart += BATCH_SIZE) {
+    const batchEnd = Math.min(batchStart + BATCH_SIZE - 1, endBlock);
+    const events = await fetchBatchEvents(batchStart, batchEnd, deps);
+
+    for (const event of events) {
+      const outcome = await ingestEvent(event, deps);
+      if (outcome === 'ingested') {
+        eventsIngested += 1;
+      } else {
+        duplicatesSkipped += 1;
+      }
+    }
+
+    blocksProcessed += batchEnd - batchStart + 1;
+    lastSyncedBlock = batchEnd;
+
+    // Checkpoint only after a batch fully succeeds so retries resume here.
+    await deps.cursors.updateCursor(sourceId, batchEnd, { network });
+    deps.log.info('Blockchain batch synced', {
+      network,
+      batchStart,
+      batchEnd,
+      eventsIngested,
+      duplicatesSkipped,
+    });
   }
 
   return {
-    network: payload.network,
-    blocksProcessed: processedBlocks,
-    transactionsFound: transactions,
+    network,
     startBlock,
     endBlock,
+    blocksProcessed,
+    eventsIngested,
+    duplicatesSkipped,
+    lastSyncedBlock,
   };
 }
 
 /**
- * Process a batch of blocks
+ * Fetch all contract events within `[batchStart, batchEnd]`, following the RPC
+ * paging cursor and stopping once events spill past the window. Every RPC call
+ * runs through the circuit breaker.
  */
-async function processBatch(
+async function fetchBatchEvents(
+  batchStart: number,
+  batchEnd: number,
+  deps: BlockchainSyncDeps
+): Promise<NormalizedChainEvent[]> {
+  const filters: rpc.Api.EventFilter[] = deps.contractId
+    ? [{ type: 'contract', contractIds: [deps.contractId] }]
+    : [{ type: 'contract' }];
+
+  const collected: NormalizedChainEvent[] = [];
+  let cursor: string | undefined;
+
+  for (let page = 0; page < MAX_PAGES_PER_BATCH; page += 1) {
+    const request: rpc.Server.GetEventsRequest = cursor
+      ? { filters, cursor, limit: EVENTS_PAGE_LIMIT }
+      : { filters, startLedger: batchStart, limit: EVENTS_PAGE_LIMIT };
+
+    let response: rpc.Api.GetEventsResponse;
+    try {
+      response = await deps.breaker.execute(() => deps.rpcSource.getEvents(request));
+    } catch (error) {
+      throw asRpcError('getEvents', error);
+    }
+
+    const pageEvents = response.events ?? [];
+    let windowEnded = false;
+
+    for (const raw of pageEvents) {
+      if (raw.ledger > batchEnd) {
+        windowEnded = true;
+        break;
+      }
+      const normalized = normalizeEvent(raw);
+      if (normalized.contractId) {
+        collected.push(normalized);
+      }
+    }
+
+    cursor = response.cursor || undefined;
+    if (windowEnded || pageEvents.length === 0 || !cursor) {
+      break;
+    }
+  }
+
+  return collected;
+}
+
+/**
+ * Persist a single event idempotently.
+ *
+ * The dedupe key is built with the shared {@link buildEventKey} helper from the
+ * contract ID, event ID, and ledger sequence. Keys already seen in this process
+ * are skipped so replayed batches do not double-write.
+ *
+ * @returns `'ingested'` when newly persisted, `'duplicate'` when skipped.
+ */
+async function ingestEvent(
+  event: NormalizedChainEvent,
+  deps: BlockchainSyncDeps
+): Promise<'ingested' | 'duplicate'> {
+  // buildEventKey only reads the identity fields (contractId/eventId/sequence).
+  const dedupeKey = buildEventKey({
+    contractId: event.contractId,
+    eventId: event.id,
+    sequence: event.ledger,
+  } as ContractEvent);
+
+  if (deps.dedupeKeys.has(dedupeKey)) {
+    return 'duplicate';
+  }
+
+  const smartEvent: SmartContractEvent = {
+    contractId: event.contractId,
+    eventType: classifyEvent(event.topics),
+    idempotencyKey: dedupeKey,
+    payload: {
+      topics: event.topics,
+      value: event.value,
+      txHash: event.txHash,
+      ledger: event.ledger,
+    },
+    timestamp: event.ledgerClosedAt,
+  };
+
+  await deps.indexer.processEvent(smartEvent);
+  deps.dedupeKeys.add(dedupeKey);
+  return 'ingested';
+}
+
+/**
+ * Classify an event by its topics. Falls back to `EscrowCreated` for
+ * unrecognized topics; the raw topics are preserved in the event payload so
+ * downstream consumers can reclassify if needed.
+ */
+function classifyEvent(topics: string[]): EventType {
+  for (const topic of topics) {
+    const mapped = TOPIC_EVENT_TYPES[topic.toLowerCase()];
+    if (mapped) {
+      return mapped;
+    }
+  }
+  return EventType.EscrowCreated;
+}
+
+/**
+ * Convert a raw RPC event into a normalized, JSON-friendly shape, decoding
+ * XDR topics/values where present. Tolerates already-decoded values so tests
+ * can supply plain objects.
+ */
+function normalizeEvent(raw: rpc.Api.EventResponse): NormalizedChainEvent {
+  return {
+    id: raw.id,
+    contractId: decodeContractId(raw.contractId),
+    ledger: raw.ledger,
+    ledgerClosedAt: raw.ledgerClosedAt ?? new Date().toISOString(),
+    topics: (raw.topic ?? []).map((topic) => String(decodeScVal(topic))),
+    value: decodeScVal(raw.value),
+    txHash: raw.txHash,
+  };
+}
+
+/** Stringify a contract id whether it arrives as a string or `Contract`. */
+function decodeContractId(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  return value ? String(value) : '';
+}
+
+/** Decode an XDR ScVal to a native value, tolerating already-native inputs. */
+function decodeScVal(value: unknown): unknown {
+  if (value === null || value === undefined) {
+    return value;
+  }
+  if (value instanceof xdr.ScVal) {
+    try {
+      return scValToNative(value);
+    } catch {
+      return undefined;
+    }
+  }
+  return value;
+}
+
+/** Compose a stable cursor source id for a network/contract pair. */
+function buildSourceId(network: string, contractId?: string): string {
+  return contractId ? `${network}:${contractId}` : network;
+}
+
+/** Stats object for an empty (already-synced) range. */
+function emptyStats(
   network: string,
   startBlock: number,
   endBlock: number
-): Promise<void> {
-  const stepDelay = process.env.JEST_WORKER_ID ? 0 : 300;
-  await new Promise((resolve) => setTimeout(resolve, stepDelay));
-  console.log(`Processed ${network} blocks ${startBlock}-${endBlock}`);
+): BlockchainSyncStats {
+  return {
+    network,
+    startBlock,
+    endBlock,
+    blocksProcessed: 0,
+    eventsIngested: 0,
+    duplicatesSkipped: 0,
+    lastSyncedBlock: startBlock - 1,
+  };
+}
+
+/**
+ * Normalize an RPC failure into an Error suitable for failing the job.
+ * Circuit-open errors pass through unchanged so callers can detect them.
+ */
+function asRpcError(operation: string, error: unknown): Error {
+  if (error instanceof CircuitOpenError) {
+    return error;
+  }
+  const reason = error instanceof Error ? error.message : 'unknown RPC error';
+  return new Error(`Soroban RPC ${operation} failed: ${reason}`);
 }

--- a/src/services/soroban/SorobanRpcService.ts
+++ b/src/services/soroban/SorobanRpcService.ts
@@ -46,6 +46,43 @@ export class SorobanRpcService {
   }
 
   /**
+   * Fetches the most recent ledger known to the RPC server.
+   *
+   * Used by sync workers to discover the chain head so they only scan up to a
+   * real, settled ledger instead of an arbitrary upper bound.
+   *
+   * @returns The latest ledger metadata (id, sequence, protocol version).
+   */
+  public async getLatestLedger(): Promise<rpc.Api.GetLatestLedgerResponse> {
+    try {
+      return await this.server.getLatestLedger();
+    } catch (error) {
+      console.error('Error fetching latest ledger:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Queries contract events from the network for a given filter/ledger window.
+   *
+   * Thin pass-through to the underlying RPC `getEvents` call. Pagination is left
+   * to the caller via the returned `cursor` so large windows can be streamed.
+   *
+   * @param request - Event filters plus the ledger/cursor window to scan.
+   * @returns A page of decoded events together with the paging cursor.
+   */
+  public async getEvents(
+    request: rpc.Server.GetEventsRequest
+  ): Promise<rpc.Api.GetEventsResponse> {
+    try {
+      return await this.server.getEvents(request);
+    } catch (error) {
+      console.error('Error fetching contract events:', error);
+      throw error;
+    }
+  }
+
+  /**
    * Simulates a given transaction on the Soroban network to calculate fees and resource usage.
    *
    * @param transaction - The unsigned or signed transaction to be simulated.

--- a/src/services/soroban/__tests__/SorobanRpcService.test.ts
+++ b/src/services/soroban/__tests__/SorobanRpcService.test.ts
@@ -6,6 +6,8 @@ const mockGetLedgerEntries = jest.fn();
 const mockSimulateTransaction = jest.fn();
 const mockSendTransaction = jest.fn();
 const mockGetTransaction = jest.fn();
+const mockGetEvents = jest.fn();
+const mockGetLatestLedger = jest.fn();
 
 jest.mock('@stellar/stellar-sdk', () => {
   const actualStellarSdk = jest.requireActual('@stellar/stellar-sdk');
@@ -19,6 +21,8 @@ jest.mock('@stellar/stellar-sdk', () => {
           simulateTransaction: mockSimulateTransaction,
           sendTransaction: mockSendTransaction,
           getTransaction: mockGetTransaction,
+          getEvents: mockGetEvents,
+          getLatestLedger: mockGetLatestLedger,
         };
       }),
     },
@@ -67,6 +71,40 @@ describe('SorobanRpcService', () => {
       const key = StellarSdk.xdr.ScVal.scvSymbol('Test');
 
       await expect(service.getContractData(contractId, key)).rejects.toThrow('Network Error');
+    });
+  });
+
+  describe('getLatestLedger', () => {
+    it('should return the latest ledger info', async () => {
+      const mockResponse = { id: 'ledger', sequence: 1234, protocolVersion: '22' };
+      mockGetLatestLedger.mockResolvedValue(mockResponse);
+
+      const result = await service.getLatestLedger();
+      expect(result).toEqual(mockResponse);
+      expect(mockGetLatestLedger).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw if the RPC call fails', async () => {
+      mockGetLatestLedger.mockRejectedValue(new Error('Ledger Error'));
+      await expect(service.getLatestLedger()).rejects.toThrow('Ledger Error');
+    });
+  });
+
+  describe('getEvents', () => {
+    it('should return events for the given request', async () => {
+      const mockResponse = { latestLedger: 10, events: [], cursor: '' };
+      mockGetEvents.mockResolvedValue(mockResponse);
+
+      const request = { filters: [{ type: 'contract' as const }], startLedger: 1 };
+      const result = await service.getEvents(request);
+      expect(result).toEqual(mockResponse);
+      expect(mockGetEvents).toHaveBeenCalledWith(request);
+    });
+
+    it('should throw if the RPC call fails', async () => {
+      mockGetEvents.mockRejectedValue(new Error('Events Error'));
+      const request = { filters: [{ type: 'contract' as const }], startLedger: 1 };
+      await expect(service.getEvents(request)).rejects.toThrow('Events Error');
     });
   });
 


### PR DESCRIPTION
## Summary

`processBlockchainSync` previously iterated a block range and called a `processBatch` helper that only `console.log`'d after an artificial delay — the job reported success while **no blockchain data was ever synced**. This PR replaces that stub with real Soroban RPC ingestion, persists events idempotently through the existing indexer, guards every RPC call with the circuit breaker, checkpoints progress for resumable sync, and applies the SSRF guard to the configured RPC URL.

The processor is now built around an injectable dependency set so it can be unit-tested without touching the network, while production calls fall back to the real Soroban stack:

```ts
processBlockchainSync(payload, deps = resolveDefaultDeps())
//                              └─ rpcSource: SorobanRpcService, indexer,
//                                 breaker, cursors, dedupeKeys, rpcUrl, contractId
```

Core flow:

```text
validate(network, range) → SSRF guard on rpcUrl
start = payload.startBlock ?? (cursor.lastSequence + 1) ?? 0
end   = payload.endBlock   ?? breaker(getLatestLedger).sequence
for each batch in [start..end]:
    events = breaker(getEvents({ filters, startLedger | cursor }))   // paginated, window-clamped
    for each event:
        key = buildEventKey(contractId, eventId, ledger)
        if dedupeKeys.has(key): duplicatesSkipped++          // idempotent replay
        else: indexer.processEvent(...) ; dedupeKeys.add(key)
    cursors.updateCursor(sourceId, batchEnd)                 // checkpoint per batch
```

RPC failures (including an open circuit) are **thrown** rather than swallowed, so the queue retries the job instead of reporting a false success. An open breaker short-circuits before any network call.

Two thin pass-through methods (`getLatestLedger`, `getEvents`) were added to `SorobanRpcService` to expose the RPC surface the worker needs.

## Changes

- Replaced the mock batch helper with real ledger/event ingestion from the Soroban RPC layer.
- Persist each event idempotently using the shared dedupe key (`contractId:eventId:ledger`); replayed/retried batches are skipped rather than re-written.
- Wrapped all RPC calls in the existing circuit breaker and made RPC/timeout errors fail the job so it retries.
- Added cursor-based checkpointing so a restarted job resumes from the last synced ledger instead of re-scanning from zero.
- Applied the SSRF guard to the configured RPC URL before any egress; unsafe/private URLs are rejected.
- Resolve the chain head via the latest ledger when no end block is supplied, and return early when there is nothing new to sync.
- Classify events by topic into the indexer taxonomy while preserving raw topics/value in the persisted payload.
- Exposed `getLatestLedger` and `getEvents` on the Soroban RPC service.
- Documented the Blockchain Sync job (behaviour, payload, configuration) in the README and added TSDoc throughout the ingestion path.

## Testing

- `npm run lint` — passes with **zero errors** (only pre-existing warnings in unrelated files).
- `npm test` on the impacted suites — **40 passing** (`blockchain-processor` + `SorobanRpcService`).
- Coverage for `blockchain-processor.ts`: **99.1% statements / 99.1% lines / 100% functions** (single uncovered line is a defensive XDR-decode `catch`).

Edge cases covered by the new tests:

- **Empty range** — returns early, makes no `getEvents` calls.
- **RPC timeout / error** — `getEvents` and `getLatestLedger` failures throw and fail the job for retry.
- **Breaker open** — job fails with `CircuitOpenError` and performs no RPC call.
- **Duplicate batch replay** — re-running the same batch ingests zero new events and never double-writes.
- **Resume** — a stored cursor makes the job start from `lastSequence + 1`; checkpoints are written per batch.
- Plus: idempotency within a single batch, contract-id RPC filtering, paging-cursor traversal with window clamping, multi-batch scans, real XDR topic/value/Contract-id decoding, and SSRF rejection.

> Note: the full `npm run test:ci` run also includes several **pre-existing failures in unrelated suites** (`shutdown`, `redact`, `requestLimits`, `webhook.service`, `contracts.controller`, `contractMetadata`). These fail identically on the base branch with this branch's changes stashed and are out of scope for this issue.

Closes #363 