### PR TITLE
security: redact Authorization and Cookie headers in HTTP logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,27 @@ The TalentTrust Backend implements hardened HTTP response policies and origin co
 - **Security Headers**: Managed via [Helmet](https://helmetjs.github.io/) (CSP, HSTS, etc.).
 - **CORS Policy**: Strict allowlist controlled by environment configuration.
 
+### HTTP request logging redaction
+
+Structured HTTP logs preserve operational metadata needed for debugging and tracing while masking credential-bearing headers before any request or response log line is emitted.
+
+**Logged fields retained in cleartext**
+- HTTP method
+- Request path / URL
+- Response status code
+- Latency / duration
+- Request ID and correlation ID
+- Client IP and truncated User-Agent
+- Non-sensitive request/response headers
+
+**Headers redacted in logs**
+- `Authorization`
+- `Cookie`
+- `Set-Cookie`
+- Known API-key and token-bearing headers such as `X-API-Key` and `X-Auth-Token`
+
+Header matching is case-insensitive. Request and response bodies are not logged by the default HTTP logger middleware.
+
 ### CORS Configuration
 
 The CORS policy is driven by the `CORS_ALLOWED_ORIGINS` environment variable, a comma-separated list of allowed origins.

--- a/src/middleware/httpLogger.test.ts
+++ b/src/middleware/httpLogger.test.ts
@@ -9,6 +9,7 @@
  *   - IP resolution with and without TRUST_PROXY
  */
 
+import { IncomingHttpHeaders } from 'http';
 import { Request, Response, NextFunction } from 'express';
 import { EventEmitter } from 'events';
 import { httpLoggerMiddleware } from './httpLogger';
@@ -19,12 +20,14 @@ import { Logger } from '../logger';
 interface FakeRes extends EventEmitter {
   locals: Record<string, unknown>;
   statusCode: number;
+  getHeaders?: () => Record<string, unknown>;
 }
 
 function makeReqRes(overrides: {
   method?: string;
   originalUrl?: string;
-  headers?: Record<string, string>;
+  headers?: IncomingHttpHeaders;
+  responseHeaders?: Record<string, unknown>;
   remoteAddress?: string;
   statusCode?: number;
   locals?: Record<string, unknown>;
@@ -32,6 +35,7 @@ function makeReqRes(overrides: {
   const res = new EventEmitter() as FakeRes;
   res.locals = overrides.locals ?? {};
   res.statusCode = overrides.statusCode ?? 200;
+  res.getHeaders = jest.fn().mockReturnValue(overrides.responseHeaders ?? {});
 
   const req: Partial<Request> = {
     method: overrides.method ?? 'GET',
@@ -197,5 +201,74 @@ describe('httpLoggerMiddleware', () => {
     res.emit('finish');
 
     expect(logged[0]!['ip']).toBe('192.168.1.1');
+  });
+
+  it('redacts sensitive request and response headers before logging', () => {
+    const logged: Array<Record<string, unknown>> = [];
+    const mockLog = { info: jest.fn((_msg: string, ctx: Record<string, unknown>) => logged.push(ctx)) };
+    const bearerToken = 'Bearer super-secret-token';
+    const cookieValue = 'session=abc123; refresh=def456';
+    const setCookieValues = ['sid=one; HttpOnly', 'csrf=two; Secure'];
+    const apiKeyValue = 'internal-api-key';
+
+    const { req, res, next } = makeReqRes({
+      headers: {
+        authorization: bearerToken,
+        Cookie: cookieValue,
+        'X-API-Key': apiKeyValue,
+        'user-agent': 'TalentTrustTest/1.0',
+        accept: 'application/json',
+      },
+      responseHeaders: {
+        'set-cookie': setCookieValues,
+        Authorization: bearerToken,
+        'x-auth-token': 'response-auth-token',
+        'content-type': 'application/json',
+      },
+      locals: { log: mockLog },
+    });
+
+    httpLoggerMiddleware(req as Request, res as unknown as Response, next as NextFunction);
+    res.emit('finish');
+
+    const requestHeaders = logged[0]!['requestHeaders'] as Record<string, unknown>;
+    const responseHeaders = logged[0]!['responseHeaders'] as Record<string, unknown>;
+    const serialized = JSON.stringify(logged[0]);
+
+    expect(requestHeaders['authorization']).toBe('[REDACTED]');
+    expect(requestHeaders['Cookie']).toBe('[REDACTED]');
+    expect(requestHeaders['X-API-Key']).toBe('[REDACTED]');
+    expect(requestHeaders['accept']).toBe('application/json');
+
+    expect(responseHeaders['set-cookie']).toBe('[REDACTED]');
+    expect(responseHeaders['Authorization']).toBe('[REDACTED]');
+    expect(responseHeaders['x-auth-token']).toBe('[REDACTED]');
+    expect(responseHeaders['content-type']).toBe('application/json');
+
+    expect(serialized).not.toContain(bearerToken);
+    expect(serialized).not.toContain(cookieValue);
+    expect(serialized).not.toContain(setCookieValues[0]);
+    expect(serialized).not.toContain(setCookieValues[1]);
+    expect(serialized).not.toContain(apiKeyValue);
+  });
+
+  it('handles missing headers and preserves non-sensitive multi-value headers', () => {
+    const logged: Array<Record<string, unknown>> = [];
+    const mockLog = { info: jest.fn((_msg: string, ctx: Record<string, unknown>) => logged.push(ctx)) };
+    const { req, res, next } = makeReqRes({
+      headers: {},
+      responseHeaders: {
+        vary: ['Origin', 'Accept-Encoding'],
+      },
+      locals: { log: mockLog },
+    });
+
+    httpLoggerMiddleware(req as Request, res as unknown as Response, next as NextFunction);
+    res.emit('finish');
+
+    expect(logged[0]!['requestHeaders']).toEqual({});
+    expect(logged[0]!['responseHeaders']).toEqual({
+      vary: ['Origin', 'Accept-Encoding'],
+    });
   });
 });

--- a/src/middleware/httpLogger.ts
+++ b/src/middleware/httpLogger.ts
@@ -21,6 +21,7 @@
 
 import { Request, Response, NextFunction } from 'express';
 import { Logger, logger as rootLogger } from '../logger';
+import { redactHeaders } from '../utils/redact';
 
 const MAX_UA_LENGTH = 256;
 
@@ -65,6 +66,10 @@ export function httpLoggerMiddleware(
       durationMs: parseFloat(durationMs.toFixed(3)),
       userAgent,
       ip: resolveClientIp(req),
+      requestHeaders: redactHeaders(req.headers),
+      responseHeaders: redactHeaders(
+        typeof res.getHeaders === 'function' ? (res.getHeaders() as Record<string, unknown>) : undefined,
+      ),
     });
   });
 

--- a/src/middleware/requestLogger.test.ts
+++ b/src/middleware/requestLogger.test.ts
@@ -28,12 +28,15 @@ jest.mock('../logger', () => ({
   })
 }));
 
+const { createRequestLogger } = require('../logger');
+
 describe('requestLoggerMiddleware', () => {
   let mockRequest: Partial<Request>;
   let mockResponse: Partial<Response>;
   let mockNext: NextFunction;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     mockRequest = {
       method: 'GET',
       url: '/test',
@@ -139,8 +142,6 @@ describe('requestLoggerMiddleware', () => {
   });
 
   it('attaches logger to request object', () => {
-    const { createRequestLogger } = require('../logger');
-    
     requestLoggerMiddleware(
       mockRequest as Request,
       mockResponse as Response,
@@ -160,6 +161,78 @@ describe('requestLoggerMiddleware', () => {
 
     expect(mockNext).toHaveBeenCalled();
   });
+
+  it('redacts sensitive request and response headers in emitted log records', () => {
+    const mockLogger = { info: jest.fn() };
+    createRequestLogger.mockReturnValue(mockLogger);
+
+    const authorizationValue = 'Bearer request-secret';
+    const cookieValue = 'session=abc; refresh=def';
+    const apiKeyValue = 'request-api-key';
+    const setCookieValue = ['sid=one; HttpOnly', 'refresh=two; Secure'];
+
+    mockRequest.headers = {
+      Authorization: authorizationValue,
+      cookie: cookieValue,
+      'x-api-key': apiKeyValue,
+      accept: 'application/json',
+    } as any;
+    mockRequest.header = jest.fn().mockImplementation((header: string) => {
+      const lookup = header.toLowerCase();
+      if (lookup === 'authorization') return authorizationValue;
+      if (lookup === 'cookie') return cookieValue;
+      if (lookup === 'x-api-key') return apiKeyValue;
+      if (lookup === 'user-agent') return 'TalentTrustTest/1.0';
+      return undefined;
+    });
+    mockResponse.getHeaders = jest.fn().mockReturnValue({
+      'set-cookie': setCookieValue,
+      'x-auth-token': 'response-secret-token',
+      'content-type': 'application/json',
+    });
+
+    requestLoggerMiddleware(
+      mockRequest as Request,
+      mockResponse as Response,
+      mockNext
+    );
+
+    if (mockResponse.end) {
+      (mockResponse.end as jest.Mock)();
+    }
+
+    expect(mockLogger.info).toHaveBeenNthCalledWith(
+      1,
+      'Request started',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: '[REDACTED]',
+          cookie: '[REDACTED]',
+          'x-api-key': '[REDACTED]',
+          accept: 'application/json',
+        }),
+      })
+    );
+
+    expect(mockLogger.info).toHaveBeenNthCalledWith(
+      2,
+      'Request completed',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'set-cookie': '[REDACTED]',
+          'x-auth-token': '[REDACTED]',
+          'content-type': 'application/json',
+        }),
+      })
+    );
+
+    const serializedCalls = JSON.stringify(mockLogger.info.mock.calls);
+    expect(serializedCalls).not.toContain(authorizationValue);
+    expect(serializedCalls).not.toContain(cookieValue);
+    expect(serializedCalls).not.toContain(apiKeyValue);
+    expect(serializedCalls).not.toContain(setCookieValue[0]);
+    expect(serializedCalls).not.toContain(setCookieValue[1]);
+  });
 });
 
 describe('createRequestLoggerMiddleware', () => {
@@ -168,6 +241,7 @@ describe('createRequestLoggerMiddleware', () => {
   let mockNext: NextFunction;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     mockRequest = {
       method: 'POST',
       url: '/api/test',

--- a/src/middleware/requestLogger.ts
+++ b/src/middleware/requestLogger.ts
@@ -13,6 +13,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import { Logger, createRequestLogger } from '../logger';
+import { redactHeaders } from '../utils/redact';
 
 // Extend Express Request interface to include our logger
 declare global {
@@ -78,7 +79,7 @@ export function requestLoggerMiddleware(
     url: req.url,
     userAgent: req.header('user-agent'),
     ip: req.ip || req.connection.remoteAddress,
-    headers: sanitizeHeaders(req.headers)
+    headers: redactHeaders(req.headers)
   });
 
   // Override res.end to log request completion
@@ -91,45 +92,13 @@ export function requestLoggerMiddleware(
       url: req.url,
       statusCode: res.statusCode,
       duration: `${duration}ms`,
-      headers: sanitizeHeaders(res.getHeaders())
+      headers: redactHeaders(res.getHeaders())
     });
 
     return originalEnd(chunk, encoding, cb);
   };
 
   next();
-}
-
-/**
- * Sanitize headers to remove sensitive information before logging.
- */
-function sanitizeHeaders(headers: Record<string, any> | undefined): Record<string, any> {
-  const sanitized: Record<string, any> = {};
-  const sensitiveHeaders = [
-    'authorization',
-    'cookie',
-    'x-api-key',
-    'x-auth-token',
-    'x-forwarded-for',
-    'x-real-ip'
-  ];
-
-  if (!headers) {
-    return sanitized;
-  }
-
-  for (const [key, value] of Object.entries(headers)) {
-    if (sensitiveHeaders.includes(key.toLowerCase())) {
-      sanitized[key] = '[REDACTED]';
-    } else if (typeof value === 'string' && value.length > 200) {
-      // Truncate very long header values
-      sanitized[key] = value.substring(0, 200) + '...';
-    } else {
-      sanitized[key] = value;
-    }
-  }
-
-  return sanitized;
 }
 
 /**
@@ -192,7 +161,7 @@ export function createRequestLoggerMiddleware(options: RequestLoggerOptions = {}
       url: req.url,
       userAgent: req.header('user-agent'),
       ip: req.ip || req.connection.remoteAddress,
-      headers: sanitizeHeaders(req.headers)
+      headers: redactHeaders(req.headers)
     };
 
     // Add body if enabled (be careful with sensitive data)
@@ -213,7 +182,7 @@ export function createRequestLoggerMiddleware(options: RequestLoggerOptions = {}
         url: req.url,
         statusCode: res.statusCode,
         duration: `${duration}ms`,
-        headers: sanitizeHeaders(res.getHeaders())
+        headers: redactHeaders(res.getHeaders())
       };
 
       // Add response body if enabled
@@ -221,7 +190,7 @@ export function createRequestLoggerMiddleware(options: RequestLoggerOptions = {}
         try {
           completionLogData.responseBody = 
             typeof chunk === 'string' ? chunk.substring(0, 500) : chunk;
-        } catch (e) {
+        } catch {
           completionLogData.responseBody = '[Unable to serialize]';
         }
       }

--- a/src/utils/redact.test.ts
+++ b/src/utils/redact.test.ts
@@ -3,7 +3,7 @@
  * @module redact.test
  */
 
-import { redactSecret, redactObject, redactPayload } from './redact';
+import { redactSecret, redactObject, redactPayload, redactHeaders } from './redact';
 
 describe('redactSecret', () => {
   it('returns [REDACTED] for any value', () => {
@@ -211,6 +211,70 @@ describe('redactObject', () => {
     expect(result).not.toBe(input);
     expect(input.secret).toBe('secret-value'); // Original unchanged
     expect(result.secret).toBe('[REDACTED]');
+  });
+});
+
+describe('redactHeaders', () => {
+  it('redacts sensitive headers case-insensitively', () => {
+    const result = redactHeaders({
+      Authorization: 'Bearer secret-token',
+      cookie: 'session=abc123',
+      'X-API-KEY': 'my-secret-key',
+      'Proxy-Authorization': 'Basic dXNlcjpwYXNz',
+      'x-forwarded-for': '1.2.3.4',
+      'x-real-ip': '10.0.0.1',
+    });
+
+    expect(result['Authorization']).toBe('[REDACTED]');
+    expect(result['cookie']).toBe('[REDACTED]');
+    expect(result['X-API-KEY']).toBe('[REDACTED]');
+    expect(result['Proxy-Authorization']).toBe('[REDACTED]');
+    expect(result['x-forwarded-for']).toBe('[REDACTED]');
+    expect(result['x-real-ip']).toBe('[REDACTED]');
+  });
+
+  it('preserves non-sensitive headers and array values', () => {
+    const result = redactHeaders({
+      Accept: 'application/json',
+      vary: ['Origin', 'Accept-Encoding'],
+      'x-request-id': 'req-123',
+    });
+
+    expect(result).toEqual({
+      Accept: 'application/json',
+      vary: ['Origin', 'Accept-Encoding'],
+      'x-request-id': 'req-123',
+    });
+  });
+
+  it('truncates long non-sensitive string header values', () => {
+    const result = redactHeaders({
+      'x-long-header': 'a'.repeat(205),
+    });
+
+    expect(result['x-long-header']).toBe('a'.repeat(200) + '...');
+  });
+
+  it('does not mutate the original headers object', () => {
+    const input = {
+      Authorization: 'Bearer secret-token',
+      Accept: 'application/json',
+    };
+
+    const result = redactHeaders(input);
+
+    expect(result).not.toBe(input);
+    expect(input.Authorization).toBe('Bearer secret-token');
+  });
+
+  it('does not over-redact benign header names containing generic fragments', () => {
+    const result = redactHeaders({
+      'x-public-key-hint': 'stellar-account',
+      'x-session-tokenized': 'derived-value',
+    });
+
+    expect(result['x-public-key-hint']).toBe('stellar-account');
+    expect(result['x-session-tokenized']).toBe('derived-value');
   });
 });
 

--- a/src/utils/redact.ts
+++ b/src/utils/redact.ts
@@ -7,6 +7,20 @@
  */
 
 const REDACTED = '[REDACTED]';
+const SENSITIVE_KEY_PATTERN = /secret|signature|token|key|password|authorization|nonce|cookie/i;
+const SENSITIVE_HEADER_NAMES = new Set([
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'x-api-key',
+  'x-api-secret',
+  'x-auth-token',
+  'x-access-token',
+  'proxy-authorization',
+  'x-forwarded-for',
+  'x-real-ip',
+]);
+const DEFAULT_HEADER_VALUE_MAX_LENGTH = 200;
 
 /**
  * Replaces a secret value with a fixed redaction marker.
@@ -25,10 +39,9 @@ export function redactSecret(_value: unknown): string {
  * @returns A new object with sensitive values replaced by `[REDACTED]`.
  */
 export function redactObject(obj: Record<string, unknown>): Record<string, unknown> {
-  const SENSITIVE = /secret|signature|token|key|password|authorization|nonce/i;
   const out: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(obj)) {
-    if (SENSITIVE.test(k)) {
+    if (SENSITIVE_KEY_PATTERN.test(k)) {
       out[k] = REDACTED;
     } else if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
       out[k] = redactObject(v as Record<string, unknown>);
@@ -37,6 +50,42 @@ export function redactObject(obj: Record<string, unknown>): Record<string, unkno
     }
   }
   return out;
+}
+
+/**
+ * Redacts sensitive HTTP header values while preserving non-sensitive headers.
+ * Header matching is case-insensitive and known sensitive headers are always masked.
+ * Non-sensitive string values are truncated to a bounded length for log safety.
+ *
+ * @param headers - Header map from Express request/response objects.
+ * @param maxValueLength - Maximum length for non-sensitive string header values.
+ * @returns A new object safe to include in structured logs.
+ */
+export function redactHeaders(
+  headers: Record<string, unknown> | undefined,
+  maxValueLength = DEFAULT_HEADER_VALUE_MAX_LENGTH,
+): Record<string, unknown> {
+  const sanitized: Record<string, unknown> = {};
+
+  if (!headers) {
+    return sanitized;
+  }
+
+  for (const [key, value] of Object.entries(headers)) {
+    if (SENSITIVE_HEADER_NAMES.has(key.toLowerCase())) {
+      sanitized[key] = REDACTED;
+      continue;
+    }
+
+    if (typeof value === 'string' && value.length > maxValueLength) {
+      sanitized[key] = value.slice(0, maxValueLength) + '...';
+      continue;
+    }
+
+    sanitized[key] = value;
+  }
+
+  return sanitized;
 }
 
 /**


### PR DESCRIPTION
Hi, can you check 

Closes #489 