### PR TITLE
test(middleware): add type-safe sanitization with prototype-pollution guard

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -47,6 +47,27 @@ The TalentTrust Backend API provides RESTful endpoints for managing escrow contr
 http://localhost:3001/api/v1
 ```
 
+## Request Sanitization
+
+Incoming request data is sanitized by the `sanitize` middleware
+(`src/middleware/sanitize.ts`) before it reaches route handlers. The
+sanitization contract is:
+
+- **Scope:** `req.body`, `req.query`, and `req.params` are sanitized recursively
+  (nested objects and arrays included).
+- **Strings:** every string value is trimmed and passed through a strict XSS
+  filter that strips all HTML tags (and the body of `<script>`/`<style>`).
+- **Type preservation:** the sanitizer is generic and returns the same shape as
+  its input, so `req.query`/`req.params` retain their expected string/array
+  structures (e.g. `?tag=a&tag=b` stays an array of strings).
+- **Prototype-pollution safe:** the keys `__proto__`, `constructor`, and
+  `prototype` are dropped during recursion and the result uses a `null`
+  prototype, so a crafted payload cannot reach `Object.prototype`.
+- **Idempotent and non-mutating:** running the middleware twice yields the same
+  result, and the original input objects are copied rather than mutated.
+- **Pass-through values:** `Date` and `Buffer` instances are returned unchanged;
+  non-string primitives (numbers, booleans, `null`) are preserved as-is.
+
 ## Request Headers
 
 ### Standard Request Headers

--- a/src/middleware/sanitize.test.ts
+++ b/src/middleware/sanitize.test.ts
@@ -70,4 +70,81 @@ describe('Sanitize Middleware', () => {
     expect(mockRequest.body.createdAt).toBe(date);
     expect(mockRequest.body.fileData).toBe(buffer);
   });
+
+  it('should sanitize deeply nested objects and arrays', () => {
+    mockRequest.body = {
+      user: { bio: '  <b>hi</b>  ', tags: ['<i>a</i>', { note: '<script>x</script>z' }] },
+    };
+
+    sanitize(mockRequest as Request, mockResponse as Response, nextFunction);
+
+    expect(mockRequest.body.user.bio).toBe('hi');
+    expect(mockRequest.body.user.tags[0]).toBe('a');
+    expect(mockRequest.body.user.tags[1].note).toBe('z');
+  });
+
+  it('should reject prototype-pollution keys without polluting Object.prototype', () => {
+    mockRequest.body = JSON.parse('{"__proto__": {"polluted": true}, "safe": "ok"}');
+
+    sanitize(mockRequest as Request, mockResponse as Response, nextFunction);
+
+    expect(mockRequest.body.safe).toBe('ok');
+    expect(Object.prototype.hasOwnProperty.call(mockRequest.body, '__proto__')).toBe(false);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it('should drop constructor and prototype keys during recursion', () => {
+    mockRequest.body = {
+      nested: JSON.parse('{"constructor": "bad", "prototype": "bad", "keep": "good"}'),
+    };
+
+    sanitize(mockRequest as Request, mockResponse as Response, nextFunction);
+
+    expect(mockRequest.body.nested.keep).toBe('good');
+    expect(Object.prototype.hasOwnProperty.call(mockRequest.body.nested, 'constructor')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(mockRequest.body.nested, 'prototype')).toBe(false);
+  });
+
+  it('should be idempotent: running twice yields the same result', () => {
+    mockRequest.body = { msg: '<script>alert(1)</script>clean', list: ['<b>x</b>'] };
+
+    sanitize(mockRequest as Request, mockResponse as Response, nextFunction);
+    const afterOnce = JSON.parse(JSON.stringify(mockRequest.body));
+
+    const second: Partial<Request> = { body: afterOnce };
+    sanitize(second as Request, mockResponse as Response, nextFunction);
+    expect(second.body).toEqual(afterOnce);
+  });
+
+  it('should not mutate the original input object', () => {
+    const original = { name: '<b>v</b>' };
+    mockRequest.body = original;
+
+    sanitize(mockRequest as Request, mockResponse as Response, nextFunction);
+
+    expect(original.name).toBe('<b>v</b>');
+    expect(mockRequest.body.name).toBe('v');
+    expect(mockRequest.body).not.toBe(original);
+  });
+
+  it('should preserve array shapes for query params (e.g. ?tag=a&tag=b)', () => {
+    mockRequest.query = { tag: ['<i>a</i>', 'b'], q: 'hi' } as never;
+
+    sanitize(mockRequest as Request, mockResponse as Response, nextFunction);
+
+    const query = mockRequest.query as Record<string, unknown>;
+    expect(Array.isArray(query.tag)).toBe(true);
+    expect(query.tag).toEqual(['a', 'b']);
+    expect(query.q).toBe('hi');
+  });
+
+  it('should preserve params shapes', () => {
+    mockRequest.params = { id: '123', slug: '<x>name</x>' } as never;
+
+    sanitize(mockRequest as Request, mockResponse as Response, nextFunction);
+
+    const params = mockRequest.params as Record<string, string>;
+    expect(params.id).toBe('123');
+    expect(params.slug).toBe('name');
+  });
 });

--- a/src/middleware/sanitize.ts
+++ b/src/middleware/sanitize.ts
@@ -14,24 +14,39 @@ const xssOptions = {
 const customXss = new FilterXSS(xssOptions);
 
 /**
- * Recursively sanitize an object or string using xss filtering.
- * 
- * @param obj The input object, array, or string to sanitize
- * @returns The sanitized object, array, or string
- * 
- * @dev Security Assumptions:
- * - This function assumes the input is a POJO (Plain Old JavaScript Object), array, or primitive.
- * - Complex objects (like Dates, Buffers) are returned as is to prevent corruption, 
- *   as they are not typical vectors for XSS in their raw form until serialized.
- * - All string values are passed through the strict XSS filter.
+ * Keys that must never be copied onto a sanitized object, because assigning them
+ * can pollute `Object.prototype` and affect every object in the process.
  */
-const sanitizeObject = (obj: any): any => {
+const PROTOTYPE_POLLUTION_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+/**
+ * Recursively sanitize an object, array, or string using strict XSS filtering.
+ *
+ * The return type mirrors the input type (`T`), so callers - and Express's
+ * `query`/`params` typings - keep their expected shapes instead of collapsing to
+ * `any`. String values are trimmed and passed through the strict XSS filter;
+ * arrays and plain objects are sanitized recursively; everything else is
+ * returned unchanged.
+ *
+ * @typeParam T - The (inferred) type of the value being sanitized.
+ * @param obj The input object, array, or string to sanitize.
+ * @returns A new sanitized value of the same shape as the input.
+ *
+ * @remarks Security guarantees:
+ * - **Prototype-pollution safe:** keys `__proto__`, `constructor`, and
+ *   `prototype` are skipped during recursion, so a crafted payload cannot reach
+ *   `Object.prototype`. The result is also created with a `null` prototype.
+ * - **Non-mutating:** input objects/arrays are copied rather than mutated.
+ * - **Idempotent:** running the function twice yields the same result.
+ * - Special objects (`Date`, `Buffer`) are returned as-is to avoid corruption.
+ */
+const sanitizeObject = <T>(obj: T): T => {
   if (typeof obj === 'string') {
-    return customXss.process(obj.trim());
+    return customXss.process(obj.trim()) as unknown as T;
   }
 
   if (Array.isArray(obj)) {
-    return obj.map((item) => sanitizeObject(item));
+    return obj.map((item) => sanitizeObject(item)) as unknown as T;
   }
 
   if (obj !== null && typeof obj === 'object') {
@@ -40,25 +55,36 @@ const sanitizeObject = (obj: any): any => {
       return obj;
     }
 
-    const sanitizedObj: { [key: string]: any } = {};
+    const sanitizedObj: { [key: string]: unknown } = Object.create(null);
     for (const [key, value] of Object.entries(obj)) {
+      // Drop prototype-pollution keys so they never survive sanitization.
+      if (PROTOTYPE_POLLUTION_KEYS.has(key)) {
+        continue;
+      }
       sanitizedObj[key] = sanitizeObject(value);
     }
-    return sanitizedObj;
+    return sanitizedObj as unknown as T;
   }
 
   return obj;
 };
 
 /**
- * Express middleware to sanitize incoming request data.
- * It sanitizes `req.body`, `req.query`, and `req.params`.
- * 
+ * Express middleware that strips XSS payloads from incoming request data.
+ *
+ * Sanitizes `req.body`, `req.query`, and `req.params` in place. Because
+ * {@link sanitizeObject} preserves the input type, `req.query` and `req.params`
+ * keep their declared `ParsedQs` / params shapes instead of degrading to `any`,
+ * so downstream handlers continue to see the expected string/array structures.
+ *
+ * The middleware is idempotent (safe to run more than once) and guards against
+ * prototype-pollution keys during sanitization.
+ *
  * @param req Express request object
  * @param res Express response object
  * @param next Express next function
  */
-export const sanitize = (req: Request, res: Response, next: NextFunction): void => {
+export const sanitize = (req: Request, _res: Response, next: NextFunction): void => {
   if (req.body) {
     req.body = sanitizeObject(req.body);
   }


### PR DESCRIPTION
Closes #571.

Makes `sanitizeObject` generic (`<T>(obj: T): T`) so `req.query`/`req.params` keep their expected shapes instead of collapsing to `any`, and guards against prototype-pollution by dropping `__proto__`/`constructor`/`prototype` keys during recursion and building results with a null prototype. The sanitizer is non-mutating (copies input) and idempotent. Adds tests in `src/middleware/sanitize.test.ts` (nested sanitization, prototype-pollution rejection, idempotency, preserved query/params types) and documents the contract in `docs/API.md`. All 11 tests pass.