### PR TITLE
fix(observability): validate correlation IDs before webhook headers

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -70,7 +70,7 @@ Optional correlation ID for distributed tracing across service boundaries. Enabl
 - **Format:** Alphanumeric characters, hyphens, and underscores only
 - **Example:** `X-Correlation-Id: trace-12345-abc`
 
-**Security Note:** The correlation ID is validated for injection attacks. Only safe characters are accepted; invalid IDs are rejected and not echoed back in the response.
+**Security Note:** The correlation ID is validated for injection attacks. Only safe characters are accepted; invalid IDs are rejected, omitted from outbound webhook headers, and not echoed back in the response.
 
 ### Propagation Through the System
 

--- a/src/middleware/requestContext.ts
+++ b/src/middleware/requestContext.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto';
 import { NextFunction, Request, Response } from 'express';
 import { AsyncLocalStorage } from 'async_hooks';
+import { sanitizeCorrelationId } from '../utils/correlationId';
 
 export interface RequestContextInfo {
   requestId: string;
@@ -27,9 +28,8 @@ export function getRequestContext(): RequestContextInfo | undefined {
  * and runs downstream middleware and route handlers inside an AsyncLocalStorage context.
  */
 export function requestContext(req: Request, res: Response, next: NextFunction): void {
-  const headerRequestId = req.header('x-request-id');
-  const requestId = headerRequestId && headerRequestId.trim() ? headerRequestId : randomUUID();
-  const correlationId = req.header('x-correlation-id') || undefined;
+  const requestId = sanitizeCorrelationId(req.header('x-request-id')) ?? randomUUID();
+  const correlationId = sanitizeCorrelationId(req.header('x-correlation-id'));
 
   res.locals.requestId = requestId;
   res.setHeader('x-request-id', requestId);

--- a/src/middleware/requestId.ts
+++ b/src/middleware/requestId.ts
@@ -29,25 +29,18 @@
 import { Request, Response, NextFunction } from 'express';
 import { randomUUID } from 'crypto';
 import { logger } from '../logger';
+import { sanitizeCorrelationId } from '../utils/correlationId';
 
 /** Header names used for propagation. */
 export const REQUEST_ID_HEADER = 'x-request-id';
 export const CORRELATION_ID_HEADER = 'x-correlation-id';
 
 /**
- * Allowlist pattern for externally supplied IDs.
- * Accepts UUID v4 format OR alphanumeric strings with hyphens/underscores
- * up to 128 characters.
- */
-const SAFE_ID_PATTERN = /^[a-zA-Z0-9\-_]{1,128}$/;
-
-/**
  * Validate an externally supplied ID string.
  * Returns the value unchanged if valid, otherwise returns undefined.
  */
 export function validateExternalId(value: unknown): string | undefined {
-  if (typeof value !== 'string') return undefined;
-  return SAFE_ID_PATTERN.test(value) ? value : undefined;
+  return sanitizeCorrelationId(value);
 }
 
 /**

--- a/src/middleware/requestLogger.ts
+++ b/src/middleware/requestLogger.ts
@@ -13,6 +13,7 @@
 import { Request, Response, NextFunction } from 'express';
 import { v4 as uuidv4 } from 'uuid';
 import { Logger, createRequestLogger } from '../logger';
+import { sanitizeCorrelationId } from '../utils/correlationId';
 
 // Extend Express Request interface to include our logger
 declare global {
@@ -28,6 +29,20 @@ declare global {
 // Header names for correlation ID
 const CORRELATION_ID_HEADER = 'x-correlation-id';
 const REQUEST_ID_HEADER = 'x-request-id';
+
+function firstValidCorrelationId(...values: Array<string | undefined>): string | undefined {
+  for (const value of values) {
+    const sanitized = sanitizeCorrelationId(value);
+    if (sanitized) {
+      return sanitized;
+    }
+  }
+  return undefined;
+}
+
+function traceparentTraceId(req: Request): string | undefined {
+  return req.header('traceparent')?.split('-')[1];
+}
 
 /**
  * Express middleware that adds request correlation and logging capabilities.
@@ -45,18 +60,16 @@ export function requestLoggerMiddleware(
   next: NextFunction
 ): void {
   // Generate or extract request ID
-  const requestId = req.header(REQUEST_ID_HEADER) || uuidv4();
+  const requestId = sanitizeCorrelationId(req.header(REQUEST_ID_HEADER)) || uuidv4();
   
   // Extract or generate correlation ID
-  let correlationId = req.header(CORRELATION_ID_HEADER);
-  if (!correlationId) {
-    // Try to extract from other common headers
-    correlationId = 
-      req.header('x-trace-id') ||
-      req.header('x-request-id') ||
-      req.header('traceparent')?.split('-')[1] || // Extract from W3C traceparent
-      uuidv4();
-  }
+  const correlationId =
+    firstValidCorrelationId(
+      req.header(CORRELATION_ID_HEADER),
+      req.header('x-trace-id'),
+      req.header('x-request-id'),
+      traceparentTraceId(req),
+    ) || uuidv4();
 
   // Store IDs on request object
   req.requestId = requestId;
@@ -160,17 +173,16 @@ export function createRequestLoggerMiddleware(options: RequestLoggerOptions = {}
     next: NextFunction
   ): void {
     // Generate or extract request ID
-    const requestId = req.header(requestIdHeader) || uuidv4();
+    const requestId = sanitizeCorrelationId(req.header(requestIdHeader)) || uuidv4();
     
     // Extract or generate correlation ID
-    let correlationId = req.header(correlationIdHeader);
-    if (!correlationId) {
-      correlationId = 
-        req.header('x-trace-id') ||
-        req.header('x-request-id') ||
-        req.header('traceparent')?.split('-')[1] ||
-        uuidv4();
-    }
+    const correlationId =
+      firstValidCorrelationId(
+        req.header(correlationIdHeader),
+        req.header('x-trace-id'),
+        req.header('x-request-id'),
+        traceparentTraceId(req),
+      ) || uuidv4();
 
     // Store IDs on request object
     req.requestId = requestId;

--- a/src/services/webhook.service.iterative.test.ts
+++ b/src/services/webhook.service.iterative.test.ts
@@ -127,6 +127,15 @@ describe('WebhookService (iterative retry)', () => {
     );
   });
 
+  it('omits invalid correlation ID header values', async () => {
+    (axios.post as jest.Mock).mockResolvedValueOnce({ status: 200 });
+
+    await service.send(makePayload({ correlationId: 'trace\nX-Injected: true' }));
+
+    const call = (axios.post as jest.Mock).mock.calls[0];
+    expect(call[2].headers).not.toHaveProperty('X-Correlation-Id');
+  });
+
   it('adds signature headers when webhookSecret provided', async () => {
     (axios.post as jest.Mock).mockResolvedValueOnce({ status: 200 });
 
@@ -153,4 +162,3 @@ describe('WebhookService (iterative retry)', () => {
     expect(call[2].headers).not.toHaveProperty('X-Signature');
   });
 });
-

--- a/src/services/webhook.service.ts
+++ b/src/services/webhook.service.ts
@@ -7,6 +7,7 @@ import { WEBHOOK_RETRY_POLICY, calculateWebhookRetryDelay } from '../queue/webho
 import { isSafeUrl } from '../utils/ssrf';
 import { RateLimitStore } from '../lib/rateLimitStore';
 import { MetricsServiceLike } from '../observability';
+import { buildWebhookHeaders } from '../utils/correlationId';
 
 /** Max deliveries per destination host per window. Default: 60. */
 const HOST_RATE_LIMIT_MAX = Number(process.env.WEBHOOK_HOST_RATE_LIMIT_MAX ?? 60);
@@ -92,9 +93,7 @@ export class WebhookService {
       }
 
       try {
-        const headers: Record<string, string> = {
-          'Content-Type': 'application/json',
-        };
+        const headers = buildWebhookHeaders(payload.correlationId);
 
         if (payload.webhookSecret) {
           const { signature, timestamp } = createWebhookSignature(
@@ -103,10 +102,6 @@ export class WebhookService {
           );
           headers['X-Signature'] = `sha256=${signature}`;
           headers['X-Timestamp'] = timestamp.toString();
-        }
-
-        if (payload.correlationId) {
-          headers['X-Correlation-Id'] = payload.correlationId;
         }
 
         await axios.post(payload.url, payload.data, { headers });
@@ -245,4 +240,3 @@ export class WebhookService {
     return { attempted, succeeded, failed, deduped };
   }
 }
-

--- a/src/utils/correlationId.test.ts
+++ b/src/utils/correlationId.test.ts
@@ -16,9 +16,34 @@ import {
   getRequestLogger,
   getRequestContext,
   buildWebhookHeaders,
+  isValidCorrelationId,
+  sanitizeCorrelationId,
 } from './correlationId';
 
 describe('correlationId utilities', () => {
+  describe('sanitizeCorrelationId', () => {
+    it('should accept alphanumeric, hyphen, and underscore IDs up to 128 chars', () => {
+      const id = `Trace_ID-${'a'.repeat(119)}`;
+
+      expect(isValidCorrelationId(id)).toBe(true);
+      expect(sanitizeCorrelationId(id)).toBe(id);
+    });
+
+    it('should reject CRLF header injection payloads', () => {
+      const malicious = 'trace\r\nX-Injected-Header: yes';
+
+      expect(isValidCorrelationId(malicious)).toBe(false);
+      expect(sanitizeCorrelationId(malicious)).toBeUndefined();
+    });
+
+    it('should reject empty, non-string, and over-length IDs', () => {
+      expect(sanitizeCorrelationId('')).toBeUndefined();
+      expect(sanitizeCorrelationId(123)).toBeUndefined();
+      expect(sanitizeCorrelationId(null)).toBeUndefined();
+      expect(sanitizeCorrelationId('a'.repeat(129))).toBeUndefined();
+    });
+  });
+
   describe('getCorrelationId', () => {
     /**
      * Should return the correlation ID from response locals when present.
@@ -57,6 +82,14 @@ describe('correlationId utilities', () => {
       const result = getCorrelationId(res);
 
       expect(result).toBeUndefined();
+    });
+
+    it('should return undefined when locals contains an unsafe correlation ID', () => {
+      const res = {
+        locals: { correlationId: 'bad\nheader' },
+      } as any as Response;
+
+      expect(getCorrelationId(res)).toBeUndefined();
     });
   });
 
@@ -257,6 +290,20 @@ describe('correlationId utilities', () => {
       const headers = buildWebhookHeaders(longId);
 
       expect(headers['X-Correlation-Id']).toBe(longId);
+    });
+
+    it('should omit unsafe correlation IDs from webhook headers', () => {
+      const headers = buildWebhookHeaders('trace\r\nX-Evil: yes');
+
+      expect(headers['X-Correlation-Id']).toBeUndefined();
+      expect(headers['Content-Type']).toBe('application/json');
+    });
+
+    it('should omit over-length correlation IDs from webhook headers', () => {
+      const headers = buildWebhookHeaders('a'.repeat(129));
+
+      expect(headers['X-Correlation-Id']).toBeUndefined();
+      expect(headers['Content-Type']).toBe('application/json');
     });
   });
 });

--- a/src/utils/correlationId.ts
+++ b/src/utils/correlationId.ts
@@ -14,6 +14,27 @@
 
 import { Response } from 'express';
 
+const SAFE_CORRELATION_ID_PATTERN = /^[a-zA-Z0-9\-_]{1,128}$/;
+
+/**
+ * Returns true when a value is a safe correlation ID for logs and HTTP headers.
+ *
+ * Correlation IDs are limited to alphanumeric characters, hyphen, and
+ * underscore with a maximum length of 128 characters. This rejects CR/LF and
+ * other control characters so caller-supplied IDs cannot inject headers.
+ */
+export function isValidCorrelationId(value: unknown): value is string {
+  return typeof value === 'string' && SAFE_CORRELATION_ID_PATTERN.test(value);
+}
+
+/**
+ * Returns a safe correlation ID or undefined when the caller-supplied value is
+ * missing or invalid.
+ */
+export function sanitizeCorrelationId(value: unknown): string | undefined {
+  return isValidCorrelationId(value) ? value : undefined;
+}
+
 /**
  * Extract correlation ID from Express response locals.
  *
@@ -33,7 +54,7 @@ import { Response } from 'express';
  * ```
  */
 export function getCorrelationId(res: Response): string | undefined {
-  return res.locals['correlationId'] as string | undefined;
+  return sanitizeCorrelationId(res.locals['correlationId']);
 }
 
 /**
@@ -128,8 +149,9 @@ export function buildWebhookHeaders(
     'Content-Type': 'application/json',
   };
 
-  if (correlationId) {
-    headers['X-Correlation-Id'] = correlationId;
+  const safeCorrelationId = sanitizeCorrelationId(correlationId);
+  if (safeCorrelationId) {
+    headers['X-Correlation-Id'] = safeCorrelationId;
   }
 
   return headers;


### PR DESCRIPTION
## Summary

- Adds a shared correlation ID validator/sanitizer enforcing the documented alphanumeric, hyphen, underscore, max-128 rule.
- Routes outbound webhook correlation headers through the sanitizer so CR/LF and over-length IDs are omitted instead of propagated.
- Reuses the same sanitizer in inbound request correlation middleware paths that previously accepted raw header values.
- Documents that invalid correlation IDs are also omitted from outbound webhook headers.

Closes #557.

## Security Notes

Invalid caller-supplied correlation IDs now fail safe: they are not attached to webhook delivery headers and are not returned from correlation utility accessors. The delivery path does not throw on invalid IDs, so webhook sending continues without the unsafe tracing header.

## Validation

- `npm test -- --runInBand src/utils/correlationId.test.ts src/services/webhook.service.iterative.test.ts src/middleware/requestId.test.ts src/middleware/requestContext.test.ts`
- `npx eslint src/utils/correlationId.ts src/utils/correlationId.test.ts src/services/webhook.service.ts src/services/webhook.service.iterative.test.ts src/middleware/requestId.ts src/middleware/requestContext.ts src/middleware/requestLogger.ts`
- `git diff --check`

Repo-wide baseline blockers observed:

- `npm run lint` currently fails on unrelated parse errors in `src/utils/swrCache.ts` and `src/utils/swrCache.test.ts`.
- `npm run build` currently fails on unrelated syntax errors in `src/utils/swrCache.ts`.
