### PR TITLE
feat: add max total poll-duration ceiling to TransactionPoller

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,16 @@ For more information, see the [Secrets Handling Documentation](docs/backend/secr
 MIT
 
 ## -------------- Utilities  ------------
+
+## Transaction Poller
+
+The `TransactionPoller` service manages blockchain transaction confirmations using an exponential backoff strategy.
+
+### Features
+- **Configurable Retries**: Set `maxRetries` to limit the number of backoff polling attempts.
+- **Duration Ceiling**: An absolute wall-clock duration limit (`maxTotalDurationMs`) can be set as a circuit breaker. If the transaction takes longer than this ceiling, polling is halted and the transaction transitions to `TIMEOUT`. This acts as an absolute guard and takes precedence over `maxRetries` if reached first.
+- **Idempotent Polling**: Safely restarts after an app crash without duplicating tracking logic.
+
 ## Retry & Backoff Utilities
 
 Reusable retry policies for handling transient failures, located in `src/utils/retry.ts`.

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -200,6 +200,21 @@ MIGRATIONS.push({
   },
 });
 
+// Version 8: add started_at to transactions table
+MIGRATIONS.push({
+  version: 8,
+  name: "add_started_at_to_transactions",
+  up: (db) => {
+    // Check if the column already exists to prevent errors during repeated migrations
+    const columns = db.pragma("table_info(transactions)") as Array<{ name: string }>;
+    const hasStartedAt = columns.some((column) => column.name === "started_at");
+
+    if (!hasStartedAt) {
+      db.exec("ALTER TABLE transactions ADD COLUMN started_at TEXT");
+    }
+  },
+});
+
 function ensureMigrationTable(db: Database.Database): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS schema_version (

--- a/src/models/Transaction.ts
+++ b/src/models/Transaction.ts
@@ -19,6 +19,7 @@ export interface Transaction {
   receipt?: any;
   lastCheckedAt?: Date;
   retryCount: number;
+  startedAt?: Date;
 }
 
 interface TransactionsDbInterface {
@@ -42,24 +43,27 @@ export const transactionsDb: TransactionsDbInterface = {
       receipt: row.receipt ? JSON.parse(row.receipt) : undefined,
       lastCheckedAt: row.last_checked_at ? new Date(row.last_checked_at) : undefined,
       retryCount: row.retry_count,
+      startedAt: row.started_at ? new Date(row.started_at) : undefined,
     };
   },
 
   set(hash: string, tx: Transaction): typeof transactionsDb {
     getDb().prepare(`
-      INSERT INTO transactions (hash, status, receipt, last_checked_at, retry_count)
-      VALUES (?, ?, ?, ?, ?)
+      INSERT INTO transactions (hash, status, receipt, last_checked_at, retry_count, started_at)
+      VALUES (?, ?, ?, ?, ?, ?)
       ON CONFLICT(hash) DO UPDATE SET
         status = excluded.status,
         receipt = excluded.receipt,
         last_checked_at = excluded.last_checked_at,
-        retry_count = excluded.retry_count
+        retry_count = excluded.retry_count,
+        started_at = excluded.started_at
     `).run(
       tx.hash,
       tx.status,
       tx.receipt ? JSON.stringify(tx.receipt) : null,
       tx.lastCheckedAt ? tx.lastCheckedAt.toISOString() : null,
-      tx.retryCount
+      tx.retryCount,
+      tx.startedAt ? tx.startedAt.toISOString() : null
     );
     return this;
   },
@@ -81,6 +85,7 @@ export const transactionsDb: TransactionsDbInterface = {
       receipt: row.receipt ? JSON.parse(row.receipt) : undefined,
       lastCheckedAt: row.last_checked_at ? new Date(row.last_checked_at) : undefined,
       retryCount: row.retry_count,
+      startedAt: row.started_at ? new Date(row.started_at) : undefined,
     }));
     return mapped.values();
   }

--- a/src/services/TransactionPoller.test.ts
+++ b/src/services/TransactionPoller.test.ts
@@ -422,4 +422,83 @@ describe('TransactionPoller', () => {
       errorSpy.mockRestore();
     });
   });
+
+  describe('duration ceiling (maxTotalDurationMs)', () => {
+    it('throws an error if ceiling is set to an invalid value (<= 0, NaN, Infinity)', () => {
+      expect(() => new TransactionPoller(mockProvider, maxRetries, initialDelay, 0)).toThrow('maxTotalDurationMs must be a positive finite number');
+      expect(() => new TransactionPoller(mockProvider, maxRetries, initialDelay, -50)).toThrow('maxTotalDurationMs must be a positive finite number');
+      expect(() => new TransactionPoller(mockProvider, maxRetries, initialDelay, NaN)).toThrow('maxTotalDurationMs must be a positive finite number');
+      expect(() => new TransactionPoller(mockProvider, maxRetries, initialDelay, Infinity)).toThrow('maxTotalDurationMs must be a positive finite number');
+    });
+
+    it('transitions to TIMEOUT immediately if ceiling is reached before max retries', async () => {
+      const txHash = '0xceiling-timeout';
+      // Poller with a strict 200ms ceiling.
+      const ceilingPoller = new TransactionPoller(mockProvider, maxRetries, initialDelay, 200);
+      mockProvider.getTransactionReceipt.mockResolvedValue(null);
+
+      const pollPromise = ceilingPoller.poll(txHash);
+      
+      await flushMicrotasks();
+      expect(transactionsDb.get(txHash)?.retryCount).toBe(1);
+
+      // Advance by 200ms, which hits the ceiling exactly
+      await advanceTimersAndFlush(200);
+
+      const stored = transactionsDb.get(txHash);
+      // Even though retryCount is 1 (maxRetries is 3), we hit the ceiling
+      expect(stored?.status).toBe(TransactionStatus.TIMEOUT);
+      expect(mockProvider.getTransactionReceipt).toHaveBeenCalledTimes(1);
+
+      await pollPromise;
+    });
+
+    it('transitions to TIMEOUT before the first retry if the initial delay itself exceeds the ceiling', async () => {
+      const txHash = '0xceiling-before-first-retry';
+      // Poller with a ceiling of 50ms, while initialDelay is 100ms.
+      const ceilingPoller = new TransactionPoller(mockProvider, maxRetries, 100, 50);
+      mockProvider.getTransactionReceipt.mockResolvedValue(null);
+
+      const pollPromise = ceilingPoller.poll(txHash);
+      
+      await flushMicrotasks();
+      // Initially, retryCount is 1 because of the first inline attempt.
+      expect(transactionsDb.get(txHash)?.retryCount).toBe(1);
+
+      // The first delay scheduled will be 100 * 0.75 = 75ms.
+      // So let's advance time by 75ms to wake it up.
+      await advanceTimersAndFlush(75);
+
+      const stored = transactionsDb.get(txHash);
+      // On waking up at 75ms, elapsed time is 75 >= 50, so it immediately times out
+      // without incrementing retryCount or calling the provider again.
+      expect(stored?.status).toBe(TransactionStatus.TIMEOUT);
+      expect(stored?.retryCount).toBe(1);
+      expect(mockProvider.getTransactionReceipt).toHaveBeenCalledTimes(1);
+
+      await pollPromise;
+    });
+
+    it('does not transition to TIMEOUT if transaction completes before ceiling', async () => {
+      const txHash = '0xceiling-success';
+      const ceilingPoller = new TransactionPoller(mockProvider, maxRetries, initialDelay, 200);
+      
+      mockProvider.getTransactionReceipt
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({ status: 1, transactionHash: txHash });
+
+      const pollPromise = ceilingPoller.poll(txHash);
+      
+      await flushMicrotasks();
+      expect(transactionsDb.get(txHash)?.retryCount).toBe(1);
+
+      // Advance by less than the ceiling (e.g., 100ms)
+      await advanceTimersAndFlush(100);
+
+      const stored = transactionsDb.get(txHash);
+      expect(stored?.status).toBe(TransactionStatus.SUCCESS);
+      
+      await pollPromise;
+    });
+  });
 });

--- a/src/services/TransactionPoller.ts
+++ b/src/services/TransactionPoller.ts
@@ -8,6 +8,14 @@ export interface IBlockchainProvider {
   getTransactionReceipt(hash: string): Promise<any>;
 }
 
+export interface IClock {
+  now(): number;
+}
+
+export const SystemClock: IClock = {
+  now: () => Date.now(),
+};
+
 /**
  * Monitors blockchain transaction status using an exponential backoff strategy.
  * Designed to ensure eventual consistency and respect RPC rate limits during peak network congestion.
@@ -16,16 +24,34 @@ export class TransactionPoller {
   private readonly provider: IBlockchainProvider;
   private readonly maxRetries: number;
   private readonly initialDelay: number;
+  private readonly maxTotalDurationMs?: number;
+  private readonly clock: IClock;
 
   /**
    * @param provider The blockchain provider instance.
    * @param maxRetries Maximum polling attempts before timeout (default: 5).
    * @param initialDelay Starting interval in milliseconds for backoff (default: 1000ms).
+   * @param maxTotalDurationMs Optional absolute maximum duration in milliseconds before timing out.
+   *                           If provided, acts as an additional guard alongside maxRetries;
+   *                           whichever threshold is reached first will trigger a TIMEOUT.
+   * @param clock Optional injectable clock for testing (default: SystemClock).
    */
-  constructor(provider: IBlockchainProvider, maxRetries: number = 5, initialDelay: number = 1000) {
+  constructor(
+    provider: IBlockchainProvider,
+    maxRetries: number = 5,
+    initialDelay: number = 1000,
+    maxTotalDurationMs?: number,
+    clock: IClock = SystemClock
+  ) {
+    if (maxTotalDurationMs !== undefined && (isNaN(maxTotalDurationMs) || maxTotalDurationMs <= 0 || maxTotalDurationMs === Infinity)) {
+      throw new Error('maxTotalDurationMs must be a positive finite number to prevent silently disabling timeouts');
+    }
+    
     this.provider = provider;
     this.maxRetries = maxRetries;
     this.initialDelay = initialDelay;
+    this.maxTotalDurationMs = maxTotalDurationMs;
+    this.clock = clock;
   }
 
   /**
@@ -40,7 +66,11 @@ export class TransactionPoller {
         hash: txHash,
         status: TransactionStatus.PENDING,
         retryCount: 0,
+        startedAt: new Date(this.clock.now()),
       };
+      transactionsDb.set(txHash, transaction);
+    } else if (!transaction.startedAt) {
+      transaction.startedAt = new Date(this.clock.now());
       transactionsDb.set(txHash, transaction);
     }
 
@@ -84,9 +114,20 @@ export class TransactionPoller {
     // Circuit breaker for long-running pending transactions
     if (transaction.retryCount >= this.maxRetries) {
       transaction.status = TransactionStatus.TIMEOUT;
-      transaction.lastCheckedAt = new Date();
+      transaction.lastCheckedAt = new Date(this.clock.now());
       transactionsDb.set(txHash, transaction);
       return;
+    }
+
+    // Circuit breaker for absolute duration ceiling
+    if (this.maxTotalDurationMs !== undefined && transaction.startedAt) {
+      const elapsedMs = this.clock.now() - transaction.startedAt.getTime();
+      if (elapsedMs >= this.maxTotalDurationMs) {
+        transaction.status = TransactionStatus.TIMEOUT;
+        transaction.lastCheckedAt = new Date(this.clock.now());
+        transactionsDb.set(txHash, transaction);
+        return;
+      }
     }
 
     try {
@@ -96,7 +137,7 @@ export class TransactionPoller {
         // Map common blockchain status codes (1: Success, 0: Reverted)
         transaction.status = receipt.status === 1 ? TransactionStatus.SUCCESS : TransactionStatus.FAILED;
         transaction.receipt = receipt;
-        transaction.lastCheckedAt = new Date();
+        transaction.lastCheckedAt = new Date(this.clock.now());
         transactionsDb.set(txHash, transaction);
         return;
       }
@@ -106,7 +147,7 @@ export class TransactionPoller {
     }
 
     transaction.retryCount++;
-    transaction.lastCheckedAt = new Date();
+    transaction.lastCheckedAt = new Date(this.clock.now());
     transactionsDb.set(txHash, transaction);
 
     const delay = calculateDelay(transaction.retryCount - 1, this.initialDelay, Infinity, true);


### PR DESCRIPTION
Fixes #468

## Summary
Added an absolute wall-clock duration ceiling (`maxTotalDurationMs`) to `TransactionPoller` to act as a fail-safe against unbounded exponential backoffs. This ensures that a severely degraded network cannot keep a transaction actively polling indefinitely simply because the retry delays compound aggressively.

## Changes
- **Model & DB:** Added `startedAt` field to `Transaction` and created SQLite migration (Version 8) to introduce `started_at`.
- **Poller:** Added `maxTotalDurationMs` parameter. The poller checks `elapsedMs` against this ceiling in `pollWithBackoff` and transitions to `TIMEOUT` if exceeded.
- **Testability:** Introduced an injectable `IClock` dependency to allow deterministic tests.
- **Tests:** Added comprehensive test coverage using Jest fake timers, ensuring the ceiling correctly preempts `maxRetries` when the absolute time limit is reached. Includes edge cases (e.g. ceiling reached before first retry, and invalid ceiling values).
- **Security:** Added strict constructor validation to prevent `maxTotalDurationMs` from being set to `<= 0`, `NaN`, or `Infinity`, which could silently disable timeouts.
- **Docs:** Documented the feature in `README.md` and JSDoc.