### PR TITLE
test(hooks): add unit tests for escrow lifecycle hook dispatch

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -39,3 +39,30 @@ Use environment variables to configure email transports:
 - Web notifications validate `userId` for basic sanity; authorization (session matching) should be enforced by callers to prevent IDOR.
 - Email addresses are redacted in logs to avoid leaking PII.
 - Secrets and API keys are redacted in logs.
+
+## Escrow Lifecycle Hook Dispatch
+The backend includes centralized dispatch hooks (`EscrowHooks`) that fan out escrow lifecycle events concurrently to all configured notification channels (e.g. Email and Web notification channels).
+
+### Lifecycle State Transitions
+The `EscrowHooks.onStateTransition` hook maps contract status changes to specific `KeyEscrowEvent` types:
+
+| Transition Type | Old Status | New Status | Event Triggered |
+|---|---|---|---|
+| **Funded** | `draft` | `active` | `KeyEscrowEvent.FUNDS_DEPOSITED` |
+| **Released** | `active` | `completed` | `KeyEscrowEvent.ESCROW_RESOLVED` |
+| **Disputed** | `active` | `disputed` | `KeyEscrowEvent.DISPUTE_RAISED` |
+
+Any other state transitions or unchanged statuses (e.g. `active` -> `active`) are ignored and do not trigger any notifications.
+
+### Payload Shape
+The event payload must conform to the `EscrowEventPayload` interface:
+```typescript
+interface EscrowEventPayload {
+  contractId: string; // The contract UUID
+  userEmail: string;  // PII-sensitive email of the recipient (redacted in logs)
+  userId: string;     // Recipient platform identifier
+  amount?: string;    // Optional contract budget/milestone amount
+  reason?: string;    // Optional reason context (e.g. for disputes)
+}
+```
+All dispatches are performed offline and deterministically in the test suite using injected fakes/mocks.

--- a/src/hooks/escrow.hooks.test.ts
+++ b/src/hooks/escrow.hooks.test.ts
@@ -1,3 +1,6 @@
+process.env.COMPLIANCE_AUDIT_SECRET = 'a'.repeat(32);
+process.env.NODE_ENV = 'test';
+
 // Mock the notification service module before any imports resolve so that
 // the module-level `notificationService` singleton (which calls validateEnv()
 // and opens a SQLite connection) is never constructed during tests.
@@ -8,10 +11,21 @@ jest.mock('../services/notification.service', () => ({
   },
 }));
 
-import { EscrowHooks, EscrowDispatchResult } from './escrow.hooks';
 import { KeyEscrowEvent } from '../types/notification.types';
-import { notificationService } from '../services/notification.service';
-import { logger } from '../logger';
+import type { EscrowDispatchResult } from './escrow.hooks';
+
+let EscrowHooks: any;
+let notificationService: any;
+let logger: any;
+
+beforeAll(async () => {
+  const hooksMod = await import('./escrow.hooks');
+  EscrowHooks = hooksMod.EscrowHooks;
+  const serviceMod = await import('../services/notification.service');
+  notificationService = serviceMod.notificationService;
+  const loggerMod = await import('../logger');
+  logger = loggerMod.logger;
+});
 
 /**
  * Baseline payload used across tests.  All PII-sensitive fields are
@@ -216,7 +230,7 @@ describe('EscrowHooks.onEscrowEvent — channel isolation', () => {
     it('does not throw — resolves with both failures', async () => {
       await expect(
         EscrowHooks.onEscrowEvent(KeyEscrowEvent.DISPUTE_RAISED, BASE_PAYLOAD),
-      ).resolves.not.toThrow();
+      ).resolves.toBeDefined();
     });
 
     it('returns allSucceeded:false, anySucceeded:false', async () => {
@@ -380,6 +394,97 @@ describe('EscrowHooks.onEscrowEvent — channel isolation', () => {
       expect(result.channels).toHaveLength(2);
       expect(sendEmailSpy).toHaveBeenCalledTimes(1);
       expect(sendWebSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ─── State Transitions (Lifecycle Hooks) ────────────────────────────────────
+
+  describe('onStateTransition — contract lifecycle transitions', () => {
+    it('dispatches FUNDS_DEPOSITED for draft -> active transition (funded)', async () => {
+      const result = await EscrowHooks.onStateTransition('draft', 'active', BASE_PAYLOAD);
+      expect(result).not.toBeNull();
+      expect(result!.allSucceeded).toBe(true);
+      expect(sendEmailSpy).toHaveBeenCalledTimes(1);
+      expect(sendEmailSpy).toHaveBeenCalledWith(
+        BASE_PAYLOAD.userEmail,
+        KeyEscrowEvent.FUNDS_DEPOSITED,
+        expect.objectContaining({
+          contractId: BASE_PAYLOAD.contractId,
+          userId: BASE_PAYLOAD.userId,
+          userEmail: BASE_PAYLOAD.userEmail,
+          amount: BASE_PAYLOAD.amount,
+        }),
+      );
+      expect(sendWebSpy).toHaveBeenCalledTimes(1);
+      expect(sendWebSpy).toHaveBeenCalledWith(
+        BASE_PAYLOAD.userId,
+        KeyEscrowEvent.FUNDS_DEPOSITED,
+        expect.objectContaining({
+          contractId: BASE_PAYLOAD.contractId,
+          userId: BASE_PAYLOAD.userId,
+          userEmail: BASE_PAYLOAD.userEmail,
+          amount: BASE_PAYLOAD.amount,
+        }),
+      );
+    });
+
+    it('dispatches ESCROW_RESOLVED for active -> completed transition (released)', async () => {
+      const result = await EscrowHooks.onStateTransition('active', 'completed', BASE_PAYLOAD);
+      expect(result).not.toBeNull();
+      expect(result!.allSucceeded).toBe(true);
+      expect(sendEmailSpy).toHaveBeenCalledTimes(1);
+      expect(sendEmailSpy).toHaveBeenCalledWith(
+        BASE_PAYLOAD.userEmail,
+        KeyEscrowEvent.ESCROW_RESOLVED,
+        expect.objectContaining({
+          contractId: BASE_PAYLOAD.contractId,
+          userId: BASE_PAYLOAD.userId,
+          userEmail: BASE_PAYLOAD.userEmail,
+        }),
+      );
+      expect(sendWebSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('dispatches DISPUTE_RAISED for active -> disputed transition (disputed)', async () => {
+      const result = await EscrowHooks.onStateTransition('active', 'disputed', BASE_PAYLOAD);
+      expect(result).not.toBeNull();
+      expect(result!.allSucceeded).toBe(true);
+      expect(sendEmailSpy).toHaveBeenCalledTimes(1);
+      expect(sendEmailSpy).toHaveBeenCalledWith(
+        BASE_PAYLOAD.userEmail,
+        KeyEscrowEvent.DISPUTE_RAISED,
+        expect.objectContaining({
+          contractId: BASE_PAYLOAD.contractId,
+          userId: BASE_PAYLOAD.userId,
+          userEmail: BASE_PAYLOAD.userEmail,
+        }),
+      );
+      expect(sendWebSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits no notifications for unchanged states', async () => {
+      const statuses = ['draft', 'active', 'completed', 'disputed', 'cancelled'];
+      for (const status of statuses) {
+        const result = await EscrowHooks.onStateTransition(status, status, BASE_PAYLOAD);
+        expect(result).toBeNull();
+      }
+      expect(sendEmailSpy).not.toHaveBeenCalled();
+      expect(sendWebSpy).not.toHaveBeenCalled();
+    });
+
+    it('emits no notifications for unknown or ignored transitions', async () => {
+      const ignoredTransitions = [
+        { old: 'draft', new: 'completed' },
+        { old: 'completed', new: 'active' },
+        { old: 'unknown_state', new: 'active' },
+        { old: 'active', new: 'unknown_state' },
+      ];
+      for (const transition of ignoredTransitions) {
+        const result = await EscrowHooks.onStateTransition(transition.old, transition.new, BASE_PAYLOAD);
+        expect(result).toBeNull();
+      }
+      expect(sendEmailSpy).not.toHaveBeenCalled();
+      expect(sendWebSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/hooks/escrow.hooks.ts
+++ b/src/hooks/escrow.hooks.ts
@@ -156,4 +156,39 @@ export class EscrowHooks {
     });
     return { channel, success: false, message: err.message };
   }
+
+  /**
+   * @notice Maps state transitions of contracts to KeyEscrowEvents and dispatches notifications.
+   *         Filters out unchanged and unknown/ignored states.
+   *
+   * @param oldStatus Starting contract status.
+   * @param newStatus Destination contract status.
+   * @param payload Context payload containing required identifiers.
+   * @returns Aggregated dispatch result, or null if no notification is triggered.
+   */
+  public static async onStateTransition(
+    oldStatus: string,
+    newStatus: string,
+    payload: EscrowEventPayload,
+  ): Promise<EscrowDispatchResult | null> {
+    if (!oldStatus || !newStatus || oldStatus === newStatus) {
+      return null;
+    }
+
+    let event: KeyEscrowEvent | null = null;
+
+    if (oldStatus === 'draft' && newStatus === 'active') {
+      event = KeyEscrowEvent.FUNDS_DEPOSITED; // funded
+    } else if (oldStatus === 'active' && newStatus === 'completed') {
+      event = KeyEscrowEvent.ESCROW_RESOLVED; // released
+    } else if (oldStatus === 'active' && newStatus === 'disputed') {
+      event = KeyEscrowEvent.DISPUTE_RAISED; // disputed
+    }
+
+    if (!event) {
+      return null;
+    }
+
+    return EscrowHooks.onEscrowEvent(event, payload);
+  }
 }


### PR DESCRIPTION
Closes #629 
# Pull Request: Add Unit Tests and Lifecycle Transition Dispatches for Escrow Hooks

## Overview
This PR implements deterministic unit testing for the escrow lifecycle hook dispatches (`src/hooks/escrow.hooks.ts`), introduces state transition routing for notifications, and adds comprehensive documentation. 

### Key Changes
1. **State Transition Dispatches**: Introduced the `onStateTransition` method in [escrow.hooks.ts](file:///c:/Users/HP/drips\client/Talenttrust-Backend/src/hooks/escrow.hooks.ts) to filter, map, and dispatch events based on contract state changes:
   - **Funded** (`draft` -> `active`): Dispatches `FUNDS_DEPOSITED`
   - **Released** (`active` -> `completed`): Dispatches `ESCROW_RESOLVED`
   - **Disputed** (`active` -> `disputed`): Dispatches `DISPUTE_RAISED`
   - **Ignored / Unchanged states**: Validates that no dispatches are triggered for invalid or unchanged transitions.
2. **Deterministic Tests**: Expanded the test suite in [escrow.hooks.test.ts](file:///c:/Users/HP/drips\client/Talenttrust-Backend/src/hooks/escrow.hooks.test.ts) to verify correct payloads, ensure that transitions dispatch exactly one message, and assert that no notifications are sent for unknown/unchanged transitions. Modules that require environment validation are now loaded dynamically to prevent test setup errors.
3. **Documentation**: Added a detailed section for **Escrow Lifecycle Hook Dispatch** in [notifications.md](file:///c:/Users/HP/drips\client/Talenttrust-Backend/docs/notifications.md) covering transition mappings, expected payload schemas, and testing instructions.

## Verification & Testing
All 33 unit tests for the escrow hooks pass successfully.

```bash
bun test src/hooks/escrow.hooks.test.ts
```

### Test Output Summary
```
bun test v1.3.14 (0d9b296a)

src\hooks\escrow.hooks.test.ts:
(pass) EscrowHooks.onEscrowEvent — channel isolation > ...
...
(pass) EscrowHooks.onEscrowEvent — channel isolation > onStateTransition — contract lifecycle transitions > dispatches FUNDS_DEPOSITED for draft -> active transition (funded) [4.64ms]
(pass) EscrowHooks.onEscrowEvent — channel isolation > onStateTransition — contract lifecycle transitions > dispatches ESCROW_RESOLVED for active -> completed transition (released) [0.67ms]
(pass) EscrowHooks.onEscrowEvent — channel isolation > onStateTransition — contract lifecycle transitions > dispatches DISPUTE_RAISED for active -> disputed transition (disputed) [0.38ms]
(pass) EscrowHooks.onEscrowEvent — channel isolation > onStateTransition — contract lifecycle transitions > emits no notifications for unchanged states [1.04ms]
(pass) EscrowHooks.onEscrowEvent — channel isolation > onStateTransition — contract lifecycle transitions > emits no notifications for unknown or ignored transitions [0.61ms]

 33 pass
 0 fail
 90 expect() calls
Ran 33 tests across 1 file. [2.18s]
```