### PR TITLE
Security/authorization deny by default

### DIFF
--- a/.deployment-state.json
+++ b/.deployment-state.json
@@ -1,5 +1,0 @@
-{
-  "activeColor": "blue",
-  "lastSwitch": 1782360129668,
-  "previousColor": "blue"
-}

--- a/AUTH.md
+++ b/AUTH.md
@@ -275,3 +275,182 @@ Revokes the current user session by clearing the refresh token hash from the dat
     "message": "Logged out successfully"
   }
   ```
+
+---
+
+## 6. Authorization Matrix (RBAC)
+
+The platform uses a **deny-by-default Role-Based Access Control (RBAC)** system enforced in `src/lib/authorization.ts`.
+
+### 6.1 Design goals
+
+| Goal | How it is enforced |
+|---|---|
+| Exhaustive at compile-time | The matrix is typed as `Record<Resource, Record<Action, Record<Role, CellValue>>>`. Adding a new `Resource` or `Action` to `types.ts` without a matrix entry is a **TypeScript compile error**. |
+| Deny-by-default at runtime | If a (resource, action, role) triplet is not found at runtime (e.g., from unsanitised input), `isAuthorized` returns `granted: false` and emits a structured `warn` log. |
+| No silent pass-through | There is no implicit fallback to "allowed". Every unresolved pair is explicitly denied and logged. |
+
+### 6.2 Types
+
+```
+Resource  = "users" | "jobs" | "proposals" | "contracts"
+          | "payments" | "reviews" | "reports" | "settings"
+
+Action    = "create" | "read" | "update" | "delete" | "list"
+
+Role      = "admin" | "auditor" | "client" | "freelancer"
+
+CellValue = false              // always denied
+          | true               // always granted
+          | { ownOnly: true }  // granted only when caller owns the record
+```
+
+### 6.3 Permission matrix
+
+Legend: `✓` = allow, `✗` = deny, `own` = allow only when `resourceOwnerId === user.id`
+
+#### `users`
+
+| Action   | admin | auditor | client | freelancer |
+|----------|-------|---------|--------|------------|
+| create   | ✓     | ✗       | ✗      | ✗          |
+| read     | ✓     | ✓       | ✗      | ✗          |
+| update   | ✓     | ✗       | ✗      | ✗          |
+| delete   | ✓     | ✗       | ✗      | ✗          |
+| list     | ✓     | ✓       | ✗      | ✗          |
+
+#### `jobs`
+
+| Action   | admin | auditor | client | freelancer |
+|----------|-------|---------|--------|------------|
+| create   | ✓     | ✗       | ✓      | ✗          |
+| read     | ✓     | ✓       | ✓      | ✓          |
+| update   | ✓     | ✗       | own    | ✗          |
+| delete   | ✓     | ✗       | own    | ✗          |
+| list     | ✓     | ✓       | ✓      | ✓          |
+
+#### `proposals`
+
+| Action   | admin | auditor | client | freelancer |
+|----------|-------|---------|--------|------------|
+| create   | ✓     | ✗       | ✗      | ✓          |
+| read     | ✓     | ✓       | own    | own        |
+| update   | ✓     | ✗       | ✗      | own        |
+| delete   | ✓     | ✗       | ✗      | own        |
+| list     | ✓     | ✓       | own    | own        |
+
+#### `contracts`
+
+| Action   | admin | auditor | client | freelancer |
+|----------|-------|---------|--------|------------|
+| create   | ✓     | ✗       | ✓      | ✗          |
+| read     | ✓     | ✓       | own    | own        |
+| update   | ✓     | ✗       | own    | own        |
+| delete   | ✓     | ✗       | ✗      | ✗          |
+| list     | ✓     | ✓       | own    | own        |
+
+#### `payments`
+
+| Action   | admin | auditor | client | freelancer |
+|----------|-------|---------|--------|------------|
+| create   | ✓     | ✗       | ✓      | ✗          |
+| read     | ✓     | ✓       | own    | own        |
+| update   | ✓     | ✗       | ✗      | ✗          |
+| delete   | ✓     | ✗       | ✗      | ✗          |
+| list     | ✓     | ✓       | own    | own        |
+
+#### `reviews`
+
+| Action   | admin | auditor | client | freelancer |
+|----------|-------|---------|--------|------------|
+| create   | ✓     | ✗       | ✓      | ✓          |
+| read     | ✓     | ✓       | ✓      | ✓          |
+| update   | ✓     | ✗       | own    | own        |
+| delete   | ✓     | ✗       | ✗      | ✗          |
+| list     | ✓     | ✓       | ✓      | ✓          |
+
+#### `reports`
+
+| Action   | admin | auditor | client | freelancer |
+|----------|-------|---------|--------|------------|
+| create   | ✓     | ✗       | ✗      | ✗          |
+| read     | ✓     | ✓       | ✗      | ✗          |
+| update   | ✓     | ✗       | ✗      | ✗          |
+| delete   | ✓     | ✗       | ✗      | ✗          |
+| list     | ✓     | ✓       | ✗      | ✗          |
+
+#### `settings`
+
+| Action   | admin | auditor | client | freelancer |
+|----------|-------|---------|--------|------------|
+| create   | ✓     | ✗       | ✗      | ✗          |
+| read     | ✓     | ✓       | own    | own        |
+| update   | ✓     | ✗       | own    | own        |
+| delete   | ✓     | ✗       | ✗      | ✗          |
+| list     | ✓     | ✓       | ✗      | ✗          |
+
+### 6.4 `isAuthorized` API
+
+```typescript
+import { isAuthorized } from "src/lib/authorization";
+
+const result = isAuthorized({
+  user:            req.user,           // { id, email, role }
+  resource:        "contracts",
+  action:          "update",
+  resourceOwnerId: contract.ownerId,   // required for ownOnly cells
+});
+
+if (!result.granted) {
+  // result.reason — human-readable explanation (safe to log, not echoed to client)
+  return res.status(403).json({ error: { code: "forbidden" } });
+}
+```
+
+`isAuthorized` never throws. It always returns `{ granted: boolean, reason: string }`.
+
+### 6.5 Deny-by-default: runtime structured log
+
+When a (resource, action, role) triplet is not found in the matrix at runtime, the function emits a `warn`-level structured log record:
+
+```json
+{
+  "timestamp": "2026-07-21T20:00:00.000Z",
+  "level": "warn",
+  "message": "authorization_deny_unresolved_resource",
+  "service": "talenttrust-backend",
+  "reason": "resource not found in permission matrix",
+  "resource": "<value>",
+  "action": "<value>",
+  "userId": "<user-id>",
+  "role": "<role>"
+}
+```
+
+Possible `message` values and their meaning:
+
+| message | trigger |
+|---|---|
+| `authorization_deny_unresolved_resource` | `resource` is not a key in `PERMISSION_MATRIX` |
+| `authorization_deny_unresolved_action` | `action` is not a key under the resource entry |
+| `authorization_deny_unresolved_role` | `role` is not a key in the action cell |
+
+### 6.6 Adding a new Resource or Action
+
+1. Add the value to the `Resource` or `Action` union in `src/lib/types.ts`.
+2. `npm run build` will immediately surface a TypeScript error in `src/lib/authorization.ts` because the `satisfies PermissionMatrix` check fails for the missing entry.
+3. Fill in the new column/row for every role. Use `DENY` (= `false`), `ALLOW` (= `true`), or `OWN` (= `{ ownOnly: true }`).
+4. Run `npm test` to verify all cells are covered.
+
+### 6.7 `isValidRole`
+
+```typescript
+import { isValidRole } from "src/lib/authorization";
+
+// Returns true only for: "admin" | "auditor" | "client" | "freelancer"
+if (!isValidRole(tokenPayload.role)) {
+  throw new ForbiddenError("Unknown role in token.");
+}
+```
+
+Used by `requireAuth` middleware to validate the `role` claim before attaching `req.user`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -392,7 +392,6 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -469,7 +468,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2517,7 +2515,6 @@
       "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2700,7 +2697,6 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -2925,7 +2921,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2974,7 +2969,6 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3157,7 +3151,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
       "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
@@ -3645,7 +3638,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -4748,7 +4740,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6365,7 +6356,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -10476,7 +10466,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10650,7 +10639,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10864,7 +10852,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11362,7 +11349,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/lib/authorization.test.ts
+++ b/src/lib/authorization.test.ts
@@ -1,0 +1,541 @@
+/**
+ * Comprehensive tests for src/lib/authorization.ts
+ *
+ * Coverage goals
+ * ──────────────
+ * 1. isValidRole         – accepts all valid roles, rejects anything else.
+ * 2. isAuthorized        – deny-by-default for unknown resource/action/role at
+ *                          runtime; explicit grants; explicit denies; ownOnly
+ *                          semantics; admin bypass.
+ * 3. Structured logging  – warn is emitted (with the right fields) for every
+ *                          unresolved pair.
+ * 4. FLAT_PERMISSION_LIST – derived list stays consistent with the matrix.
+ * 5. Matrix exhaustiveness – every known (Resource × Action) has an entry for
+ *                            every known role.
+ */
+
+import { isValidRole, isAuthorized, PERMISSION_MATRIX, FLAT_PERMISSION_LIST } from "./authorization";
+import type { Action, Resource, Role, User } from "./types";
+import * as loggerModule from "../logger";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const ALL_RESOURCES: Resource[] = [
+  "users", "jobs", "proposals", "contracts",
+  "payments", "reviews", "reports", "settings",
+];
+
+const ALL_ACTIONS: Action[] = ["create", "read", "update", "delete", "list"];
+const ALL_ROLES:   Role[]   = ["admin", "auditor", "client", "freelancer"];
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeUser(role: Role, id = "user-1"): User {
+  return { id, email: `${role}@test.com`, role };
+}
+
+// ─── isValidRole ─────────────────────────────────────────────────────────────
+
+describe("isValidRole", () => {
+  it.each(ALL_ROLES)("accepts valid role: %s", (role) => {
+    expect(isValidRole(role)).toBe(true);
+  });
+
+  it.each([
+    "superadmin", "guest", "ADMIN", "Admin", "", " ", "0", null, undefined, 42, {},
+  ])("rejects invalid value: %p", (value) => {
+    expect(isValidRole(value)).toBe(false);
+  });
+});
+
+// ─── Matrix exhaustiveness ────────────────────────────────────────────────────
+
+describe("PERMISSION_MATRIX exhaustiveness", () => {
+  it("contains every Resource", () => {
+    for (const resource of ALL_RESOURCES) {
+      expect(PERMISSION_MATRIX).toHaveProperty(resource);
+    }
+  });
+
+  it("contains every Action for every Resource", () => {
+    for (const resource of ALL_RESOURCES) {
+      for (const action of ALL_ACTIONS) {
+        expect(PERMISSION_MATRIX[resource]).toHaveProperty(action);
+      }
+    }
+  });
+
+  it("contains every Role for every Resource × Action cell", () => {
+    for (const resource of ALL_RESOURCES) {
+      for (const action of ALL_ACTIONS) {
+        for (const role of ALL_ROLES) {
+          const cell = PERMISSION_MATRIX[resource][action][role];
+          expect(cell === false || cell === true || (typeof cell === "object" && cell.ownOnly === true))
+            .toBe(true);
+        }
+      }
+    }
+  });
+});
+
+// ─── Deny-by-default: runtime unresolved pairs ───────────────────────────────
+
+describe("isAuthorized – deny-by-default for unresolved pairs", () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    // Spy on the Logger's warn method via the module-level logger instance.
+    // createLogger returns a Logger; we intercept the prototype.
+    warnSpy = jest.spyOn(loggerModule.Logger.prototype, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("denies an unknown resource and emits a structured warn", () => {
+    const result = isAuthorized({
+      user: makeUser("admin"),
+      resource: "invoices" as Resource,
+      action: "read",
+    });
+
+    expect(result.granted).toBe(false);
+    expect(result.reason).toMatch(/not registered in the permission matrix/i);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [message, fields] = warnSpy.mock.calls[0] as [string, Record<string, unknown>];
+    expect(message).toBe("authorization_deny_unresolved_resource");
+    expect(fields).toMatchObject({
+      resource: "invoices",
+      action: "read",
+      role: "admin",
+    });
+  });
+
+  it("denies an unknown action on a valid resource and emits a structured warn", () => {
+    const result = isAuthorized({
+      user: makeUser("admin"),
+      resource: "jobs",
+      action: "execute" as Action,
+    });
+
+    expect(result.granted).toBe(false);
+    expect(result.reason).toMatch(/not registered in the permission matrix/i);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [message, fields] = warnSpy.mock.calls[0] as [string, Record<string, unknown>];
+    expect(message).toBe("authorization_deny_unresolved_action");
+    expect(fields).toMatchObject({ resource: "jobs", action: "execute" });
+  });
+
+  it("denies an unknown role for a valid resource/action and emits a structured warn", () => {
+    const result = isAuthorized({
+      user: { id: "u1", email: "x@y.com", role: "superadmin" as Role },
+      resource: "jobs",
+      action: "read",
+    });
+
+    expect(result.granted).toBe(false);
+    expect(result.reason).toMatch(/not registered in the permission matrix/i);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const [message, fields] = warnSpy.mock.calls[0] as [string, Record<string, unknown>];
+    expect(message).toBe("authorization_deny_unresolved_role");
+    expect(fields).toMatchObject({ role: "superadmin" });
+  });
+
+  it("does NOT emit a warn for a legitimate deny (false cell)", () => {
+    // freelancer cannot create jobs → cell is false, not unresolved
+    const result = isAuthorized({
+      user: makeUser("freelancer"),
+      resource: "jobs",
+      action: "create",
+    });
+
+    expect(result.granted).toBe(false);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Admin: full access + ownOnly bypass ─────────────────────────────────────
+
+describe("isAuthorized – admin role", () => {
+  it("grants admin access to every resource/action combination", () => {
+    const admin = makeUser("admin");
+    for (const resource of ALL_RESOURCES) {
+      for (const action of ALL_ACTIONS) {
+        const { granted } = isAuthorized({ user: admin, resource, action });
+        expect(granted).toBe(true);
+      }
+    }
+  });
+
+  it("grants admin access to ownOnly resources without providing resourceOwnerId", () => {
+    // contracts.read for admin is a plain ALLOW cell, so "Permission granted." is the expected reason.
+    // The "Admin bypass." path fires only when the cell is { ownOnly: true }, which admin never hits
+    // because their cells are all ALLOW. Verify that granted is true regardless.
+    const result = isAuthorized({
+      user: makeUser("admin"),
+      resource: "contracts",
+      action: "read",
+    });
+    expect(result.granted).toBe(true);
+    expect(result.reason).toBe("Permission granted.");
+  });
+
+  it("grants admin access to ownOnly resources even when resourceOwnerId differs", () => {
+    // Same reasoning: admin cells are ALLOW, not OWN, so the admin bypass short-circuit does not fire.
+    // Confirm that admin can update a contract owned by someone else and gets granted.
+    const admin = makeUser("admin", "admin-1");
+    const result = isAuthorized({
+      user: admin,
+      resource: "contracts",
+      action: "update",
+      resourceOwnerId: "someone-else",
+    });
+    expect(result.granted).toBe(true);
+    expect(result.reason).toBe("Permission granted.");
+  });
+});
+
+// ─── Auditor: read-only compliance role ──────────────────────────────────────
+
+describe("isAuthorized – auditor role", () => {
+  it("grants auditor read access to every resource", () => {
+    const auditor = makeUser("auditor");
+    for (const resource of ALL_RESOURCES) {
+      const { granted } = isAuthorized({ user: auditor, resource, action: "read" });
+      expect(granted).toBe(true);
+    }
+  });
+
+  it("grants auditor list access to every resource", () => {
+    const auditor = makeUser("auditor");
+    for (const resource of ALL_RESOURCES) {
+      const { granted } = isAuthorized({ user: auditor, resource, action: "list" });
+      expect(granted).toBe(true);
+    }
+  });
+
+  it("denies auditor create on every resource", () => {
+    const auditor = makeUser("auditor");
+    for (const resource of ALL_RESOURCES) {
+      const { granted } = isAuthorized({ user: auditor, resource, action: "create" });
+      expect(granted).toBe(false);
+    }
+  });
+
+  it("denies auditor update on every resource", () => {
+    const auditor = makeUser("auditor");
+    for (const resource of ALL_RESOURCES) {
+      const { granted } = isAuthorized({ user: auditor, resource, action: "update" });
+      expect(granted).toBe(false);
+    }
+  });
+
+  it("denies auditor delete on every resource", () => {
+    const auditor = makeUser("auditor");
+    for (const resource of ALL_RESOURCES) {
+      const { granted } = isAuthorized({ user: auditor, resource, action: "delete" });
+      expect(granted).toBe(false);
+    }
+  });
+});
+
+// ─── Client role ─────────────────────────────────────────────────────────────
+
+describe("isAuthorized – client role", () => {
+  const client = makeUser("client", "client-1");
+
+  // Explicit grants (non-ownOnly)
+  it("grants client create on jobs", () => {
+    expect(isAuthorized({ user: client, resource: "jobs", action: "create" }).granted).toBe(true);
+  });
+
+  it("grants client read on jobs (public)", () => {
+    expect(isAuthorized({ user: client, resource: "jobs", action: "read" }).granted).toBe(true);
+  });
+
+  it("grants client list on jobs (public)", () => {
+    expect(isAuthorized({ user: client, resource: "jobs", action: "list" }).granted).toBe(true);
+  });
+
+  it("grants client create on payments", () => {
+    expect(isAuthorized({ user: client, resource: "payments", action: "create" }).granted).toBe(true);
+  });
+
+  it("grants client create on reviews", () => {
+    expect(isAuthorized({ user: client, resource: "reviews", action: "create" }).granted).toBe(true);
+  });
+
+  it("grants client read on reviews (public)", () => {
+    expect(isAuthorized({ user: client, resource: "reviews", action: "read" }).granted).toBe(true);
+  });
+
+  // Explicit denies
+  it("denies client create on users", () => {
+    expect(isAuthorized({ user: client, resource: "users", action: "create" }).granted).toBe(false);
+  });
+
+  it("denies client create on reports", () => {
+    expect(isAuthorized({ user: client, resource: "reports", action: "create" }).granted).toBe(false);
+  });
+
+  it("denies client read on reports", () => {
+    expect(isAuthorized({ user: client, resource: "reports", action: "read" }).granted).toBe(false);
+  });
+
+  it("denies client delete on contracts", () => {
+    expect(isAuthorized({ user: client, resource: "contracts", action: "delete" }).granted).toBe(false);
+  });
+
+  it("denies client create on proposals (freelancer-only)", () => {
+    expect(isAuthorized({ user: client, resource: "proposals", action: "create" }).granted).toBe(false);
+  });
+
+  // ownOnly semantics
+  it("grants client update on jobs they own", () => {
+    expect(isAuthorized({
+      user: client, resource: "jobs", action: "update", resourceOwnerId: "client-1",
+    }).granted).toBe(true);
+  });
+
+  it("denies client update on jobs owned by someone else", () => {
+    const result = isAuthorized({
+      user: client, resource: "jobs", action: "update", resourceOwnerId: "other-user",
+    });
+    expect(result.granted).toBe(false);
+    expect(result.reason).toMatch(/owned by a different user/i);
+  });
+
+  it("denies client update on jobs when resourceOwnerId is not provided", () => {
+    const result = isAuthorized({ user: client, resource: "jobs", action: "update" });
+    expect(result.granted).toBe(false);
+    expect(result.reason).toMatch(/ownership could not be verified/i);
+  });
+});
+
+// ─── Freelancer role ──────────────────────────────────────────────────────────
+
+describe("isAuthorized – freelancer role", () => {
+  const freelancer = makeUser("freelancer", "free-1");
+
+  // Explicit grants
+  it("grants freelancer read on jobs (public)", () => {
+    expect(isAuthorized({ user: freelancer, resource: "jobs", action: "read" }).granted).toBe(true);
+  });
+
+  it("grants freelancer list on jobs (public)", () => {
+    expect(isAuthorized({ user: freelancer, resource: "jobs", action: "list" }).granted).toBe(true);
+  });
+
+  it("grants freelancer create on proposals", () => {
+    expect(isAuthorized({ user: freelancer, resource: "proposals", action: "create" }).granted).toBe(true);
+  });
+
+  it("grants freelancer create on reviews", () => {
+    expect(isAuthorized({ user: freelancer, resource: "reviews", action: "create" }).granted).toBe(true);
+  });
+
+  it("grants freelancer read on reviews (public)", () => {
+    expect(isAuthorized({ user: freelancer, resource: "reviews", action: "read" }).granted).toBe(true);
+  });
+
+  // Explicit denies
+  it("denies freelancer create on jobs", () => {
+    expect(isAuthorized({ user: freelancer, resource: "jobs", action: "create" }).granted).toBe(false);
+  });
+
+  it("denies freelancer create on contracts", () => {
+    expect(isAuthorized({ user: freelancer, resource: "contracts", action: "create" }).granted).toBe(false);
+  });
+
+  it("denies freelancer delete on contracts", () => {
+    expect(isAuthorized({ user: freelancer, resource: "contracts", action: "delete" }).granted).toBe(false);
+  });
+
+  it("denies freelancer create on payments", () => {
+    expect(isAuthorized({ user: freelancer, resource: "payments", action: "create" }).granted).toBe(false);
+  });
+
+  it("denies freelancer any action on reports", () => {
+    for (const action of ALL_ACTIONS) {
+      expect(isAuthorized({ user: freelancer, resource: "reports", action }).granted).toBe(false);
+    }
+  });
+
+  it("denies freelancer any action on users", () => {
+    for (const action of ALL_ACTIONS) {
+      expect(isAuthorized({ user: freelancer, resource: "users", action }).granted).toBe(false);
+    }
+  });
+
+  // ownOnly semantics
+  it("grants freelancer read on their own proposal", () => {
+    expect(isAuthorized({
+      user: freelancer, resource: "proposals", action: "read", resourceOwnerId: "free-1",
+    }).granted).toBe(true);
+  });
+
+  it("denies freelancer read on a proposal they do not own", () => {
+    const result = isAuthorized({
+      user: freelancer, resource: "proposals", action: "read", resourceOwnerId: "other-free",
+    });
+    expect(result.granted).toBe(false);
+    expect(result.reason).toMatch(/owned by a different user/i);
+  });
+
+  it("denies freelancer read on a proposal when no resourceOwnerId given", () => {
+    const result = isAuthorized({ user: freelancer, resource: "proposals", action: "read" });
+    expect(result.granted).toBe(false);
+    expect(result.reason).toMatch(/ownership could not be verified/i);
+  });
+
+  it("grants freelancer read on own contract", () => {
+    expect(isAuthorized({
+      user: freelancer, resource: "contracts", action: "read", resourceOwnerId: "free-1",
+    }).granted).toBe(true);
+  });
+
+  it("grants freelancer update on own settings", () => {
+    expect(isAuthorized({
+      user: freelancer, resource: "settings", action: "update", resourceOwnerId: "free-1",
+    }).granted).toBe(true);
+  });
+});
+
+// ─── ownOnly edge cases ───────────────────────────────────────────────────────
+
+describe("isAuthorized – ownOnly edge cases", () => {
+  it("denies when resourceOwnerId is an empty string (not equal to user.id)", () => {
+    const user = makeUser("client", "client-1");
+    const result = isAuthorized({
+      user, resource: "jobs", action: "update", resourceOwnerId: "",
+    });
+    expect(result.granted).toBe(false);
+    expect(result.reason).toMatch(/owned by a different user/i);
+  });
+
+  it("denies when user.id is empty and resourceOwnerId is non-empty", () => {
+    const user: User = { id: "", email: "c@t.com", role: "client" };
+    const result = isAuthorized({
+      user, resource: "jobs", action: "update", resourceOwnerId: "some-owner",
+    });
+    expect(result.granted).toBe(false);
+  });
+});
+
+// ─── AuthorizationResult shape ────────────────────────────────────────────────
+
+describe("isAuthorized – result shape", () => {
+  it("always returns { granted: boolean, reason: string }", () => {
+    const cases: Parameters<typeof isAuthorized>[0][] = [
+      { user: makeUser("admin"),      resource: "users",    action: "create" },
+      { user: makeUser("auditor"),    resource: "reports",  action: "read"   },
+      { user: makeUser("client"),     resource: "jobs",     action: "create" },
+      { user: makeUser("freelancer"), resource: "jobs",     action: "create" },
+    ];
+    for (const input of cases) {
+      const result = isAuthorized(input);
+      expect(typeof result.granted).toBe("boolean");
+      expect(typeof result.reason).toBe("string");
+      expect(result.reason.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns reason 'Permission granted.' for a flat ALLOW cell", () => {
+    const { reason } = isAuthorized({ user: makeUser("admin"), resource: "users", action: "create" });
+    expect(reason).toBe("Permission granted.");
+  });
+
+  it("returns reason containing role/action/resource for a false cell", () => {
+    const { reason } = isAuthorized({
+      user: makeUser("freelancer"), resource: "jobs", action: "create",
+    });
+    expect(reason).toMatch(/freelancer/);
+    expect(reason).toMatch(/create/);
+    expect(reason).toMatch(/jobs/);
+  });
+});
+
+// ─── FLAT_PERMISSION_LIST consistency ────────────────────────────────────────
+
+describe("FLAT_PERMISSION_LIST", () => {
+  it("is a non-empty readonly array", () => {
+    expect(Array.isArray(FLAT_PERMISSION_LIST)).toBe(true);
+    expect(FLAT_PERMISSION_LIST.length).toBeGreaterThan(0);
+  });
+
+  it("never contains an entry whose matrix cell is false", () => {
+    for (const entry of FLAT_PERMISSION_LIST) {
+      const cell = PERMISSION_MATRIX[entry.resource][entry.action][entry.role];
+      expect(cell).not.toBe(false);
+    }
+  });
+
+  it("marks ownOnly correctly for every entry", () => {
+    for (const entry of FLAT_PERMISSION_LIST) {
+      const cell = PERMISSION_MATRIX[entry.resource][entry.action][entry.role];
+      if (typeof cell === "object" && cell.ownOnly) {
+        expect(entry.ownOnly).toBe(true);
+      } else {
+        expect(entry.ownOnly).toBeUndefined();
+      }
+    }
+  });
+
+  it("contains an entry for admin on every resource/action", () => {
+    for (const resource of ALL_RESOURCES) {
+      for (const action of ALL_ACTIONS) {
+        const found = FLAT_PERMISSION_LIST.some(
+          (e) => e.role === "admin" && e.resource === resource && e.action === action
+        );
+        expect(found).toBe(true);
+      }
+    }
+  });
+
+  it("does not duplicate (role, resource, action) triplets", () => {
+    const seen = new Set<string>();
+    for (const entry of FLAT_PERMISSION_LIST) {
+      const key = `${entry.role}:${entry.resource}:${entry.action}`;
+      expect(seen.has(key)).toBe(false);
+      seen.add(key);
+    }
+  });
+});
+
+// ─── Security: response must not leak internal IDs ───────────────────────────
+
+describe("isAuthorized – security: no internal ID leakage in reason strings", () => {
+  it("does not echo user.id into the reason on a deny", () => {
+    const user = makeUser("client", "secret-internal-id-xyz");
+    const { reason } = isAuthorized({ user, resource: "users", action: "create" });
+    expect(reason).not.toContain("secret-internal-id-xyz");
+  });
+
+  it("does not echo resourceOwnerId into the reason on an ownership deny", () => {
+    const user = makeUser("client", "client-id");
+    const { reason } = isAuthorized({
+      user, resource: "jobs", action: "update", resourceOwnerId: "sensitive-owner-id",
+    });
+    expect(reason).not.toContain("sensitive-owner-id");
+    expect(reason).not.toContain("client-id");
+  });
+
+  it("does not echo unknown resource name into the structured log fields beyond what is intentional", () => {
+    // The reason string may contain the resource name (by design — it's the
+    // untrusted value that caused the deny). Verify the warn fields include
+    // the resource for auditability but the reason is clearly framed as a deny.
+    const warnSpy = jest.spyOn(loggerModule.Logger.prototype, "warn").mockImplementation(() => {});
+    const { granted, reason } = isAuthorized({
+      user: makeUser("admin"),
+      resource: "malicious-resource" as Resource,
+      action: "read",
+    });
+    expect(granted).toBe(false);
+    expect(reason).toMatch(/Explicit deny/);
+    warnSpy.mockRestore();
+  });
+});

--- a/src/lib/authorization.ts
+++ b/src/lib/authorization.ts
@@ -1,4 +1,9 @@
 import type { Action, Permission, Resource, Role, User } from "./types";
+import { createLogger } from "../logger";
+
+// ─── Internal logger ─────────────────────────────────────────────────────────
+
+const log = createLogger({ module: "authorization" });
 
 // ─── Role allowlist ───────────────────────────────────────────────────────────
 
@@ -6,91 +11,139 @@ const ALL_ROLES: ReadonlySet<string> = new Set<Role>(["admin", "auditor", "clien
 
 /**
  * Type-guard / validator for role claim values coming out of a JWT.
- * Returns true only for the three platform roles; rejects any other string.
+ * Returns true only for the known platform roles; rejects any other string.
  */
 export function isValidRole(value: unknown): value is Role {
   return typeof value === "string" && ALL_ROLES.has(value);
 }
 
-// ─── Permission matrix ────────────────────────────────────────────────────────
+// ─── Matrix cell types ────────────────────────────────────────────────────────
 
 /**
- * The authoritative permission matrix for the platform.
+ * Per-cell value in the permission matrix.
  *
- * Reads top-to-bottom:
- *   "An <role> may <action> <resource> [only when they own the record]."
- *
- * Design decisions:
- *  - admin has unrestricted access to every resource and action.
- *  - client can manage jobs/contracts they own, read public proposals, pay.
- *  - freelancer can propose on jobs, manage their own proposals/contracts.
- *  - Reviews are readable by all roles but writable only by their author.
+ * - `false`           → always denied
+ * - `true`            → always granted
+ * - `{ ownOnly: true }` → granted only when the caller owns the record
  */
-const CLIENT_MATRIX: readonly Permission[] = [
-  // ── client ────────────────────────────────────────────────────────────────
-  { role: "client", resource: "jobs",      action: "create"                 },
-  { role: "client", resource: "jobs",      action: "read"                   },
-  { role: "client", resource: "jobs",      action: "update", ownOnly: true  },
-  { role: "client", resource: "jobs",      action: "delete", ownOnly: true  },
-  { role: "client", resource: "jobs",      action: "list"                   },
-  { role: "client", resource: "proposals", action: "read",   ownOnly: true  },
-  { role: "client", resource: "proposals", action: "list",   ownOnly: true  },
-  { role: "client", resource: "contracts", action: "create"                 },
-  { role: "client", resource: "contracts", action: "read",   ownOnly: true  },
-  { role: "client", resource: "contracts", action: "update", ownOnly: true  },
-  { role: "client", resource: "contracts", action: "list",   ownOnly: true  },
-  { role: "client", resource: "payments",  action: "create"                 },
-  { role: "client", resource: "payments",  action: "read",   ownOnly: true  },
-  { role: "client", resource: "payments",  action: "list",   ownOnly: true  },
-  { role: "client", resource: "reviews",   action: "create"                 },
-  { role: "client", resource: "reviews",   action: "read"                   },
-  { role: "client", resource: "reviews",   action: "update", ownOnly: true  },
-  { role: "client", resource: "reviews",   action: "list"                   },
-  { role: "client", resource: "settings",  action: "read",   ownOnly: true  },
-  { role: "client", resource: "settings",  action: "update", ownOnly: true  },
-];
+type CellValue = false | true | { ownOnly: true };
 
-const FREELANCER_MATRIX: readonly Permission[] = [
-  // ── freelancer ────────────────────────────────────────────────────────────
-  { role: "freelancer", resource: "jobs",      action: "read"                   },
-  { role: "freelancer", resource: "jobs",      action: "list"                   },
-  { role: "freelancer", resource: "proposals", action: "create"                 },
-  { role: "freelancer", resource: "proposals", action: "read",   ownOnly: true  },
-  { role: "freelancer", resource: "proposals", action: "update", ownOnly: true  },
-  { role: "freelancer", resource: "proposals", action: "delete", ownOnly: true  },
-  { role: "freelancer", resource: "proposals", action: "list",   ownOnly: true  },
-  { role: "freelancer", resource: "contracts", action: "read",   ownOnly: true  },
-  { role: "freelancer", resource: "contracts", action: "update", ownOnly: true  },
-  { role: "freelancer", resource: "contracts", action: "list",   ownOnly: true  },
-  { role: "freelancer", resource: "payments",  action: "read",   ownOnly: true  },
-  { role: "freelancer", resource: "payments",  action: "list",   ownOnly: true  },
-  { role: "freelancer", resource: "reviews",   action: "create"                 },
-  { role: "freelancer", resource: "reviews",   action: "read"                   },
-  { role: "freelancer", resource: "reviews",   action: "update", ownOnly: true  },
-  { role: "freelancer", resource: "reviews",   action: "list"                   },
-  { role: "freelancer", resource: "settings",  action: "read",   ownOnly: true  },
-  { role: "freelancer", resource: "settings",  action: "update", ownOnly: true  },
-];
+/**
+ * The full matrix type.
+ *
+ * Using `Record<Resource, Record<Action, Record<Role, CellValue>>>` forces
+ * TypeScript to flag a compile-time error whenever a new `Resource` or
+ * `Action` value is added to `types.ts` without a corresponding entry here.
+ */
+type PermissionMatrix = Record<Resource, Record<Action, Record<Role, CellValue>>>;
 
-const ADMIN_MATRIX: readonly Permission[] = (
-  ["users", "jobs", "proposals", "contracts", "payments", "reviews", "reports", "settings"] as Resource[]
-).flatMap((resource) =>
-  (["create", "read", "update", "delete", "list"] as Action[]).map(
-    (action): Permission => ({ role: "admin", resource, action })
-  )
-);
+// Convenience aliases
+const DENY = false as const;
+const ALLOW = true as const;
+const OWN = { ownOnly: true } as const;
 
-export const PERMISSION_MATRIX: readonly Permission[] = ADMIN_MATRIX.concat(CLIENT_MATRIX).concat(FREELANCER_MATRIX);
+// ─── Permission matrix ────────────────────────────────────────────────────────
+/**
+ * The authoritative, exhaustive permission matrix for the platform.
+ *
+ * Every (Resource × Action × Role) triplet has an explicit value. A missing
+ * triplet is a TypeScript compile error, ensuring that adding a new
+ * Resource or Action to `types.ts` immediately surfaces here.
+ *
+ * Design decisions
+ * ─────────────────
+ * - admin has unrestricted access to every resource and action.
+ * - auditor has read/list access to all resources (read-only compliance role).
+ * - client can manage jobs/contracts they own, read public proposals, pay.
+ * - freelancer can propose on jobs, manage their own proposals/contracts.
+ * - Reviews are readable by all roles but writable only by their author.
+ * - users resource (user management) is admin-only.
+ * - reports resource is admin/auditor only.
+ * - settings are self-service (read/update own record only).
+ */
+export const PERMISSION_MATRIX: PermissionMatrix = {
+  // ── users ──────────────────────────────────────────────────────────────────
+  users: {
+    create: { admin: ALLOW,  auditor: DENY,  client: DENY, freelancer: DENY },
+    read:   { admin: ALLOW,  auditor: ALLOW, client: DENY, freelancer: DENY },
+    update: { admin: ALLOW,  auditor: DENY,  client: DENY, freelancer: DENY },
+    delete: { admin: ALLOW,  auditor: DENY,  client: DENY, freelancer: DENY },
+    list:   { admin: ALLOW,  auditor: ALLOW, client: DENY, freelancer: DENY },
+  },
+
+  // ── jobs ───────────────────────────────────────────────────────────────────
+  jobs: {
+    create: { admin: ALLOW,  auditor: DENY,  client: ALLOW,    freelancer: DENY },
+    read:   { admin: ALLOW,  auditor: ALLOW, client: ALLOW,    freelancer: ALLOW },
+    update: { admin: ALLOW,  auditor: DENY,  client: OWN,      freelancer: DENY },
+    delete: { admin: ALLOW,  auditor: DENY,  client: OWN,      freelancer: DENY },
+    list:   { admin: ALLOW,  auditor: ALLOW, client: ALLOW,    freelancer: ALLOW },
+  },
+
+  // ── proposals ──────────────────────────────────────────────────────────────
+  proposals: {
+    create: { admin: ALLOW,  auditor: DENY,  client: DENY,     freelancer: ALLOW },
+    read:   { admin: ALLOW,  auditor: ALLOW, client: OWN,      freelancer: OWN },
+    update: { admin: ALLOW,  auditor: DENY,  client: DENY,     freelancer: OWN },
+    delete: { admin: ALLOW,  auditor: DENY,  client: DENY,     freelancer: OWN },
+    list:   { admin: ALLOW,  auditor: ALLOW, client: OWN,      freelancer: OWN },
+  },
+
+  // ── contracts ──────────────────────────────────────────────────────────────
+  contracts: {
+    create: { admin: ALLOW,  auditor: DENY,  client: ALLOW,    freelancer: DENY },
+    read:   { admin: ALLOW,  auditor: ALLOW, client: OWN,      freelancer: OWN },
+    update: { admin: ALLOW,  auditor: DENY,  client: OWN,      freelancer: OWN },
+    delete: { admin: ALLOW,  auditor: DENY,  client: DENY,     freelancer: DENY },
+    list:   { admin: ALLOW,  auditor: ALLOW, client: OWN,      freelancer: OWN },
+  },
+
+  // ── payments ───────────────────────────────────────────────────────────────
+  payments: {
+    create: { admin: ALLOW,  auditor: DENY,  client: ALLOW,    freelancer: DENY },
+    read:   { admin: ALLOW,  auditor: ALLOW, client: OWN,      freelancer: OWN },
+    update: { admin: ALLOW,  auditor: DENY,  client: DENY,     freelancer: DENY },
+    delete: { admin: ALLOW,  auditor: DENY,  client: DENY,     freelancer: DENY },
+    list:   { admin: ALLOW,  auditor: ALLOW, client: OWN,      freelancer: OWN },
+  },
+
+  // ── reviews ────────────────────────────────────────────────────────────────
+  reviews: {
+    create: { admin: ALLOW,  auditor: DENY,  client: ALLOW,    freelancer: ALLOW },
+    read:   { admin: ALLOW,  auditor: ALLOW, client: ALLOW,    freelancer: ALLOW },
+    update: { admin: ALLOW,  auditor: DENY,  client: OWN,      freelancer: OWN },
+    delete: { admin: ALLOW,  auditor: DENY,  client: DENY,     freelancer: DENY },
+    list:   { admin: ALLOW,  auditor: ALLOW, client: ALLOW,    freelancer: ALLOW },
+  },
+
+  // ── reports ────────────────────────────────────────────────────────────────
+  reports: {
+    create: { admin: ALLOW,  auditor: DENY,  client: DENY,     freelancer: DENY },
+    read:   { admin: ALLOW,  auditor: ALLOW, client: DENY,     freelancer: DENY },
+    update: { admin: ALLOW,  auditor: DENY,  client: DENY,     freelancer: DENY },
+    delete: { admin: ALLOW,  auditor: DENY,  client: DENY,     freelancer: DENY },
+    list:   { admin: ALLOW,  auditor: ALLOW, client: DENY,     freelancer: DENY },
+  },
+
+  // ── settings ───────────────────────────────────────────────────────────────
+  settings: {
+    create: { admin: ALLOW,  auditor: DENY,  client: DENY,     freelancer: DENY },
+    read:   { admin: ALLOW,  auditor: ALLOW, client: OWN,      freelancer: OWN },
+    update: { admin: ALLOW,  auditor: DENY,  client: OWN,      freelancer: OWN },
+    delete: { admin: ALLOW,  auditor: DENY,  client: DENY,     freelancer: DENY },
+    list:   { admin: ALLOW,  auditor: ALLOW, client: DENY,     freelancer: DENY },
+  },
+} satisfies PermissionMatrix;
 
 // ─── isAuthorized ─────────────────────────────────────────────────────────────
 
 interface AuthorizationInput {
-  user:             User;
-  resource:         Resource;
-  action:           Action;
+  user: User;
+  resource: Resource;
+  action: Action;
   /**
    * The id of the user who owns the target record.
-   * Required when the matching permission entry has `ownOnly: true`.
+   * Required when the matching cell has `ownOnly: true`.
    * For admin the value is ignored — admins always pass.
    */
   resourceOwnerId?: string;
@@ -98,21 +151,26 @@ interface AuthorizationInput {
 
 interface AuthorizationResult {
   granted: boolean;
-  reason:  string;
+  reason: string;
 }
 
 /**
  * Evaluates whether `user` may perform `action` on `resource`.
  *
- * Logic:
- *  1. Find the matching permission entry (role + resource + action).
- *  2. If no entry exists → denied.
- *  3. If the entry has no `ownOnly` flag → granted.
- *  4. If `ownOnly: true` and the user is an admin → granted (admins are exempt).
- *  5. If `ownOnly: true` and `resourceOwnerId` is absent → denied
- *     (caller did not supply a resolver, treat as no-access).
- *  6. If `ownOnly: true` and `resourceOwnerId !== user.id` → denied.
- *  7. Otherwise → granted.
+ * Logic
+ * ──────
+ * 1. Look up the cell in the exhaustive PERMISSION_MATRIX.
+ *    - If the runtime (resource, action, role) triplet falls outside the
+ *      matrix (e.g., due to unsanitised input), a structured `warn` is
+ *      emitted and the request is explicitly denied. This is the
+ *      deny-by-default safety net.
+ * 2. `false` cell → denied.
+ * 3. `true` cell → granted.
+ * 4. `{ ownOnly: true }` cell:
+ *    a. Admin is always exempt from ownership checks → granted.
+ *    b. No `resourceOwnerId` supplied → denied.
+ *    c. `resourceOwnerId !== user.id` → denied.
+ *    d. Otherwise → granted (owner confirmed).
  */
 export function isAuthorized({
   user,
@@ -120,26 +178,72 @@ export function isAuthorized({
   action,
   resourceOwnerId,
 }: AuthorizationInput): AuthorizationResult {
-  const entry = PERMISSION_MATRIX.find(
-    (p) => p.role === user.role && p.resource === resource && p.action === action
-  );
-
-  if (!entry) {
-    console.log('Client matrix items in Jest:', JSON.stringify(PERMISSION_MATRIX.filter(p => p.role === 'client')));
-    return { granted: false, reason: `Role '${user.role}' may not '${action}' '${resource}'.` };
+  // ── Runtime deny-by-default safety net ───────────────────────────────────
+  // The matrix is exhaustive at compile-time, but callers may pass values that
+  // have been cast from unvalidated input (e.g., from a request parameter).
+  const resourceEntry = (PERMISSION_MATRIX as Record<string, unknown>)[resource];
+  if (resourceEntry === undefined) {
+    log.warn("authorization_deny_unresolved_resource", {
+      reason: "resource not found in permission matrix",
+      resource,
+      action,
+      userId: user.id,
+      role: user.role,
+    });
+    return {
+      granted: false,
+      reason: `Explicit deny: resource '${resource}' is not registered in the permission matrix.`,
+    };
   }
 
-  // No ownership restriction on this entry.
-  if (!entry.ownOnly) {
+  const actionEntry = (resourceEntry as Record<string, unknown>)[action];
+  if (actionEntry === undefined) {
+    log.warn("authorization_deny_unresolved_action", {
+      reason: "action not found in permission matrix",
+      resource,
+      action,
+      userId: user.id,
+      role: user.role,
+    });
+    return {
+      granted: false,
+      reason: `Explicit deny: action '${action}' on resource '${resource}' is not registered in the permission matrix.`,
+    };
+  }
+
+  const cell = (actionEntry as Record<string, CellValue>)[user.role];
+  if (cell === undefined) {
+    log.warn("authorization_deny_unresolved_role", {
+      reason: "role not found in permission matrix cell",
+      resource,
+      action,
+      userId: user.id,
+      role: user.role,
+    });
+    return {
+      granted: false,
+      reason: `Explicit deny: role '${user.role}' is not registered in the permission matrix.`,
+    };
+  }
+
+  // ── Matrix cell evaluation ────────────────────────────────────────────────
+  if (cell === false) {
+    return {
+      granted: false,
+      reason: `Role '${user.role}' may not '${action}' '${resource}'.`,
+    };
+  }
+
+  if (cell === true) {
     return { granted: true, reason: "Permission granted." };
   }
 
+  // ── ownOnly branch ────────────────────────────────────────────────────────
   // Admins are always exempt from ownership checks.
   if (user.role === "admin") {
     return { granted: true, reason: "Admin bypass." };
   }
 
-  // Ownership check required but no owner id was resolved.
   if (resourceOwnerId === undefined) {
     return { granted: false, reason: "Ownership could not be verified." };
   }
@@ -150,3 +254,25 @@ export function isAuthorized({
 
   return { granted: true, reason: "Permission granted (owner)." };
 }
+
+// ─── Legacy flat-array export ─────────────────────────────────────────────────
+//
+// Consumers that previously imported `PERMISSION_MATRIX` as a flat `Permission[]`
+// can still do so via this derived export. It is generated from the exhaustive
+// matrix so it stays in sync automatically.
+
+export const FLAT_PERMISSION_LIST: readonly Permission[] = (
+  Object.entries(PERMISSION_MATRIX) as [Resource, Record<Action, Record<Role, CellValue>>][]
+).flatMap(([resource, actions]) =>
+  (Object.entries(actions) as [Action, Record<Role, CellValue>][]).flatMap(
+    ([action, roles]) =>
+      (Object.entries(roles) as [Role, CellValue][])
+        .filter(([, cell]) => cell !== false)
+        .map(([role, cell]): Permission => ({
+          role,
+          resource,
+          action,
+          ...(typeof cell === "object" && cell.ownOnly ? { ownOnly: true } : {}),
+        }))
+  )
+);


### PR DESCRIPTION
 What changed
  
  src/lib/authorization.ts
  
  - PERMISSION_MATRIX is now typed as Record<Resource, Record<Action,
  Record<Role, CellValue>>> with satisfies PermissionMatrix. Adding a new
  Resource or Action to types.ts without filling in the matrix is a TypeScript
  compile error.
  - Runtime deny-by-default: if unsanitised input produces an unknown resource,
  action, or role at runtime, isAuthorized returns { granted: false } and emits
  a structured warn log (authorization_deny_unresolved_resource / _action /
  _role) with resource, action, userId, role fields.
  - Removed the accidental console.log that leaked matrix contents in the deny
  path.
  - FLAT_PERMISSION_LIST derived automatically from the matrix for backward
  compatibility.
  
  src/lib/authorization.test.ts (new, 73 tests)
  
  - isValidRole accept/reject coverage
  - Matrix exhaustiveness assertions (every Resource × Action × Role has a cell)
  - Deny-by-default with Logger.prototype.warn spy verifying message and fields
  - Per-role grant/deny/ownOnly coverage for admin, auditor, client, freelancer
  - FLAT_PERMISSION_LIST consistency checks
  - Security: no user ID or owner ID leakage in reason strings
  
  AUTH.md — new Section 6 with full permission tables, isAuthorized API, log
  format reference, and step-by-step guide for adding new Resources/Actions.
 
closes #641 