### PR TITLE
Harden/compliance audit secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ DEBUG=true
 
 # Security
 JWT_SECRET=your-secret-key-at-least-8-chars-long
+COMPLIANCE_AUDIT_SECRET=your-compliance-secret-key
 
 # Admin API Authentication
 # Optional API key for admin endpoints (DLQ, deploy).

--- a/docs/backend/environment-variables.md
+++ b/docs/backend/environment-variables.md
@@ -237,9 +237,8 @@ Defined in: `src/retention/audit.ts`
 
 | Variable                  | Required             | Default                                  | Description                                                                                                                       |
 | ------------------------- | -------------------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `COMPLIANCE_AUDIT_SECRET` | **Yes (production)** | `talenttrust-compliance-secret-key-2024` | HMAC-SHA256 key used to sign compliance audit exports. **The default is hardcoded and insecure — always override in production.** |
+| `COMPLIANCE_AUDIT_SECRET` | **Yes**              | _(none)_                  | HMAC-SHA256 key used to sign compliance audit exports. **Must be at least 32 characters. There is no fallback.** |
 
-> **Warning:** This variable is missing from `.env.example`. Add it before deploying to any non-development environment.
 
 ---
 
@@ -387,7 +386,6 @@ TRUST_PROXY=true                           # if behind a load balancer
 
 | Issue                                                                                | Recommendation                                                          |
 | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
-| `COMPLIANCE_AUDIT_SECRET` has a hardcoded insecure default                           | Add to `.env.example` and enforce via `REQUIRED_ENV_VARS` in production |
 | `ALLOWED_ORIGINS` and `CORS_ORIGINS` serve the same purpose in two different modules | Consolidate to a single variable in a future refactor                   |
 | `SOROBAN_RPC_URL` has different defaults in `env.schema.ts` vs `sorobanEnv.ts`       | Set `SOROBAN_RPC_URL` explicitly in all environments to avoid ambiguity |
 | `METRICS_AUTH_TOKEN` is optional but the `/metrics` endpoint is open without it      | Enforce this variable via `REQUIRED_ENV_VARS` in staging and production |

--- a/src/config/env.schema.ts
+++ b/src/config/env.schema.ts
@@ -43,7 +43,10 @@ export const envSchema = z.object({
 
   // Secrets
   JWT_SECRET: z.string().min(8, "JWT_SECRET must be at least 8 characters").optional(),
-
+  // Compliance audit HMAC secret – required for proof generation.
+  COMPLIANCE_AUDIT_SECRET: z.string()
+    .min(32, "COMPLIANCE_AUDIT_SECRET must be at least 32 characters")
+    .nonempty("COMPLIANCE_AUDIT_SECRET cannot be empty"),
   // Admin API Key Configuration
   ADMIN_API_KEY: z.string().optional(),
   ADMIN_API_KEY_SCOPES: z.string()

--- a/src/config/env.test.ts
+++ b/src/config/env.test.ts
@@ -1,0 +1,24 @@
+import { validateEnv } from './env.schema';
+
+describe('Environment validation', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('should throw when COMPLIANCE_AUDIT_SECRET is missing', () => {
+    delete process.env.COMPLIANCE_AUDIT_SECRET;
+    expect(() => validateEnv()).toThrow(/COMPLIANCE_AUDIT_SECRET/);
+  });
+
+  it('should pass when COMPLIANCE_AUDIT_SECRET is provided', () => {
+    process.env.COMPLIANCE_AUDIT_SECRET = 'a'.repeat(32);
+    expect(() => validateEnv()).not.toThrow();
+  });
+});

--- a/src/config/ssrf.integration.test.ts
+++ b/src/config/ssrf.integration.test.ts
@@ -1,9 +1,12 @@
 import { envSchema } from './env.schema';
 
 describe('envSchema SSRF Protection', () => {
+  const dummySecret = 'a'.repeat(32);
+
   it('should reject private URLs in API_BASE_URL', () => {
     const result = envSchema.safeParse({
-      API_BASE_URL: 'http://localhost:3000'
+      API_BASE_URL: 'http://localhost:3000',
+      COMPLIANCE_AUDIT_SECRET: dummySecret
     });
     expect(result.success).toBe(false);
     if (!result.success) {
@@ -13,7 +16,8 @@ describe('envSchema SSRF Protection', () => {
 
   it('should reject private URLs in STELLAR_HORIZON_URL', () => {
     const result = envSchema.safeParse({
-      STELLAR_HORIZON_URL: 'http://127.0.0.1:8000'
+      STELLAR_HORIZON_URL: 'http://127.0.0.1:8000',
+      COMPLIANCE_AUDIT_SECRET: dummySecret
     });
     expect(result.success).toBe(false);
     if (!result.success) {
@@ -23,7 +27,8 @@ describe('envSchema SSRF Protection', () => {
 
   it('should reject private URLs in STELLAR_RPC_URL', () => {
     const result = envSchema.safeParse({
-      STELLAR_RPC_URL: 'http://169.254.169.254/latest/meta-data/'
+      STELLAR_RPC_URL: 'http://169.254.169.254/latest/meta-data/',
+      COMPLIANCE_AUDIT_SECRET: dummySecret
     });
     expect(result.success).toBe(false);
     if (!result.success) {
@@ -36,8 +41,10 @@ describe('envSchema SSRF Protection', () => {
       API_BASE_URL: 'https://api.talenttrust.io',
       STELLAR_HORIZON_URL: 'https://horizon-testnet.stellar.org',
       SOROBAN_RPC_URL: 'https://soroban-testnet.stellar.org',
-      STELLAR_RPC_URL: 'https://rpc-testnet.stellar.org'
+      STELLAR_RPC_URL: 'https://rpc-testnet.stellar.org',
+      COMPLIANCE_AUDIT_SECRET: dummySecret
     });
     expect(result.success).toBe(true);
   });
 });
+

--- a/src/retention/audit.ts
+++ b/src/retention/audit.ts
@@ -104,7 +104,8 @@ export class ComplianceAuditLogger {
     });
 
     // In production, use a secure key from environment variables
-    const secret = process.env.COMPLIANCE_AUDIT_SECRET || 'talenttrust-compliance-secret-key-2024';
+    const secret = process.env.COMPLIANCE_AUDIT_SECRET;
+    if (!secret) { throw new Error('COMPLIANCE_AUDIT_SECRET is required'); }
     
     return crypto
       .createHmac('sha256', secret)

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -45,3 +45,5 @@ jest.mock('ioredis', () => ({
 process.env.NODE_ENV = 'test';
 process.env.REDIS_HOST = 'localhost';
 process.env.REDIS_PORT = '6379';
+process.env.COMPLIANCE_AUDIT_SECRET = 'a'.repeat(32);
+


### PR DESCRIPTION
this pr closes #360 Removed insecure fallback HMAC secret** from `src/retention/audit.ts`. The function now **fails fast** when `process.env.COMPLIANCE_AUDIT_SECRET` is missing, aligning with the existing `validateEnv()` behavior.
- **Added strict environment validation**:
  - Updated `src/config/env.schema.ts` to require `COMPLIANCE_AUDIT_SECRET` (minimum 32 characters) via Zod.
  - Added unit tests (`src/config/env.test.ts`) to verify the validation behavior.
- **Documentation updates**:
  - Added `COMPLIANCE_AUDIT_SECRET` placeholder to `.env.example`.
  - Ensured the environment‑variables docs reflect the new requirement.
- **Git operations**
  - Created branch `docs/database-27-migrations`.
  - Committed changes with message:  
    `harden: remove hardcoded fallback HMAC secret for compliance audit proofs and enforce COMPLIANCE_AUDIT_SECRET env var`
  - Set the branch as upstream and pushed to remote.
#### Why this change matters
- The previous hard‑coded secret (`talenttrust‑compliance‑secret‑key‑2024`) made audit proofs trivially forgeable.
- Enforcing the presence of a securely‑managed secret restores tamper‑evidence for delete/archive operations and brings the codebase in line with security best practices.
#### Checklist
- [x] Code changes committed and pushed.
- [x] Tests added for environment validation.
- [x] Documentation updated.
- [x] Branch set as upstream.  