### PR TITLE
fix(webhooks): bound outbound delivery attempts

### DIFF
--- a/docs/WEBHOOK-DLQ.md
+++ b/docs/WEBHOOK-DLQ.md
@@ -31,6 +31,14 @@ that cannot finish within the grace window are force-flushed to the DLQ.
 - 10 % jitter to prevent thundering herd
 - Max delay cap: 30 s
 
+### Delivery Timeout
+
+Each outbound webhook HTTP attempt is capped by `WEBHOOK_DELIVERY_TIMEOUT_MS`.
+The default is `10000` ms. Values are validated at startup and must be an
+integer between `100` and `120000` ms. Timeout failures count as ordinary
+transient delivery failures: the attempt increments `retryCount`, uses the
+configured retry backoff, and moves to the DLQ when retries are exhausted.
+
 ### Admin Endpoints (`src/routes/admin.routes.ts`)
 
 | Method | Endpoint                                      | Description            |

--- a/src/config/env.schema.ts
+++ b/src/config/env.schema.ts
@@ -110,6 +110,11 @@ export const envSchema = z.object({
     .transform((val) => val ? val.split(',').map(p => p.trim()) : undefined)
     .pipe(z.array(z.string()).optional()),
 
+  WEBHOOK_DELIVERY_TIMEOUT_MS: z.string()
+    .default('10000')
+    .transform((val) => parseInt(val, 10))
+    .pipe(z.number().int().min(100).max(120_000)),
+
   IDEMPOTENCY_TTL_MS: z.string()
     .optional()
     .transform((val) => val === undefined ? undefined : parseInt(val, 10))

--- a/src/config/env.test.ts
+++ b/src/config/env.test.ts
@@ -22,4 +22,28 @@ describe('Environment validation', () => {
     process.env.COMPLIANCE_AUDIT_SECRET = 'a'.repeat(32);
     expect(() => validateEnv()).not.toThrow();
   });
+
+  it('should default WEBHOOK_DELIVERY_TIMEOUT_MS to 10000', () => {
+    process.env.NODE_ENV = 'test';
+    process.env.COMPLIANCE_AUDIT_SECRET = 'a'.repeat(32);
+    delete process.env.WEBHOOK_DELIVERY_TIMEOUT_MS;
+
+    expect(validateEnv().WEBHOOK_DELIVERY_TIMEOUT_MS).toBe(10_000);
+  });
+
+  it('should parse WEBHOOK_DELIVERY_TIMEOUT_MS from env', () => {
+    process.env.NODE_ENV = 'test';
+    process.env.COMPLIANCE_AUDIT_SECRET = 'a'.repeat(32);
+    process.env.WEBHOOK_DELIVERY_TIMEOUT_MS = '2500';
+
+    expect(validateEnv().WEBHOOK_DELIVERY_TIMEOUT_MS).toBe(2_500);
+  });
+
+  it('should reject invalid WEBHOOK_DELIVERY_TIMEOUT_MS values', () => {
+    process.env.NODE_ENV = 'test';
+    process.env.COMPLIANCE_AUDIT_SECRET = 'a'.repeat(32);
+    process.env.WEBHOOK_DELIVERY_TIMEOUT_MS = '0';
+
+    expect(() => validateEnv()).toThrow(/WEBHOOK_DELIVERY_TIMEOUT_MS/);
+  });
 });

--- a/src/services/webhook.service.iterative.test.ts
+++ b/src/services/webhook.service.iterative.test.ts
@@ -75,6 +75,56 @@ describe('WebhookService (iterative retry)', () => {
     expect(mockDLQ.addEntry).not.toHaveBeenCalled();
   });
 
+  it('passes a bounded timeout to each delivery attempt', async () => {
+    (axios.post as jest.Mock).mockResolvedValueOnce({ status: 200 });
+
+    await service.send(makePayload());
+
+    expect(axios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.anything(),
+      expect.objectContaining({
+        timeout: 10_000,
+      }),
+    );
+  });
+
+  it('treats axios timeout errors as retryable failures', async () => {
+    const timeoutError = Object.assign(new Error('timeout of 10000ms exceeded'), {
+      code: 'ECONNABORTED',
+    });
+    (axios.post as jest.Mock)
+      .mockRejectedValueOnce(timeoutError)
+      .mockResolvedValueOnce({ status: 200 });
+
+    const payload = makePayload();
+    await service.send(payload);
+
+    expect(axios.post).toHaveBeenCalledTimes(2);
+    expect(payload.retryCount).toBe(1);
+    expect(mockDLQ.addEntry).not.toHaveBeenCalled();
+  });
+
+  it('DLQs after all timeout attempts are exhausted', async () => {
+    const timeoutError = Object.assign(new Error('timeout of 10000ms exceeded'), {
+      code: 'ECONNABORTED',
+    });
+    (axios.post as jest.Mock).mockRejectedValue(timeoutError);
+    (mockDLQ.addEntry as jest.Mock).mockResolvedValueOnce(undefined);
+
+    await service.send(makePayload());
+
+    expect(axios.post).toHaveBeenCalledTimes(4);
+    expect(mockDLQ.addEntry).toHaveBeenCalledWith(
+      'webhook-1',
+      'https://example.com/hook',
+      { event: 'test' },
+      expect.any(Number),
+      'timeout of 10000ms exceeded',
+      undefined,
+    );
+  });
+
   it('retries and succeeds mid-retry', async () => {
     (axios.post as jest.Mock)
       .mockRejectedValueOnce(new Error('timeout'))
@@ -153,4 +203,3 @@ describe('WebhookService (iterative retry)', () => {
     expect(call[2].headers).not.toHaveProperty('X-Signature');
   });
 });
-

--- a/src/services/webhook.service.ts
+++ b/src/services/webhook.service.ts
@@ -7,11 +7,14 @@ import { WEBHOOK_RETRY_POLICY, calculateWebhookRetryDelay } from '../queue/webho
 import { isSafeUrl } from '../utils/ssrf';
 import { RateLimitStore } from '../lib/rateLimitStore';
 import { MetricsServiceLike } from '../observability';
+import { validateEnv } from '../config/env.schema';
 
 /** Max deliveries per destination host per window. Default: 60. */
 const HOST_RATE_LIMIT_MAX = Number(process.env.WEBHOOK_HOST_RATE_LIMIT_MAX ?? 60);
 /** Window length in ms for per-host rate limiting. Default: 60 000 ms. */
 const HOST_RATE_LIMIT_WINDOW_MS = Number(process.env.WEBHOOK_HOST_RATE_LIMIT_WINDOW_MS ?? 60_000);
+/** Per-attempt outbound webhook timeout, validated through env schema. */
+const WEBHOOK_DELIVERY_TIMEOUT_MS = validateEnv().WEBHOOK_DELIVERY_TIMEOUT_MS;
 
 export interface WebhookPayload {
   id: string;
@@ -66,6 +69,8 @@ export class WebhookService {
    * Before each attempt the destination URL is re-validated with `isSafeUrl`
    * (SSRF guard) and a per-host sliding-window rate limit is applied.  Either
    * check failing causes an immediate DLQ enqueue without further retries.
+   * Each outbound HTTP attempt also uses a validated per-request timeout so a
+   * slow receiver cannot pin the delivery worker indefinitely.
    *
    * @remarks
    * Uses a bounded for-loop so no call stack growth occurs across retries.
@@ -109,7 +114,10 @@ export class WebhookService {
           headers['X-Correlation-Id'] = payload.correlationId;
         }
 
-        await axios.post(payload.url, payload.data, { headers });
+        await axios.post(payload.url, payload.data, {
+          headers,
+          timeout: WEBHOOK_DELIVERY_TIMEOUT_MS,
+        });
         return;
       } catch (error: unknown) {
         lastError = error as Error;
@@ -245,4 +253,3 @@ export class WebhookService {
     return { attempted, succeeded, failed, deduped };
   }
 }
-


### PR DESCRIPTION
## Summary

- Adds validated `WEBHOOK_DELIVERY_TIMEOUT_MS` config with a 10000 ms default.
- Passes the configured timeout to outbound webhook `axios.post` calls.
- Keeps timeout failures on the existing retry/DLQ path so slow receivers cannot pin a delivery worker indefinitely.
- Documents the timeout behavior in the webhook DLQ guide.

Closes #556.

## Security Notes

Each delivery attempt now has a bounded HTTP timeout. Axios timeout failures are treated as transient failures: they increment retry state, use normal backoff, and move to the DLQ after retry exhaustion.

## Validation

- `npm test -- --runInBand src/services/webhook.service.iterative.test.ts src/config/env.test.ts`
- `npx eslint src/config/env.schema.ts src/config/env.test.ts src/services/webhook.service.ts src/services/webhook.service.iterative.test.ts`
- `git diff --check`

Repo-wide baseline blockers observed:

- `npm run lint` currently fails on unrelated parse errors in `src/utils/swrCache.ts` and `src/utils/swrCache.test.ts`.
- `npm run build` currently fails on unrelated syntax errors in `src/utils/swrCache.ts`.
