### PR TITLE
Add configurable CORS allowlist from environment config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,9 +30,9 @@ DATABASE_URL=postgresql://localhost:5432/talenttrust
 
 # CORS Configuration
 # Comma-separated list of allowed origins for CORS requests
-# Example: ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com
+# Example: CORS_ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com
 # Note: Wildcard (*) is not allowed in production mode
-# ALLOWED_ORIGINS=http://localhost:3000,http://localhost:3001
+# CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:3001
 
 # Stellar Network
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org

--- a/README.md
+++ b/README.md
@@ -281,7 +281,39 @@ decisions and planned integrations.
 The TalentTrust Backend implements hardened HTTP response policies and origin controls.
 
 - **Security Headers**: Managed via [Helmet](https://helmetjs.github.io/) (CSP, HSTS, etc.).
-- **CORS Policy**: Configurable origin controls.
+- **CORS Policy**: Strict allowlist controlled by environment configuration.
+
+### CORS Configuration
+
+The CORS policy is driven by the `CORS_ALLOWED_ORIGINS` environment variable, a comma-separated list of allowed origins.
+
+```bash
+# Allow specific origins
+CORS_ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com
+```
+
+#### Behavior by environment
+
+| Environment | Default | Behavior |
+|---|---|---|
+| `production` | Deny-by-default (empty allowlist) | Only origins in `CORS_ALLOWED_ORIGINS` are accepted. Wildcard (`*`) and localhost origins are rejected at startup. |
+| `development` / `staging` / `test` | `http://localhost:3000,http://localhost:3001` | Localhost origins are pre-configured for convenience. Explicitly setting the variable overrides the default. |
+
+#### Security guarantees
+
+- The request `Origin` header is reflected in `Access-Control-Allow-Origin` **only** when it exists in the allowlist.
+- Arbitrary origins are never echoed back.
+- Wildcard (`*`) is never used as `Access-Control-Allow-Origin` because credentials are always enabled.
+- `Access-Control-Allow-Credentials: true` is set for all allowlisted requests.
+- Requests without an `Origin` header (server-to-server, curl, health checks) are allowed.
+
+#### Allowed methods
+
+`GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`
+
+#### Allowed headers
+
+`Content-Type`, `Authorization`
 
 For detailed information, see [Security Documentation](docs/backend/security.md).
 
@@ -355,11 +387,12 @@ This prevents polls and queue jobs from being interrupted mid-flight while prese
 All configuration is managed through `src/config/` and validated at startup using **Zod**. This ensures a fail-fast behavior with clear error messages. Copy `.env.example` to `.env` to get started. See [docs/backend/config.md](docs/backend/config.md) for full details.
 
 | Variable | Default | Description |
-|---|---|---|
+|---|---|---|---|
 | `PORT` | `3001` | HTTP port for the Express server |
 | `NODE_ENV` | `development` | Runtime environment (`development`, `staging`, `production`, `test`) |
 | `API_BASE_URL` | `http://localhost:${PORT}` | Base URL for the API |
 | `DEBUG` | `false` | Enable/disable debug logging |
+| `CORS_ALLOWED_ORIGINS` | *(see CORS Configuration)* | Comma-separated list of allowed CORS origins. In production defaults to deny-by-default; in development defaults to `http://localhost:3000`. |
 | `DATABASE_URL` | *(optional)* | Database connection string |
 | `JWT_SECRET` | *(optional)* | Secret used for JWT signing (min 8 chars) |
 | `IDEMPOTENCY_TTL_MS` | `3600000` | Idempotency key TTL in ms (default 1 hour); after expiry keys are eligible for eviction and re-submission is processed fresh |

--- a/docs/backend/config.md
+++ b/docs/backend/config.md
@@ -41,7 +41,7 @@ src/config/
 - **Numeric variables** (e.g. `PORT`) are automatically parsed and validated as integers.
 - **Enums** (e.g. `NODE_ENV`) are strictly validated against allowed values.
 - **URLs** (e.g. `STELLAR_HORIZON_URL`) must be valid URL formats.
-- **Transformation**: Comma-separated strings (e.g. `CORS_ORIGINS`) are automatically converted to arrays.
+- **Transformation**: Comma-separated strings (e.g. `CORS_ALLOWED_ORIGINS`) are automatically converted to arrays.
 - **Fail-Fast**: If validation fails, the application prints a safe error (no secret values leaked) and exits with code `1`.
 
 ### Adding a New Variable

--- a/docs/backend/deployment-guide.md
+++ b/docs/backend/deployment-guide.md
@@ -105,7 +105,7 @@ All environments require:
 - `API_BASE_URL`: API base URL
 - `DEBUG`: Enable debug logging (true/false)
 - `DATABASE_URL`: Database connection string
-- `CORS_ORIGINS`: Comma-separated list of allowed origins
+- `CORS_ALLOWED_ORIGINS`: Comma-separated list of allowed origins
 - `MAX_REQUEST_SIZE`: Maximum request body size (default: 10mb)
 
 ### Environment-Specific Requirements

--- a/docs/backend/environment-examples.md
+++ b/docs/backend/environment-examples.md
@@ -14,7 +14,7 @@ NODE_ENV=development
 PORT=3001
 API_BASE_URL=http://localhost:3001
 DEBUG=true
-CORS_ORIGINS=http://localhost:3000,http://localhost:3001
+CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:3001
 MAX_REQUEST_SIZE=10mb
 ```
 
@@ -49,7 +49,7 @@ NODE_ENV=staging
 PORT=3002
 API_BASE_URL=https://staging-api.talenttrust.example.com
 DEBUG=false
-CORS_ORIGINS=https://staging.talenttrust.example.com
+CORS_ALLOWED_ORIGINS=https://staging.talenttrust.example.com
 MAX_REQUEST_SIZE=10mb
 DATABASE_URL=postgresql://user:pass@staging-db.example.com:5432/talenttrust
 ```
@@ -93,7 +93,7 @@ NODE_ENV=production
 PORT=3000
 API_BASE_URL=https://api.talenttrust.example.com
 DEBUG=false
-CORS_ORIGINS=https://app.talenttrust.example.com,https://www.talenttrust.example.com
+CORS_ALLOWED_ORIGINS=https://app.talenttrust.example.com,https://www.talenttrust.example.com
 MAX_REQUEST_SIZE=10mb
 DATABASE_URL=postgresql://user:pass@prod-db.example.com:5432/talenttrust
 ```
@@ -299,12 +299,12 @@ API_BASE_URL=https://api.example.com
 
 ```bash
 # ❌ Invalid for production
-CORS_ORIGINS=*
-CORS_ORIGINS=http://localhost:3000
+CORS_ALLOWED_ORIGINS=*
+CORS_ALLOWED_ORIGINS=http://localhost:3000
 
 # ✅ Valid for production
-CORS_ORIGINS=https://app.example.com
-CORS_ORIGINS=https://app.example.com,https://www.example.com
+CORS_ALLOWED_ORIGINS=https://app.example.com
+CORS_ALLOWED_ORIGINS=https://app.example.com,https://www.example.com
 ```
 
 ### Issue: Production Network

--- a/docs/backend/environment-variables.md
+++ b/docs/backend/environment-variables.md
@@ -73,8 +73,7 @@ Two separate CORS variables exist — one used by the security middleware and on
 
 | Variable          | Required | Default                                        | Description                                                                                                                                                           |
 | ----------------- | -------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ALLOWED_ORIGINS` | No       | `http://localhost:3000, http://localhost:3001` | Comma-separated list of origins allowed by the CORS middleware (`src/config/security.ts`). Wildcards (`*`) and `localhost` origins are rejected in `production` mode. |
-| `CORS_ORIGINS`    | No       | `http://localhost:3000`                        | Comma-separated origins used by the Zod-validated config (`src/config/env.schema.ts`). Automatically parsed into an array.                                            |
+| `CORS_ALLOWED_ORIGINS` | No       | *(environment-dependent)*                     | Comma-separated list of allowed CORS origins. In production defaults to deny-by-default (empty); in development defaults to `http://localhost:3000`. Wildcards (`*`) and `localhost` origins are rejected in `production` mode. This is the single source of truth for CORS configuration, validated via Zod and consumed by the CORS middleware. |
 
 **Production rules enforced at startup:**
 
@@ -344,8 +343,7 @@ NODE_ENV=staging
 PORT=3002
 DEBUG=false
 API_BASE_URL=https://staging-api.talenttrust.example.com
-CORS_ORIGINS=https://staging.talenttrust.example.com
-ALLOWED_ORIGINS=https://staging.talenttrust.example.com
+CORS_ALLOWED_ORIGINS=https://staging.talenttrust.example.com
 DATABASE_URL=postgresql://user:pass@staging-db.example.com:5432/talenttrust
 JWT_SECRET=<strong-random-secret>
 REDIS_HOST=<redis-host>
@@ -364,8 +362,7 @@ NODE_ENV=production
 PORT=3000
 DEBUG=false
 API_BASE_URL=https://api.talenttrust.example.com
-CORS_ORIGINS=https://app.talenttrust.example.com
-ALLOWED_ORIGINS=https://app.talenttrust.example.com
+CORS_ALLOWED_ORIGINS=https://app.talenttrust.example.com
 DATABASE_URL=postgresql://user:pass@prod-db.example.com:5432/talenttrust
 JWT_SECRET=<strong-random-secret>          # ⚠️ Required
 REDIS_HOST=<redis-host>
@@ -386,7 +383,7 @@ TRUST_PROXY=true                           # if behind a load balancer
 
 | Issue                                                                                | Recommendation                                                          |
 | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
-| `ALLOWED_ORIGINS` and `CORS_ORIGINS` serve the same purpose in two different modules | Consolidate to a single variable in a future refactor                   |
+| N/A (consolidated)                                                                  | `CORS_ALLOWED_ORIGINS` is now the single validated variable for CORS    |
 | `SOROBAN_RPC_URL` has different defaults in `env.schema.ts` vs `sorobanEnv.ts`       | Set `SOROBAN_RPC_URL` explicitly in all environments to avoid ambiguity |
 | `METRICS_AUTH_TOKEN` is optional but the `/metrics` endpoint is open without it      | Enforce this variable via `REQUIRED_ENV_VARS` in staging and production |
 | Redis password is not registered in `SecretsManager`                                 | Register it for centralised rotation support                            |

--- a/docs/backend/quick-reference.md
+++ b/docs/backend/quick-reference.md
@@ -60,7 +60,7 @@ npm test -- --coverage --coverageReporters=text-summary
 - `API_BASE_URL` - API base URL
 - `DEBUG` - Enable debug logging (true/false)
 - `DATABASE_URL` - Database connection string
-- `CORS_ORIGINS` - Comma-separated allowed origins
+- `CORS_ALLOWED_ORIGINS` - Comma-separated allowed origins
 - `MAX_REQUEST_SIZE` - Max request body size (default: 10mb)
 
 ## Promotion Paths

--- a/docs/backend/security.md
+++ b/docs/backend/security.md
@@ -31,9 +31,9 @@ Cross-Origin Resource Sharing is restricted to authorized origins to prevent una
 - **Allowed Origins**: 
   - `http://localhost:3000` (Default Development)
   - `http://localhost:3001` (Default Development)
-  - Configurable via `ALLOWED_ORIGINS` environment variable (comma-separated list).
-  - **Production Restriction**: Wildcard origin (`*`) is strictly denied in production mode (`NODE_ENV=production`)
-- **Allowed Methods**: `GET`, `POST`, `PUT`, `DELETE`, `OPTIONS`, `PATCH`.
+   - Configurable via `CORS_ALLOWED_ORIGINS` environment variable (comma-separated list).
+   - **Production Restriction**: Wildcard origin (`*`) is strictly denied in production mode (`NODE_ENV=production`)
+- **Allowed Methods**: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`.
 - **Allowed Headers**: `Content-Type`, `Authorization`.
 - **Credentials**: Enabled (Allows sending cookies/authorization headers).
 - **Max Age**: 86400 seconds (24 hours cache for preflight requests).
@@ -43,7 +43,7 @@ Cross-Origin Resource Sharing is restricted to authorized origins to prevent una
 The CORS configuration is validated at application startup:
 
 1. **Wildcard Denial in Production**: If `NODE_ENV=production` and the allowlist contains `*`, the application will fail to start with error: "Wildcard CORS origin (*) is not allowed in production mode"
-2. **Empty Allowlist Prevention**: The allowlist cannot be empty. If no origins are configured, defaults to localhost origins.
+2. **Deny-by-default in Production**: If `NODE_ENV=production` and `CORS_ALLOWED_ORIGINS` is not set, the allowlist is empty and all cross-origin requests are rejected.
 3. **Origin Format Validation**: Origins that don't start with `http://` or `https://` will trigger a warning (except for wildcard `*`).
 
 ### Configuration Examples
@@ -57,19 +57,19 @@ NODE_ENV=development
 **Development with custom origins**:
 ```bash
 NODE_ENV=development
-ALLOWED_ORIGINS=http://localhost:3000,http://localhost:4200,http://127.0.0.1:3000
+CORS_ALLOWED_ORIGINS=http://localhost:3000,http://localhost:4200,http://127.0.0.1:3000
 ```
 
 **Production**:
 ```bash
 NODE_ENV=production
-ALLOWED_ORIGINS=https://app.talenttrust.com,https://admin.talenttrust.com
+CORS_ALLOWED_ORIGINS=https://app.talenttrust.com,https://admin.talenttrust.com
 ```
 
 **Invalid (will fail in production)**:
 ```bash
 NODE_ENV=production
-ALLOWED_ORIGINS=*  # ERROR: Wildcard not allowed in production
+CORS_ALLOWED_ORIGINS=*  # ERROR: Wildcard not allowed in production
 ```
 
 ## Threat Scenarios Mitigated

--- a/src/app.integration.test.ts
+++ b/src/app.integration.test.ts
@@ -213,3 +213,103 @@ describe('Correlation ID propagation integration', () => {
     }
   });
 });
+
+/**
+ * @module app.integration.test
+ * @description Integration tests for CORS allowlist enforcement.
+ *
+ * Verifies that:
+ * 1. Allowlisted origins succeed with matching ACAO header.
+ * 2. Disallowed origins get 403 without origin reflection.
+ * 3. Missing Origin header behaves normally.
+ * 4. OPTIONS preflight respects the allowlist.
+ */
+describe('CORS Policy', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv, NODE_ENV: 'test' };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  async function withApp(
+    origins: string,
+    testFn: (port: number) => Promise<void>,
+  ): Promise<void> {
+    process.env.CORS_ALLOWED_ORIGINS = origins;
+    const app = createApp();
+    const server = app.listen(0);
+    const { port } = server.address() as AddressInfo;
+    try {
+      await testFn(port);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err?: Error) => (err ? reject(err) : resolve()));
+      });
+    }
+  }
+
+  it('should allow requests from allowlisted origin and echo it in ACAO', async () => {
+    await withApp('http://localhost:3000', async (port) => {
+      const response = await fetch(`http://127.0.0.1:${port}/api/v1/contracts`, {
+        headers: { Origin: 'http://localhost:3000' },
+      });
+      expect(response.status).toBe(200);
+      expect(response.headers.get('access-control-allow-origin')).toBe('http://localhost:3000');
+    });
+  });
+
+  it('should reject requests from disallowed origin without reflection', async () => {
+    await withApp('https://allowed.example.com', async (port) => {
+      const response = await fetch(`http://127.0.0.1:${port}/api/v1/contracts`, {
+        headers: { Origin: 'https://evil.example.com' },
+      });
+      expect(response.status).toBe(403);
+      expect(response.headers.get('access-control-allow-origin')).toBeNull();
+    });
+  });
+
+  it('should allow requests with no Origin header', async () => {
+    await withApp('http://localhost:3000', async (port) => {
+      const response = await fetch(`http://127.0.0.1:${port}/api/v1/contracts`);
+      expect(response.status).toBe(200);
+    });
+  });
+
+  it('should allow OPTIONS preflight from allowlisted origin', async () => {
+    await withApp('http://localhost:3000', async (port) => {
+      const response = await fetch(
+        `http://127.0.0.1:${port}/api/v1/contracts`,
+        {
+          method: 'OPTIONS',
+          headers: {
+            Origin: 'http://localhost:3000',
+            'Access-Control-Request-Method': 'GET',
+          },
+        },
+      );
+      expect(response.status).toBe(204);
+      expect(response.headers.get('access-control-allow-origin')).toBe('http://localhost:3000');
+    });
+  });
+
+  it('should reject OPTIONS preflight from disallowed origin', async () => {
+    await withApp('https://allowed.example.com', async (port) => {
+      const response = await fetch(
+        `http://127.0.0.1:${port}/api/v1/contracts`,
+        {
+          method: 'OPTIONS',
+          headers: {
+            Origin: 'https://evil.example.com',
+            'Access-Control-Request-Method': 'GET',
+          },
+        },
+      );
+      expect(response.status).toBe(403);
+      expect(response.headers.get('access-control-allow-origin')).toBeNull();
+    });
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -56,11 +56,11 @@ export function attachTerminalHandlers(app: express.Application): void {
  */
 export function createApp(options?: AppFactoryOptions): express.Application {
   const includeTerminalHandlers = options?.includeTerminalHandlers ?? true;
-  validateEnv();
+  const env = validateEnv();
   const app = express();
 
   // ── Security Middleware ───────────────────────────────────────────────────
-  applySecurityMiddleware(app);
+  applySecurityMiddleware(app, env.CORS_ALLOWED_ORIGINS);
 
   const metricsService = new MetricsService(
     process.env['SERVICE_NAME'] ?? 'talenttrust-backend',

--- a/src/config/env.schema.ts
+++ b/src/config/env.schema.ts
@@ -34,9 +34,12 @@ export const envSchema = z.object({
 
   MAX_REQUEST_SIZE: z.string().default('10mb'),
 
-  CORS_ORIGINS: z.string()
+  CORS_ALLOWED_ORIGINS: z.string()
     .optional()
-    .transform((val) => val ? val.split(',') : ['http://localhost:3000']),
+    .transform((val) => {
+      if (val === undefined) return undefined;
+      return val.split(',').map(o => o.trim()).filter(Boolean);
+    }),
 
   // Database
   DATABASE_URL: z.string().optional(),

--- a/src/config/environment.test.ts
+++ b/src/config/environment.test.ts
@@ -114,7 +114,7 @@ describe('Environment Configuration', () => {
 
     it('should parse CORS origins from comma-separated list', () => {
       process.env.NODE_ENV = 'development';
-      process.env.CORS_ORIGINS = 'https://app1.com,https://app2.com';
+      process.env.CORS_ALLOWED_ORIGINS = 'https://app1.com,https://app2.com';
       const config = loadEnvironmentConfig();
 
       expect(config.corsOrigins).toEqual(['https://app1.com', 'https://app2.com']);
@@ -173,12 +173,12 @@ describe('Environment Configuration', () => {
       expect(() => loadEnvironmentConfig()).toThrow();
     });
 
-    it('should handle empty CORS_ORIGINS using default', () => {
+    it('should use empty array when CORS_ALLOWED_ORIGINS is set to empty string', () => {
       process.env.NODE_ENV = 'development';
-      process.env.CORS_ORIGINS = '';
+      process.env.CORS_ALLOWED_ORIGINS = '';
       const config = loadEnvironmentConfig();
 
-      expect(config.corsOrigins).toEqual(['http://localhost:3000']);
+      expect(config.corsOrigins).toEqual([]);
     });
 
     it('should handle DEBUG=false', () => {

--- a/src/config/environment.ts
+++ b/src/config/environment.ts
@@ -75,7 +75,7 @@ export function loadEnvironmentConfig(): EnvironmentConfig {
     databaseUrl: validated.DATABASE_URL,
     stellarNetwork: environment === 'production' ? 'mainnet' : 'testnet',
     maxRequestSize: validated.MAX_REQUEST_SIZE,
-    corsOrigins: validated.CORS_ORIGINS ?? ['http://localhost:3000'],
+    corsOrigins: validated.CORS_ALLOWED_ORIGINS ?? (validated.NODE_ENV === 'production' ? [] : ['http://localhost:3000']),
   };
   
   return baseConfig;

--- a/src/config/security.test.ts
+++ b/src/config/security.test.ts
@@ -20,7 +20,7 @@ describe('Security Configuration', () => {
         describe('Wildcard Origin Validation', () => {
             it('should reject wildcard origin in production mode', () => {
                 process.env.NODE_ENV = 'production';
-                process.env.ALLOWED_ORIGINS = '*';
+                process.env.CORS_ALLOWED_ORIGINS = '*';
 
                 expect(() => {
                     jest.isolateModules(() => {
@@ -31,7 +31,7 @@ describe('Security Configuration', () => {
 
             it('should accept wildcard origin in development mode', () => {
                 process.env.NODE_ENV = 'development';
-                process.env.ALLOWED_ORIGINS = '*';
+                process.env.CORS_ALLOWED_ORIGINS = '*';
 
                 expect(() => {
                     jest.isolateModules(() => {
@@ -42,7 +42,7 @@ describe('Security Configuration', () => {
 
             it('should accept wildcard origin when NODE_ENV is not set', () => {
                 delete process.env.NODE_ENV;
-                process.env.ALLOWED_ORIGINS = '*';
+                process.env.CORS_ALLOWED_ORIGINS = '*';
 
                 expect(() => {
                     jest.isolateModules(() => {
@@ -53,7 +53,7 @@ describe('Security Configuration', () => {
 
             it('should reject wildcard mixed with other origins in production', () => {
                 process.env.NODE_ENV = 'production';
-                process.env.ALLOWED_ORIGINS = 'https://example.com,*,https://other.com';
+                process.env.CORS_ALLOWED_ORIGINS = 'https://example.com,*,https://other.com';
 
                 expect(() => {
                     jest.isolateModules(() => {
@@ -65,7 +65,7 @@ describe('Security Configuration', () => {
 
         describe('Origin Parsing', () => {
             it('should parse comma-separated origins', () => {
-                process.env.ALLOWED_ORIGINS = 'https://example.com,https://other.com,http://localhost:3000';
+                process.env.CORS_ALLOWED_ORIGINS = 'https://example.com,https://other.com,http://localhost:3000';
 
                 expect(() => {
                     jest.isolateModules(() => {
@@ -75,7 +75,7 @@ describe('Security Configuration', () => {
             });
 
             it('should trim whitespace from origins', () => {
-                process.env.ALLOWED_ORIGINS = ' https://example.com , https://other.com , http://localhost:3000 ';
+                process.env.CORS_ALLOWED_ORIGINS = ' https://example.com , https://other.com , http://localhost:3000 ';
 
                 expect(() => {
                     jest.isolateModules(() => {
@@ -85,7 +85,7 @@ describe('Security Configuration', () => {
             });
 
             it('should filter out empty strings', () => {
-                process.env.ALLOWED_ORIGINS = 'https://example.com,,https://other.com,,,';
+                process.env.CORS_ALLOWED_ORIGINS = 'https://example.com,,https://other.com,,,';
 
                 expect(() => {
                     jest.isolateModules(() => {
@@ -94,8 +94,8 @@ describe('Security Configuration', () => {
                 }).not.toThrow();
             });
 
-            it('should use default origins when ALLOWED_ORIGINS is not set', () => {
-                delete process.env.ALLOWED_ORIGINS;
+            it('should use default origins when CORS_ALLOWED_ORIGINS is not set', () => {
+                delete process.env.CORS_ALLOWED_ORIGINS;
 
                 expect(() => {
                     jest.isolateModules(() => {
@@ -106,31 +106,52 @@ describe('Security Configuration', () => {
         });
 
         describe('Empty Allowlist Validation', () => {
-            it('should reject empty allowlist', () => {
-                process.env.ALLOWED_ORIGINS = '';
+            it('should warn on empty allowlist in development (not throw)', () => {
+                const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+                process.env.CORS_ALLOWED_ORIGINS = '';
 
                 expect(() => {
                     jest.isolateModules(() => {
                         require('./security');
                     });
-                }).toThrow('CORS allowlist cannot be empty');
+                }).not.toThrow();
+                expect(consoleWarnSpy).toHaveBeenCalledWith(
+                    expect.stringContaining('empty')
+                );
+                consoleWarnSpy.mockRestore();
             });
 
-            it('should reject allowlist with only whitespace', () => {
-                process.env.ALLOWED_ORIGINS = '   ,  ,  ';
+            it('should warn on allowlist with only whitespace', () => {
+                const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+                process.env.CORS_ALLOWED_ORIGINS = '   ,  ,  ';
 
                 expect(() => {
                     jest.isolateModules(() => {
                         require('./security');
                     });
-                }).toThrow('CORS allowlist cannot be empty');
+                }).not.toThrow();
+                expect(consoleWarnSpy).toHaveBeenCalledWith(
+                    expect.stringContaining('empty')
+                );
+                consoleWarnSpy.mockRestore();
+            });
+
+            it('should accept empty allowlist in production (deny-by-default)', () => {
+                process.env.NODE_ENV = 'production';
+                process.env.CORS_ALLOWED_ORIGINS = '';
+
+                expect(() => {
+                    jest.isolateModules(() => {
+                        require('./security');
+                    });
+                }).not.toThrow();
             });
         });
 
         describe('Origin Format Validation', () => {
             it('should warn about origins without http:// or https://', () => {
                 const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
-                process.env.ALLOWED_ORIGINS = 'example.com,localhost:3000';
+                process.env.CORS_ALLOWED_ORIGINS = 'example.com,localhost:3000';
 
                 jest.isolateModules(() => {
                     require('./security');
@@ -148,7 +169,7 @@ describe('Security Configuration', () => {
 
             it('should not warn about valid http:// origins', () => {
                 const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
-                process.env.ALLOWED_ORIGINS = 'http://localhost:3000,http://example.com';
+                process.env.CORS_ALLOWED_ORIGINS = 'http://localhost:3000,http://example.com';
 
                 jest.isolateModules(() => {
                     require('./security');
@@ -160,7 +181,7 @@ describe('Security Configuration', () => {
 
             it('should not warn about valid https:// origins', () => {
                 const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
-                process.env.ALLOWED_ORIGINS = 'https://example.com,https://other.com';
+                process.env.CORS_ALLOWED_ORIGINS = 'https://example.com,https://other.com';
 
                 jest.isolateModules(() => {
                     require('./security');
@@ -173,7 +194,7 @@ describe('Security Configuration', () => {
             it('should not warn about wildcard origin', () => {
                 const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
                 process.env.NODE_ENV = 'development';
-                process.env.ALLOWED_ORIGINS = '*';
+                process.env.CORS_ALLOWED_ORIGINS = '*';
 
                 jest.isolateModules(() => {
                     require('./security');
@@ -186,7 +207,7 @@ describe('Security Configuration', () => {
 
         describe('CORS Origin Callback', () => {
             it('should allow requests from allowed origins', (done) => {
-                process.env.ALLOWED_ORIGINS = 'https://example.com,https://other.com';
+                process.env.CORS_ALLOWED_ORIGINS = 'https://example.com,https://other.com';
 
                 jest.isolateModules(() => {
                     const { corsConfig: config } = require('./security');
@@ -204,7 +225,7 @@ describe('Security Configuration', () => {
             });
 
             it('should reject requests from disallowed origins', (done) => {
-                process.env.ALLOWED_ORIGINS = 'https://example.com';
+                process.env.CORS_ALLOWED_ORIGINS = 'https://example.com';
 
                 jest.isolateModules(() => {
                     const { corsConfig: config } = require('./security');
@@ -222,7 +243,7 @@ describe('Security Configuration', () => {
             });
 
             it('should allow requests with no origin header', (done) => {
-                process.env.ALLOWED_ORIGINS = 'https://example.com';
+                process.env.CORS_ALLOWED_ORIGINS = 'https://example.com';
 
                 jest.isolateModules(() => {
                     const { corsConfig: config } = require('./security');
@@ -240,7 +261,7 @@ describe('Security Configuration', () => {
             });
 
             it('should perform case-sensitive origin matching', (done) => {
-                process.env.ALLOWED_ORIGINS = 'https://example.com';
+                process.env.CORS_ALLOWED_ORIGINS = 'https://example.com';
 
                 jest.isolateModules(() => {
                     const { corsConfig: config } = require('./security');
@@ -260,7 +281,7 @@ describe('Security Configuration', () => {
 
         describe('CORS Configuration Properties', () => {
             it('should maintain allowed methods', () => {
-                expect(corsConfig.methods).toEqual(['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH']);
+                expect(corsConfig.methods).toEqual(['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS']);
             });
 
             it('should maintain allowed headers', () => {

--- a/src/config/security.ts
+++ b/src/config/security.ts
@@ -25,11 +25,6 @@ function validateCorsAllowlist(origins: string[]): void {
         throw new Error('Localhost CORS origin is not allowed in production mode');
     }
     
-    // Check for empty allowlist
-    if (origins.length === 0) {
-        throw new Error('CORS allowlist cannot be empty');
-    }
-    
     // Warn about invalid origin formats
     origins.forEach(origin => {
         if (origin !== '*' && !origin.startsWith('http://') && !origin.startsWith('https://')) {
@@ -40,18 +35,29 @@ function validateCorsAllowlist(origins: string[]): void {
 
 /**
  * @notice Parses and validates CORS allowed origins from environment
- * @dev Trims whitespace and filters empty strings
+ * @dev Production defaults to deny-by-default (empty list).
+ *      Non-production defaults to localhost origins for convenience.
  * @returns Array of validated allowed origins
  */
 function parseAllowedOrigins(): string[] {
-    // Check if ALLOWED_ORIGINS is explicitly set (even if empty)
-    const hasAllowedOrigins = 'ALLOWED_ORIGINS' in process.env;
+    const isProduction = process.env.NODE_ENV === 'production';
+    const hasAllowedOrigins = 'CORS_ALLOWED_ORIGINS' in process.env;
     
-    const origins = hasAllowedOrigins
-        ? process.env.ALLOWED_ORIGINS!.split(',').map(o => o.trim()).filter(Boolean)
-        : ['http://localhost:3000', 'http://localhost:3001'];
+    let origins: string[];
+    if (hasAllowedOrigins) {
+        const raw = process.env.CORS_ALLOWED_ORIGINS!;
+        origins = raw ? raw.split(',').map(o => o.trim()).filter(Boolean) : [];
+    } else {
+        // Production defaults to deny-by-default; development defaults to localhost
+        origins = isProduction ? [] : ['http://localhost:3000', 'http://localhost:3001'];
+    }
     
-    validateCorsAllowlist(origins);
+    if (origins.length > 0) {
+        validateCorsAllowlist(origins);
+    } else if (!isProduction) {
+        console.warn('[CORS] Allowlist is empty — all cross-origin requests from browsers will be rejected');
+    }
+    
     return origins;
 }
 
@@ -59,24 +65,35 @@ function parseAllowedOrigins(): string[] {
 const allowedOrigins = parseAllowedOrigins();
 
 /**
- * @notice CORS configuration options
- * @dev Rejects requests from origins not in the allowed pool
+ * @notice Creates a CORS configuration from an explicit allowlist.
+ * @dev Used when the validated environment config drives CORS (preferred over process.env).
+ * @param origins Array of allowed origins
  */
-export const corsConfig: CorsOptions = {
-    origin: (origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) => {
-        // Allow requests with no origin (like server-to-server or curl requests) if desired
-        // In this secure baseline, we restrict it unless it matches allowed origins.
-        if (!origin || allowedOrigins.indexOf(origin) !== -1) {
-            callback(null, true);
-        } else {
-            callback(new Error('Not allowed by CORS policy'));
-        }
-    },
-    methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PATCH'],
-    allowedHeaders: ['Content-Type', 'Authorization'],
-    credentials: true,
-    maxAge: 86400, // 24 hours
-};
+export function createCorsConfig(origins: string[]): CorsOptions {
+    if (origins.length > 0) {
+        validateCorsAllowlist(origins);
+    }
+    return {
+        origin: (origin: string | undefined, callback: (err: Error | null, allow?: boolean) => void) => {
+            if (!origin || origins.indexOf(origin) !== -1) {
+                callback(null, true);
+            } else {
+                callback(new Error('Not allowed by CORS policy'));
+            }
+        },
+        methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+        allowedHeaders: ['Content-Type', 'Authorization'],
+        credentials: true,
+        maxAge: 86400,
+    };
+}
+
+/**
+ * @notice CORS configuration options
+ * @dev Rejects requests from origins not in the allowed pool.
+ *      Never echoes arbitrary origins and never uses wildcard with credentials enabled.
+ */
+export const corsConfig: CorsOptions = createCorsConfig(allowedOrigins);
 
 /**
  * @notice Helmet configuration options

--- a/src/deployment/integration.test.ts
+++ b/src/deployment/integration.test.ts
@@ -45,7 +45,7 @@ describe('Deployment Integration Tests', () => {
       process.env.NODE_ENV = 'staging';
       process.env.PORT = '3002';
       process.env.API_BASE_URL = 'https://staging-api.example.com';
-      process.env.CORS_ORIGINS = 'https://staging.example.com';
+      process.env.CORS_ALLOWED_ORIGINS = 'https://staging.example.com';
 
       // Load and validate configuration
       const config = loadEnvironmentConfig();
@@ -61,7 +61,7 @@ describe('Deployment Integration Tests', () => {
       process.env.NODE_ENV = 'production';
       process.env.PORT = '3000';
       process.env.API_BASE_URL = 'https://api.example.com';
-      process.env.CORS_ORIGINS = 'https://app.example.com';
+      process.env.CORS_ALLOWED_ORIGINS = 'https://app.example.com';
       process.env.DEBUG = 'false';
 
       // Load and validate configuration
@@ -173,7 +173,7 @@ describe('Deployment Integration Tests', () => {
     it('should reject production config with testnet', async () => {
       process.env.NODE_ENV = 'production';
       process.env.API_BASE_URL = 'https://api.example.com';
-      process.env.CORS_ORIGINS = 'https://app.example.com';
+      process.env.CORS_ALLOWED_ORIGINS = 'https://app.example.com';
 
       const config = loadEnvironmentConfig();
       // Force testnet for testing
@@ -187,7 +187,7 @@ describe('Deployment Integration Tests', () => {
     it('should reject production config with localhost CORS', async () => {
       process.env.NODE_ENV = 'production';
       process.env.API_BASE_URL = 'https://api.example.com';
-      process.env.CORS_ORIGINS = 'http://localhost:3000';
+      process.env.CORS_ALLOWED_ORIGINS = 'http://localhost:3000';
 
       const config = loadEnvironmentConfig();
       const validation = validateDeploymentConfig(config);
@@ -199,7 +199,7 @@ describe('Deployment Integration Tests', () => {
     it('should warn about debug mode in production', async () => {
       process.env.NODE_ENV = 'production';
       process.env.API_BASE_URL = 'https://api.example.com';
-      process.env.CORS_ORIGINS = 'https://app.example.com';
+      process.env.CORS_ALLOWED_ORIGINS = 'https://app.example.com';
       process.env.DEBUG = 'true';
 
       const config = loadEnvironmentConfig();
@@ -229,7 +229,7 @@ describe('Deployment Integration Tests', () => {
 
       // Step 3: Validate staging
       process.env.NODE_ENV = 'staging';
-      process.env.CORS_ORIGINS = 'https://staging.example.com';
+      process.env.CORS_ALLOWED_ORIGINS = 'https://staging.example.com';
       const stagingConfig = loadEnvironmentConfig();
       const stagingValidation = await validateDeploymentReadiness(stagingConfig);
       expect(stagingValidation.valid).toBe(true);
@@ -246,7 +246,7 @@ describe('Deployment Integration Tests', () => {
 
       // Step 5: Validate production
       process.env.NODE_ENV = 'production';
-      process.env.CORS_ORIGINS = 'https://app.example.com';
+      process.env.CORS_ALLOWED_ORIGINS = 'https://app.example.com';
       const prodConfig = loadEnvironmentConfig();
       const prodValidation = await validateDeploymentReadiness(prodConfig);
       expect(prodValidation.valid).toBe(true);
@@ -258,7 +258,7 @@ describe('Deployment Integration Tests', () => {
       // Simulate failed production deployment
       process.env.NODE_ENV = 'production';
       process.env.API_BASE_URL = 'invalid-url';
-      process.env.CORS_ORIGINS = 'https://app.example.com';
+      process.env.CORS_ALLOWED_ORIGINS = 'https://app.example.com';
 
       // Load and validate configuration - should fail fast due to Zod validation
       expect(() => loadEnvironmentConfig()).toThrow();

--- a/src/deployment/promoter.ts
+++ b/src/deployment/promoter.ts
@@ -241,7 +241,7 @@ export async function promoteDeployment(request: PromotionRequest): Promise<Prom
 
   // Load environment config for target environment transiently to pass validation
   const originalNodeEnv = process.env.NODE_ENV;
-  const originalCorsOrigins = process.env.CORS_ORIGINS;
+  const originalCorsOrigins = process.env.CORS_ALLOWED_ORIGINS;
   const originalApiBaseUrl = process.env.API_BASE_URL;
   const originalStellarNetwork = process.env.STELLAR_NETWORK;
   
@@ -251,15 +251,15 @@ export async function promoteDeployment(request: PromotionRequest): Promise<Prom
     
     // Set realistic defaults for target environment to pass validation during promotion/tests
     if (request.to === 'production') {
-      process.env.CORS_ORIGINS = 'https://app.example.com';
+      process.env.CORS_ALLOWED_ORIGINS = 'https://app.example.com';
       process.env.API_BASE_URL = 'https://api.example.com';
       process.env.STELLAR_NETWORK = 'mainnet';
     } else if (request.to === 'staging') {
-      process.env.CORS_ORIGINS = 'https://staging.example.com';
+      process.env.CORS_ALLOWED_ORIGINS = 'https://staging.example.com';
       process.env.API_BASE_URL = 'https://staging-api.example.com';
       process.env.STELLAR_NETWORK = 'testnet';
     } else {
-      process.env.CORS_ORIGINS = 'https://dev.example.com';
+      process.env.CORS_ALLOWED_ORIGINS = 'https://dev.example.com';
       process.env.API_BASE_URL = 'https://dev-api.example.com';
       process.env.STELLAR_NETWORK = 'testnet';
     }
@@ -268,9 +268,9 @@ export async function promoteDeployment(request: PromotionRequest): Promise<Prom
   } finally {
     process.env.NODE_ENV = originalNodeEnv;
     if (originalCorsOrigins !== undefined) {
-      process.env.CORS_ORIGINS = originalCorsOrigins;
+      process.env.CORS_ALLOWED_ORIGINS = originalCorsOrigins;
     } else {
-      delete process.env.CORS_ORIGINS;
+      delete process.env.CORS_ALLOWED_ORIGINS;
     }
     if (originalApiBaseUrl !== undefined) {
       process.env.API_BASE_URL = originalApiBaseUrl;

--- a/src/middleware/security.test.ts
+++ b/src/middleware/security.test.ts
@@ -22,7 +22,7 @@ describe('Security Middleware Integration', () => {
 
     describe('CORS Middleware', () => {
         it('should allow requests from allowed origins', async () => {
-            process.env.ALLOWED_ORIGINS = 'https://example.com';
+            process.env.CORS_ALLOWED_ORIGINS = 'https://example.com';
             
             jest.isolateModules(() => {
                 const { applySecurityMiddleware: applySecurity } = require('./security');
@@ -40,7 +40,7 @@ describe('Security Middleware Integration', () => {
         });
 
         it('should reject requests from disallowed origins', async () => {
-            process.env.ALLOWED_ORIGINS = 'https://example.com';
+            process.env.CORS_ALLOWED_ORIGINS = 'https://example.com';
             
             jest.isolateModules(() => {
                 const { applySecurityMiddleware: applySecurity } = require('./security');
@@ -68,7 +68,7 @@ describe('Security Middleware Integration', () => {
         });
 
         it('should handle preflight OPTIONS requests', async () => {
-            process.env.ALLOWED_ORIGINS = 'https://example.com';
+            process.env.CORS_ALLOWED_ORIGINS = 'https://example.com';
             
             jest.isolateModules(() => {
                 const { applySecurityMiddleware: applySecurity } = require('./security');
@@ -88,7 +88,7 @@ describe('Security Middleware Integration', () => {
         });
 
         it('should include credentials in CORS response', async () => {
-            process.env.ALLOWED_ORIGINS = 'https://example.com';
+            process.env.CORS_ALLOWED_ORIGINS = 'https://example.com';
             
             jest.isolateModules(() => {
                 const { applySecurityMiddleware: applySecurity } = require('./security');
@@ -140,7 +140,7 @@ describe('Security Middleware Integration', () => {
 
     describe('Combined Security Middleware', () => {
         it('should apply both CORS and Helmet headers', async () => {
-            process.env.ALLOWED_ORIGINS = 'https://example.com';
+            process.env.CORS_ALLOWED_ORIGINS = 'https://example.com';
             
             jest.isolateModules(() => {
                 const { applySecurityMiddleware: applySecurity } = require('./security');

--- a/src/middleware/security.ts
+++ b/src/middleware/security.ts
@@ -6,14 +6,16 @@
 import { Application } from 'express';
 import helmet from 'helmet';
 import cors from 'cors';
-import { corsConfig, helmetConfig } from '../config/security';
+import { corsConfig, helmetConfig, createCorsConfig } from '../config/security';
 
 /**
  * @notice Applies security policies to the Express application
- * @dev Attaches CORS and Helmet middlewares with predefined config
+ * @dev Attaches CORS and Helmet middlewares with predefined config.
+ *      When allowedOrigins is provided, it overrides the environment-based config.
  * @param app The Express Application instance
+ * @param allowedOrigins Optional explicit list of allowed CORS origins
  */
-export function applySecurityMiddleware(app: Application): void {
+export function applySecurityMiddleware(app: Application, allowedOrigins?: string[]): void {
     app.use(helmet(helmetConfig));
-    app.use(cors(corsConfig));
+    app.use(cors(allowedOrigins ? createCorsConfig(allowedOrigins) : corsConfig));
 }


### PR DESCRIPTION
Closes #490

Summary:
Adds a strict environment-driven CORS allowlist for the Express API.

Changes:

- Added validated CORS origin configuration
- Updated Express CORS middleware to:
  - allow only configured origins
  - reject unknown origins
  - prevent arbitrary origin reflection
  - support credentials only for trusted origins

CORS configuration:

- Added explicit allowed methods
- Added explicit allowed headers
- Added secure preflight handling

Tests added:

- Allowlisted origin access
- Rejected disallowed origin
- Requests without Origin header
- OPTIONS preflight validation

Documentation:

- Added README documentation for CORS environment variables

Validation:

- npm test passes
- npm run lint passes
- No wildcard origin with credentials
- Impacted modules maintain required coverage