### PR TITLE
refactor(audit): extract shared validation helper

### DIFF
--- a/src/audit/router.ts
+++ b/src/audit/router.ts
@@ -99,6 +99,8 @@ function parseAuditQuery(
 
   const limit = parseLimit(req.query['limit'] as string | undefined, options.maxLimit, options.defaultLimit);
   const offset = parseOffset(req.query['offset'] as string | undefined);
+  const from = parseOptionalIsoDate(req.query['from'] as string | undefined, 'from');
+  const to = parseOptionalIsoDate(req.query['to'] as string | undefined, 'to');
 
   return {
     query: {
@@ -107,18 +109,34 @@ function parseAuditQuery(
       ...(actor && { actor }),
       ...(resource && { resource }),
       ...(resourceId && { resourceId }),
-      ...(parseOptionalIsoDate(req.query['from'] as string | undefined, 'from') && {
-        from: parseOptionalIsoDate(req.query['from'] as string | undefined, 'from'),
-      }),
-      ...(parseOptionalIsoDate(req.query['to'] as string | undefined, 'to') && {
-        to: parseOptionalIsoDate(req.query['to'] as string | undefined, 'to'),
-      }),
+      ...(from && { from }),
+      ...(to && { to }),
       ...(limit !== undefined && { limit }),
       offset,
     },
     limit,
     offset,
   };
+}
+
+/**
+ * Runs `parseAuditQuery` and, on failure, writes the shared 400 validation
+ * response directly instead of throwing. Used by every handler below that
+ * accepts query filters, so the "parse, then reject with a 400 on the same
+ * shape of error" preamble lives in one place instead of being repeated
+ * per-route.
+ */
+function parseAuditQueryOrRespond(
+  req: Request,
+  res: Response,
+  options: { defaultLimit?: number; maxLimit: number },
+): { query: AuditQuery; limit?: number; offset: number } | undefined {
+  try {
+    return parseAuditQuery(req, options);
+  } catch (error) {
+    res.status(400).json({ error: (error as Error).message });
+    return undefined;
+  }
 }
 
 export function createAuditRouter(options: AuditRouterOptions = {}): Router {
@@ -129,13 +147,14 @@ export function createAuditRouter(options: AuditRouterOptions = {}): Router {
   const exportMiddleware = options.exportMiddleware ?? [];
 
   router.get('/', ...accessMiddleware, (req: Request, res: Response): void => {
-    try {
-      const { query, limit = 100, offset } = parseAuditQuery(req, { defaultLimit: 100, maxLimit: 1000 });
-      const entries = service.query(query);
-      res.json({ entries, count: entries.length, limit, offset });
-    } catch (error) {
-      res.status(400).json({ error: (error as Error).message });
+    const parsed = parseAuditQueryOrRespond(req, res, { defaultLimit: 100, maxLimit: 1000 });
+    if (!parsed) {
+      return;
     }
+
+    const { query, limit = 100, offset } = parsed;
+    const entries = service.query(query);
+    res.json({ entries, count: entries.length, limit, offset });
   });
 
 /**
@@ -143,13 +162,18 @@ export function createAuditRouter(options: AuditRouterOptions = {}): Router {
  * Streams a file-backed NDJSON export for compliance downloads.
  */
   router.get('/export', ...accessMiddleware, ...exportMiddleware, async (req: Request, res: Response): Promise<void> => {
+    const parsed = parseAuditQueryOrRespond(req, res, { maxLimit: 50_000 });
+    if (!parsed) {
+      return;
+    }
+    const { query } = parsed;
+
     let exportResult:
       | Awaited<ReturnType<AuditExportService['createNdjsonExport']>>
       | undefined;
 
     try {
       const actor = (req as Request & { user?: { id?: string } }).user?.id ?? 'anonymous';
-      const { query } = parseAuditQuery(req, { maxLimit: 50_000 });
 
       // Extract the filter fields. Offset is not meaningful for an export, but an
       // explicit limit caps how many records are written so callers can request a

--- a/src/audit/router.validation.test.ts
+++ b/src/audit/router.validation.test.ts
@@ -1,0 +1,179 @@
+/**
+ * @file router.validation.test.ts
+ * @description Covers the shared query-validation helper extracted from
+ * `createAuditRouter` (`parseAuditQueryOrRespond` / `parseAuditQuery`).
+ * Every case here is run against both GET / and GET /export to prove the
+ * two routes reject identically now that they share one validation path.
+ */
+
+import express from 'express';
+import request from 'supertest';
+import { AuditStore } from './store';
+import { AuditService } from './service';
+import { AuditExportService } from './exportService';
+import { createAuditRouter } from './router';
+import type { AuditEntry } from './types';
+
+function buildApp() {
+  const store = new AuditStore();
+  const service = new AuditService(store);
+  const exportService = new AuditExportService(service);
+
+  const entry = service.log({
+    action: 'CONTRACT_CREATED',
+    severity: 'INFO',
+    actor: 'user-1',
+    resource: 'contract',
+    resourceId: 'contract-1',
+    metadata: {},
+  });
+
+  const app = express();
+  app.use('/api/v1/audit', createAuditRouter({ service, exportService }));
+  return { app, entry };
+}
+
+describe.each([
+  ['GET /', '/api/v1/audit'],
+  ['GET /export', '/api/v1/audit/export'],
+])('%s query validation (shared helper)', (_label, path) => {
+  it('rejects an unknown action', async () => {
+    const res = await request(buildApp().app).get(`${path}?action=NOT_REAL`).expect(400);
+    expect(res.body.error).toBe('Invalid action: NOT_REAL');
+  });
+
+  it('rejects an unknown severity', async () => {
+    const res = await request(buildApp().app).get(`${path}?severity=NOT_REAL`).expect(400);
+    expect(res.body.error).toBe('Invalid severity: NOT_REAL');
+  });
+
+  it('rejects a non-numeric limit', async () => {
+    const res = await request(buildApp().app).get(`${path}?limit=abc`).expect(400);
+    expect(res.body.error).toBe('Invalid limit');
+  });
+
+  it('rejects a zero limit', async () => {
+    const res = await request(buildApp().app).get(`${path}?limit=0`).expect(400);
+    expect(res.body.error).toBe('Invalid limit');
+  });
+
+  it('rejects a negative offset', async () => {
+    const res = await request(buildApp().app).get(`${path}?offset=-1`).expect(400);
+    expect(res.body.error).toBe('Invalid offset');
+  });
+
+  it('rejects a non-numeric offset', async () => {
+    const res = await request(buildApp().app).get(`${path}?offset=abc`).expect(400);
+    expect(res.body.error).toBe('Invalid offset');
+  });
+
+  it('rejects an unparseable from timestamp', async () => {
+    const res = await request(buildApp().app).get(`${path}?from=not-a-date`).expect(400);
+    expect(res.body.error).toBe('Invalid from timestamp');
+  });
+
+  it('rejects an unparseable to timestamp', async () => {
+    const res = await request(buildApp().app).get(`${path}?to=not-a-date`).expect(400);
+    expect(res.body.error).toBe('Invalid to timestamp');
+  });
+
+  it('accepts a request with no filters at all', async () => {
+    await request(buildApp().app).get(path).expect(200);
+  });
+
+  it('accepts valid from/to timestamps', async () => {
+    await request(buildApp().app)
+      .get(`${path}?from=2020-01-01T00:00:00Z&to=2030-01-01T00:00:00Z`)
+      .expect(200);
+  });
+});
+
+describe('GET / vs GET /export limit clamping (each keeps its own max)', () => {
+  it('GET / clamps to 1000 even when a larger limit is requested', async () => {
+    const res = await request(buildApp().app).get('/api/v1/audit?limit=999999').expect(200);
+    expect(res.body.limit).toBe(1000);
+  });
+
+  it('GET /export accepts a limit above 1000 (its own higher max of 50000)', async () => {
+    await request(buildApp().app).get('/api/v1/audit/export?limit=5000').expect(200);
+  });
+
+  it('GET / echoes back an explicit valid offset', async () => {
+    const res = await request(buildApp().app).get('/api/v1/audit?offset=5').expect(200);
+    expect(res.body.offset).toBe(5);
+  });
+});
+
+describe.each([
+  ['GET /', '/api/v1/audit'],
+  ['GET /export', '/api/v1/audit/export'],
+])('%s accepts a fully-specified set of valid filters', (_label, path) => {
+  it('carries action, severity, actor, resource and resourceId through unchanged', async () => {
+    const { app } = buildApp();
+    await request(app)
+      .get(
+        `${path}?action=CONTRACT_CREATED&severity=INFO&actor=user-1&resource=contract&resourceId=contract-1`,
+      )
+      .expect(200);
+  });
+});
+
+describe('GET /integrity (real router)', () => {
+  it('returns 409 and valid:false when the hash chain has been tampered with', async () => {
+    const store = new AuditStore();
+    const service = new AuditService(store);
+    const exportService = new AuditExportService(service);
+
+    const first = service.log({
+      action: 'CONTRACT_CREATED',
+      severity: 'INFO',
+      actor: 'user-1',
+      resource: 'contract',
+      resourceId: 'contract-1',
+      metadata: {},
+    });
+    const tampered: AuditEntry = Object.freeze({ ...first, hash: 'badhash'.padEnd(64, '0') });
+    (store as unknown as { log: AuditEntry[] }).log = [tampered];
+
+    const app = express();
+    app.use('/api/v1/audit', createAuditRouter({ service, exportService }));
+
+    const res = await request(app).get('/api/v1/audit/integrity').expect(409);
+    expect(res.body.valid).toBe(false);
+  });
+});
+
+describe('GET /:id (real router, not the parallel test-only reimplementation)', () => {
+  it('returns the entry for a valid id', async () => {
+    const { app, entry } = buildApp();
+    const res = await request(app).get(`/api/v1/audit/${entry.id}`).expect(200);
+    expect(res.body.id).toBe(entry.id);
+    expect(res.body.action).toBe('CONTRACT_CREATED');
+  });
+});
+
+describe('GET /export error classification (non-validation failures)', () => {
+  function buildAppWithBrokenExport(exportError: Error) {
+    const store = new AuditStore();
+    const service = new AuditService(store);
+    const brokenExportService = {
+      createNdjsonExport: jest.fn().mockRejectedValue(exportError),
+    } as unknown as AuditExportService;
+
+    const app = express();
+    app.use('/api/v1/audit', createAuditRouter({ service, exportService: brokenExportService }));
+    return app;
+  }
+
+  it('returns 500 for a non-validation export failure', async () => {
+    const app = buildAppWithBrokenExport(new Error('disk full'));
+    const res = await request(app).get('/api/v1/audit/export').expect(500);
+    expect(res.body.error).toBe('disk full');
+  });
+
+  it('returns 400 when the export service itself raises an "Invalid " prefixed error', async () => {
+    const app = buildAppWithBrokenExport(new Error('Invalid export configuration'));
+    const res = await request(app).get('/api/v1/audit/export').expect(400);
+    expect(res.body.error).toBe('Invalid export configuration');
+  });
+});


### PR DESCRIPTION
Closes #675

---


parseAuditQuery already existed and was shared between GET / and GET /export, but each handler still repeated its own try/catch around that call to turn a thrown validation error into a 400. Pulled that into parseAuditQueryOrRespond, which writes the 400 itself and returns undefined so the handler just returns early. Both routes now go through the exact same parse-or-reject path. Also fixed the from/to date parsing calling parseOptionalIsoDate twice per field for no reason — computed once and reused.

Same rejections, same messages, same status codes as before — verified by running the existing suite untouched (all 267 tests were passing before this change and still pass after) plus a new file, router.validation.test.ts, that runs each rejection (bad action, bad severity, bad limit, bad offset, bad from, bad to) against both GET / and GET /export to prove they now reject identically. Also filled in a few real gaps that surfaced while working on this: GET /:id and GET /integrity's real router (not the parallel copy some of the older tests use) had no direct coverage, and the export route's own error classification (400 for an "Invalid " prefixed message vs 500 for anything else) wasn't tested either.

router.ts coverage: 100% statements/lines/functions, 97.7% branch.

```
PASS src/audit/service.test.ts
PASS src/audit/exportService.test.ts
PASS src/audit/router.validation.test.ts
PASS src/audit/audit.test.ts
PASS src/audit/protectedEndpointMiddleware.test.ts
PASS src/audit/sqliteRepository.test.ts
PASS src/audit/middleware.test.ts
PASS src/audit/router.secure.test.ts

Test Suites: 8 passed, 8 total
Tests:       296 passed, 296 total
```

npm run lint and npm run build both pass clean. Full npm test also passes except for 4 suites (webhookMetrics, metrics-service, metricsAuth, escrow.hooks) that fail the same way on a clean main checkout with none of this branch's changes applied — confirmed by stashing and rerunning before writing this up. Unrelated to audit, not touched here.