### PR TITLE
test: cover chaos policy targeting and mode-dispatch branches

### DIFF
--- a/src/chaos/chaosPolicy.test.ts
+++ b/src/chaos/chaosPolicy.test.ts
@@ -123,6 +123,16 @@ describe('ChaosPolicy', () => {
 
       expect(policy.decide('contracts')).toBe('none');
     });
+
+    it('returns none for an unknown mode, falling back to default', () => {
+      const policy = new ChaosPolicy({
+        chaosMode: 'invalid_mode' as any,
+        chaosTargets: ['contracts'],
+        chaosProbability: 1,
+      });
+
+      expect(policy.decide('contracts')).toBe('none');
+    });
   });
 
   describe('probability logic in random mode', () => {

--- a/src/chaos/chaosPolicy.ts
+++ b/src/chaos/chaosPolicy.ts
@@ -4,6 +4,14 @@ export type ChaosResult = 'none' | 'error' | 'timeout';
 
 /**
  * Decides whether to inject deterministic or probabilistic failures for a dependency call.
+ * 
+ * Decision Matrix:
+ * 1. Target match: If `chaosTargets` is empty, all dependencies match. Otherwise, matched case-insensitively. If no match, returns 'none'.
+ * 2. Mode dispatch:
+ *    - 'error': returns 'error'
+ *    - 'timeout': returns 'timeout'
+ *    - 'random': evaluates `Math.random() < chaosProbability` ? 'error' : 'none'
+ *    - default (e.g. 'off' or unknown): returns 'none'
  */
 export class ChaosPolicy {
   constructor(private readonly config: Pick<AppConfig, 'chaosMode' | 'chaosTargets' | 'chaosProbability'>) {}


### PR DESCRIPTION
Fixes #496

## Summary
Added missing branch coverage and JSDoc documentation for the `ChaosPolicy` decision logic.

## Changes
- **Tests:** Extended `src/chaos/chaosPolicy.test.ts` to explicitly cover the `default` dispatch branch by asserting that an unknown or invalid `chaosMode` safely resolves to `'none'`. (Other targeting, case-insensitivity, and probability boundary tests were already present).
- **Docs:** Added the decision matrix into the JSDoc header of `src/chaos/chaosPolicy.ts` for clarity and maintainability.
- **Security:** Verified that the decision logic strictly guarantees non-activation when dependencies are untargeted or modes are invalid.