### PR TITLE
fix(security): normalize emails to prevent case-variant duplicate accounts (#630)

### DIFF
--- a/AUTH.md
+++ b/AUTH.md
@@ -158,7 +158,14 @@ The authentication path employs strict measures to prevent attackers from determ
 1. **Constant-Time Verification**: On login, if an email is not found, the service hashes a dummy password (``${"a".repeat(32)}:${"b".repeat(128)}``) to ensure that the request takes the same amount of time as a matching account check.
 2. **Generic Error Messages**: Registration and login endpoints return generic codes and messages (e.g., `invalid_credentials` or `Registration failed. Please try again.`) without disclosing whether the password or the email was incorrect.
 
-### E. Centralized JWT Configuration (Algorithm Confusion Mitigation)
+### E. Email Normalization (Case-Variant Duplicate Prevention)
+Emails are normalized (trimmed + lowercased) before every write and lookup, via a single shared helper (`normalizeEmail` in [userRepository.ts](file:///c:/Users/DELL/Desktop/Talenttrust-Backend/src/repositories/userRepository.ts)) used by both `AuthService` (register/login) and `UserRepository` (create/findByEmail). This prevents `User@x.com` and `user@x.com` from registering as two distinct accounts, which would otherwise allow account confusion or impersonation of an existing identity.
+
+As defense in depth, a `UNIQUE` index on `LOWER(TRIM(email))` is enforced at the schema level (migration `add_unique_index_on_normalized_email`), so a case-variant duplicate is rejected by the database even if application code ever fails to normalize before an insert.
+
+The anti-enumeration behavior on login (Section D) is unaffected: the constant-time comparison still runs regardless of whether the normalized email matches an existing row.
+
+### F. Centralized JWT Configuration (Algorithm Confusion Mitigation)
 To prevent algorithm-confusion vulnerabilities (e.g., where a verification library honors a token header specifying `alg: none` or swaps RSA public keys for HMAC validation), all token verification calls MUST use the centralized config in [jwtConfig.ts](file:///c:/Users/DELL/Desktop/Talenttrust-Backend/src/auth/jwtConfig.ts):
 ```typescript
 export const JWT_VERIFY_OPTIONS = {

--- a/src/db/migrations.test.ts
+++ b/src/db/migrations.test.ts
@@ -32,6 +32,24 @@ describe("runMigrations", () => {
     expect(rows.every((row) => /^[a-f0-9]{64}$/.test(row.checksum))).toBe(true);
   });
 
+  it("enforces a unique index on the normalized (trimmed + lowercased) email", () => {
+    runMigrations(db);
+
+    db.prepare(
+      `INSERT INTO users (id, username, email, role, created_at)
+       VALUES ('u1', 'alice', 'alice@example.com', 'client', '2026-01-01T00:00:00.000Z')`
+    ).run();
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO users (id, username, email, role, created_at)
+           VALUES ('u2', 'alice2', '  Alice@Example.COM  ', 'client', '2026-01-01T00:00:00.000Z')`
+        )
+        .run()
+    ).toThrow();
+  });
+
   it("is idempotent when run multiple times", () => {
     runMigrations(db);
     runMigrations(db);

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -268,6 +268,23 @@ MIGRATIONS.push({
   },
 });
 
+// Version 10: unique index on the normalised (trimmed + lowercased) email so
+// case-variant duplicates (e.g. "User@x.com" vs "user@x.com") are rejected at
+// the schema level even if application code ever writes an unnormalised
+// value. Application code additionally normalises before every write/lookup
+// (see UserRepository.normalizeEmail / AuthService), so this index enforces
+// the invariant rather than being the primary defense.
+MIGRATIONS.push({
+  version: 10,
+  name: "add_unique_index_on_normalized_email",
+  up: (db) => {
+    db.exec(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email_normalized
+        ON users (LOWER(TRIM(email)));
+    `);
+  },
+});
+
 function ensureMigrationTable(db: Database.Database): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS schema_version (

--- a/src/repositories/userRepository.test.ts
+++ b/src/repositories/userRepository.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { getDb, closeDb } from "../db/database";
-import { UserRepository } from "./userRepository";
+import { UserRepository, normalizeEmail } from "./userRepository";
 
 let userRepo: UserRepository;
 
@@ -88,6 +88,38 @@ describe("UserRepository.create", () => {
       }),
     ).toThrow();
   });
+
+  it("normalizes (trims + lowercases) the email before storing it", () => {
+    const user = userRepo.create({
+      username: "alice",
+      email: "  Alice@Example.COM  ",
+      role: "client",
+    });
+    expect(user.email).toBe("alice@example.com");
+    expect(userRepo.findById(user.id)?.email).toBe("alice@example.com");
+  });
+
+  it("throws on a case-variant duplicate email (normalized UNIQUE index)", () => {
+    userRepo.create(baseData());
+    expect(() =>
+      userRepo.create({
+        username: "other",
+        email: "ALICE@EXAMPLE.COM",
+        role: "client",
+      }),
+    ).toThrow();
+  });
+
+  it("throws on a whitespace-variant duplicate email (normalized UNIQUE index)", () => {
+    userRepo.create(baseData());
+    expect(() =>
+      userRepo.create({
+        username: "other",
+        email: " alice@example.com ",
+        role: "client",
+      }),
+    ).toThrow();
+  });
 });
 
 describe("UserRepository.findById", () => {
@@ -112,6 +144,28 @@ describe("UserRepository.findByEmail", () => {
 
   it("returns undefined for an unknown email", () => {
     expect(userRepo.findByEmail("ghost@example.com")).toBeUndefined();
+  });
+
+  it("finds a user regardless of case or surrounding whitespace in the query", () => {
+    const created = userRepo.create({
+      username: "alice",
+      email: "alice@example.com",
+      role: "client",
+    });
+
+    expect(userRepo.findByEmail("Alice@Example.com")?.id).toBe(created.id);
+    expect(userRepo.findByEmail("  alice@example.com  ")?.id).toBe(created.id);
+    expect(userRepo.findByEmail("ALICE@EXAMPLE.COM")?.id).toBe(created.id);
+  });
+});
+
+describe("normalizeEmail", () => {
+  it("trims surrounding whitespace and lowercases", () => {
+    expect(normalizeEmail("  User@Example.COM  ")).toBe("user@example.com");
+  });
+
+  it("is a no-op for an already-normalized email", () => {
+    expect(normalizeEmail("user@example.com")).toBe("user@example.com");
   });
 });
 

--- a/src/repositories/userRepository.ts
+++ b/src/repositories/userRepository.ts
@@ -2,19 +2,31 @@
  * UserRepository — CRUD operations for the `users` table.
  *
  * Uses prepared statements throughout to prevent SQL injection.
- * Username and email uniqueness is enforced at the DB level (UNIQUE constraint)
- * in addition to any application-level validation.
+ * Username and email uniqueness is enforced at the DB level (UNIQUE constraint
+ * on the raw column, plus a unique index on the normalised email — see
+ * migration `add_unique_index_on_normalized_email`) in addition to
+ * application-level validation.
  *
  * Security notes:
  *  - Passwords / credentials are NOT stored here; authentication is handled
  *    externally (Stellar key-based or third-party auth).
- *  - Email addresses are stored verbatim; normalise (lowercase) before
- *    inserting to avoid duplicate-email bypasses.
+ *  - Emails are normalised (trimmed + lowercased) via {@link normalizeEmail}
+ *    on both write and lookup paths to prevent case-variant duplicate
+ *    accounts and the account-confusion/impersonation risk that follows.
  */
 
 import Database from "better-sqlite3";
 import { randomUUID } from "crypto";
 import type { User, UserRole } from "../db/types";
+
+/**
+ * Normalises an email address for storage and lookup: trims surrounding
+ * whitespace and lowercases it, so `" User@X.com "` and `"user@x.com"`
+ * resolve to the same account.
+ */
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
 
 /** Raw row shape returned from SQLite (snake_case columns). */
 interface UserRow {
@@ -76,13 +88,14 @@ export class UserRepository {
   /**
    * Finds a user by their unique email address.
    *
-   * @param email - Email address to search for (case-sensitive).
+   * @param email - Email address to search for (normalised before lookup,
+   *                so the match is case- and whitespace-insensitive).
    * @returns The matching User or `undefined` if not found.
    */
   findByEmail(email: string): User | undefined {
     const row = this.db
       .prepare<[string], UserRow>("SELECT * FROM users WHERE email = ?")
-      .get(email);
+      .get(normalizeEmail(email));
     return row ? toUser(row) : undefined;
   }
 
@@ -90,21 +103,24 @@ export class UserRepository {
    * Creates a new user record.
    *
    * @param data - Required user fields (id and createdAt are generated).
-   * @returns  The newly created User.
+   *               The email is normalised (trimmed + lowercased) before
+   *               being persisted.
+   * @returns  The newly created User (with the normalised email).
    * @throws   If username or email already exists (SQLite UNIQUE constraint).
    */
   create(data: Omit<User, "id" | "createdAt">): User {
     const id = randomUUID();
     const createdAt = new Date().toISOString();
+    const email = normalizeEmail(data.email);
 
     this.db
       .prepare<[string, string, string, string, string]>(
         `INSERT INTO users (id, username, email, role, created_at)
          VALUES (?, ?, ?, ?, ?)`,
       )
-      .run(id, data.username, data.email, data.role, createdAt);
+      .run(id, data.username, email, data.role, createdAt);
 
-    return { id, ...data, createdAt };
+    return { id, ...data, email, createdAt };
   }
 
   /**

--- a/src/services/auth.service.test.ts
+++ b/src/services/auth.service.test.ts
@@ -135,6 +135,24 @@ describe("AuthService — password hashing with scrypt", () => {
     const login2 = await authService.login("USER@TEST.COM", "Pass123!");
     expect(login2.accessToken).toBeDefined();
   });
+
+  it("trims surrounding whitespace from emails on register and login", async () => {
+    const result = await authService.register("  user@test.com  ", "Pass123!", "testuser");
+    const decoded = jwt.verify(result.accessToken, TEST_JWT_SECRET) as Record<string, unknown>;
+
+    expect(decoded.email).toBe("user@test.com");
+
+    const login = await authService.login("  user@test.com  ", "Pass123!");
+    expect(login.accessToken).toBeDefined();
+  });
+
+  it("rejects registration when a case-and-whitespace variant of an existing email is used", async () => {
+    await authService.register("user@test.com", "Pass123!", "testuser");
+
+    await expect(
+      authService.register("  USER@Test.com  ", "DifferentPass!", "anotheruser")
+    ).rejects.toThrow("An account with that email already exists.");
+  });
 });
 
 describe("AuthService — anti-enumeration (uniform error contract)", () => {

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -21,6 +21,7 @@ import { randomBytes, scryptSync, timingSafeEqual, createHash } from "crypto";
 import jwt from "jsonwebtoken";
 import Database from "better-sqlite3";
 import { JWT_VERIFY_OPTIONS, JWT_SIGN_ALGORITHMS } from "../auth/jwtConfig";
+import { normalizeEmail } from "../repositories/userRepository";
 
 const SCRYPT_KEYLEN = 64;
 const SCRYPT_PARAMS = { N: 16384, r: 8, p: 1 };
@@ -109,7 +110,7 @@ export class AuthService {
   /**
    * Registers a new user with a hashed password.
    *
-   * @param email    - Normalised (lowercased) email address.
+   * @param email    - Email address, normalised (trimmed + lowercased) internally.
    * @param password - Plaintext password (min 8 chars enforced by Zod schema).
    * @param username - Display name.
    * @param role     - User role (default: 'client').
@@ -122,7 +123,7 @@ export class AuthService {
     username: string,
     role = "client"
   ): Promise<AuthTokens> {
-    const normalised = email.toLowerCase();
+    const normalised = normalizeEmail(email);
     const existing = this.db
       .prepare<[string], { id: string }>("SELECT id FROM users WHERE email = ?")
       .get(normalised);
@@ -163,7 +164,7 @@ export class AuthService {
    * @throws Error with `invalid_credentials` code on any auth failure.
    */
   async login(email: string, password: string): Promise<AuthTokens> {
-    const normalised = email.toLowerCase();
+    const normalised = normalizeEmail(email);
     const row = this.db
       .prepare<[string], UserAuthRow>(
         "SELECT id, username, email, role, password_hash, refresh_token_hash FROM users WHERE email = ?"


### PR DESCRIPTION
## Summary

`UserRepository.create()` and `findByEmail()` stored and looked up emails verbatim, so `User@x.com` and `user@x.com` could register as two distinct accounts. `AuthService.register()`/`login()` already lowercased the email but never trimmed it, and `users.email` is `UNIQUE` in SQLite with the default (case-sensitive) collation, so there was no real duplicate protection at the schema level — only whatever the caller happened to do before insert.

- Added a shared `normalizeEmail()` helper (trim + lowercase) in `src/repositories/userRepository.ts`, used by both `UserRepository` (`create`, `findByEmail`) and `AuthService` (`register`, `login`), so every write and lookup path goes through the same normalization.
- Added migration `add_unique_index_on_normalized_email` (`src/db/migrations.ts`): a `UNIQUE INDEX` on `LOWER(TRIM(email))`, so a case/whitespace-variant duplicate is rejected at the schema level even if application code ever skips normalization.
- Login's existing constant-time / anti-enumeration behavior is unchanged — only the email lookup key is normalized.
- Documented the change in `AUTH.md` (new "Email Normalization" section).

## Test plan
- [x] `userRepository.test.ts`: `create` normalizes before insert, case/whitespace-variant `create` throws (schema-level unique index), `findByEmail` is case/whitespace-insensitive, `normalizeEmail` unit tests.
- [x] `auth.service.test.ts`: register/login trim whitespace, registering a case-and-whitespace variant of an existing email is rejected with `duplicate_email`.
- [x] `migrations.test.ts`: running the full migration set enforces the unique index against a raw case-variant insert.
- [x] Genuineness check: reverted the three implementation files only, confirmed the new/modified tests fail with the expected messages, then restored the fix — all 60 tests in the three affected suites pass.
- [x] `npx eslint` on all changed files: 0 errors (pre-existing unrelated warnings only).
- [x] `npx jest src/repositories/userRepository.test.ts src/services/auth.service.test.ts src/db/migrations.test.ts`: 60/60 passing.

Note: `npm run build` currently reports ~51 pre-existing TypeScript errors unrelated to this change (in `src/api/jobs.ts`, `src/contracts/cursor.repository.ts`, `src/controllers/contracts.controller.ts`, etc.) — none of the files touched by this PR are affected; verified by diffing the build output against the file list in this PR.

Closes #630