### PR TITLE
feat(utils): log SWR revalidation errors via structured logger

### DIFF
--- a/src/utils/swrCache.test.ts
+++ b/src/utils/swrCache.test.ts
@@ -1,4 +1,5 @@
 import { SWRCache, CacheOptions, DEFAULT_MAX_ENTRIES } from './swrCache';
+import { logger } from '../logger';
 
 describe('SWRCache', () => {
   let cache: SWRCache;
@@ -111,7 +112,9 @@ describe('SWRCache', () => {
 
   describe('revalidation error', () => {
     it('does not throw to callers and retains stale value after background revalidation fails', async () => {
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const logSpy = jest.spyOn(logger, 'error').mockImplementation();
+      const onRevalidationError = jest.fn();
+      cache = new SWRCache({ onRevalidationError });
 
       const seedFetcher = jest.fn().mockResolvedValue('stale-data');
       const key = 'test:reval-error';
@@ -131,16 +134,25 @@ describe('SWRCache', () => {
 
       await Promise.resolve();
 
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining('Background revalidation failed'),
-        'network down',
+      expect(logSpy).toHaveBeenCalledWith(
+        'SWR background revalidation failed',
+        expect.objectContaining({
+          cacheKey: '[REDACTED]',
+          err: expect.any(Error),
+        }),
+      );
+      expect(onRevalidationError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key,
+          error: expect.any(Error),
+        }),
       );
 
-      consoleSpy.mockRestore();
+      logSpy.mockRestore();
     });
 
     it('does not rethrow revalidation errors to stale callers', async () => {
-      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+      const logSpy = jest.spyOn(logger, 'error').mockImplementation();
 
       const fetcher = jest.fn().mockResolvedValue('original');
       const key = 'test:reval-no-throw';
@@ -157,7 +169,42 @@ describe('SWRCache', () => {
 
       await expect(errorPromise).resolves.toEqual(result);
 
-      consoleSpy.mockRestore();
+      logSpy.mockRestore();
+    });
+
+    it('swallows callback errors after logging the revalidation failure', async () => {
+      const logSpy = jest.spyOn(logger, 'error').mockImplementation();
+      cache = new SWRCache({
+        onRevalidationError: () => {
+          throw new Error('metrics sink down');
+        },
+      });
+
+      await cache.get('callback:key', jest.fn().mockResolvedValue('old'), options);
+      jest.advanceTimersByTime(ttlMs + 10);
+
+      const result = await cache.get(
+        'callback:key',
+        jest.fn().mockRejectedValue(new Error('upstream down')),
+        options,
+      );
+
+      expect(result).toEqual({ data: 'old', degraded: true, source: 'cache_stale' });
+
+      await Promise.resolve();
+
+      expect(logSpy).toHaveBeenNthCalledWith(
+        1,
+        'SWR background revalidation failed',
+        expect.objectContaining({ cacheKey: '[REDACTED]', err: expect.any(Error) }),
+      );
+      expect(logSpy).toHaveBeenNthCalledWith(
+        2,
+        'SWR revalidation error callback failed',
+        expect.objectContaining({ cacheKey: '[REDACTED]', err: expect.any(Error) }),
+      );
+
+      logSpy.mockRestore();
     });
   });
 

--- a/src/utils/swrCache.ts
+++ b/src/utils/swrCache.ts
@@ -18,6 +18,9 @@
  * promise already pending resolves with the data it was awaiting.
  */
 
+import { logger } from '../logger';
+import { redactSecret } from './redact';
+
 export interface CacheOptions {
   /** Time-To-Live in milliseconds. Cache is considered fresh during this period. */
   ttlMs: number;
@@ -31,7 +34,26 @@ export interface SWRCacheOptions {
    * Must be a positive integer. Defaults to {@link DEFAULT_MAX_ENTRIES}.
    */
   maxEntries?: number;
+  /**
+   * Optional hook fired after a background SWR revalidation fails.
+   *
+   * Use this for metrics or alerts. The hook runs after the structured log is
+   * emitted, and any hook error is swallowed so stale callers never observe a
+   * background revalidation failure.
+   */
+  onRevalidationError?: SWRRevalidationErrorHandler;
 }
+
+export type SWRRevalidationErrorEvent = {
+  /** Cache key whose background revalidation failed. */
+  key: string;
+  /** Original error thrown by the upstream fetcher. */
+  error: unknown;
+};
+
+export type SWRRevalidationErrorHandler = (
+  event: SWRRevalidationErrorEvent,
+) => void;
 
 export interface SWRResult<T> {
   data: T;
@@ -68,6 +90,8 @@ export const DEFAULT_MAX_ENTRIES = 1000;
 export class SWRCache {
   /** Maximum number of entries permitted before LRU eviction is triggered. */
   public readonly maxEntries: number;
+  /** Optional observer for background revalidation failures. */
+  private readonly onRevalidationError: SWRRevalidationErrorHandler | undefined;
   /** Insertion-ordered Map keyed by `string`. Iteration yields least-recently-used first. */
   private cache = new Map<string, CacheEntry<unknown>>();
   /** In-flight fetch promises, decoupled from cache membership so eviction cannot corrupt them. */
@@ -85,6 +109,7 @@ export class SWRCache {
       );
     }
     this.maxEntries = supplied;
+    this.onRevalidationError = options.onRevalidationError;
   }
 
   /**
@@ -132,7 +157,7 @@ export class SWRCache {
           // logged inside revalidate()'s catch block; we attach a no-op catch
           // here to prevent Node from treating the unhandled rejection as a
           // fatal error and to avoid test runner leakage.
-          this.revalidate(key, fetcher).catch(() => undefined);
+          this.revalidate(key, fetcher, true).catch(() => undefined);
         }
         this.touch(key, entry);
         return { data: entry.data as T, degraded: true, source: 'cache_stale' };
@@ -208,18 +233,20 @@ export class SWRCache {
    * `.catch` so that the activeFetches bookkeeping is guaranteed even if
    * the upstream fetcher throws synchronously.
    */
-  private revalidate<T>(key: string, fetcher: () => Promise<T>): Promise<T> {
+  private revalidate<T>(
+    key: string,
+    fetcher: () => Promise<T>,
+    isBackground = false,
+  ): Promise<T> {
     const fetchPromise = (async (): Promise<T> => {
       try {
         const newData = await fetcher();
         this.setEntry(key, { data: newData as unknown, updatedAt: Date.now() });
         return newData;
       } catch (err) {
-        // eslint-disable-next-line no-console
-        console.error(
-          `[SWR Cache] Background revalidation failed for key: ${key}`,
-          (err as Error).message,
-        );
+        if (isBackground) {
+          this.handleRevalidationError(key, err);
+        }
         throw err;
       } finally {
         this.activeFetches.delete(key);
@@ -227,5 +254,36 @@ export class SWRCache {
     })();
     this.activeFetches.set(key, fetchPromise as Promise<unknown>);
     return fetchPromise;
+  }
+
+  /**
+   * Emit structured telemetry for background revalidation failures.
+   *
+   * The cache key is routed through the shared redaction helper before logging,
+   * because callers may include user IDs or access-control scope in cache keys.
+   * The optional observer receives the original key/error for local metrics, but
+   * observer failures are swallowed and logged so stale callers are insulated.
+   */
+  private handleRevalidationError(key: string, error: unknown): void {
+    const cacheKey = redactSecret(key);
+    const err =
+      error instanceof Error ? error : new Error(String(error ?? 'unknown'));
+
+    logger.error('SWR background revalidation failed', {
+      cacheKey,
+      err,
+    });
+
+    try {
+      this.onRevalidationError?.({ key, error });
+    } catch (callbackError) {
+      logger.error('SWR revalidation error callback failed', {
+        cacheKey,
+        err:
+          callbackError instanceof Error
+            ? callbackError
+            : new Error(String(callbackError ?? 'unknown')),
+      });
+    }
   }
 }


### PR DESCRIPTION
## Summary
- replace the SWR background revalidation `console.error` with the shared structured logger
- add an optional `onRevalidationError` observer hook for metrics/alerts without changing stale response behavior
- cover structured logging, callback delivery, and callback-failure swallowing in `swrCache` tests

Closes #621.

## Validation
- `git diff --check`
- `npm test -- --runTestsByPath src/utils/swrCache.test.ts --runInBand` could not be run in this Codex environment because `npm` is not installed; I did not install dependencies or run project toolchains.