### PR TITLE
docs(api-keys): document key lifecycle, scopes, and rotation

### DIFF
--- a/docs/api-keys.md
+++ b/docs/api-keys.md
@@ -6,6 +6,20 @@ This document describes the API key authentication system implemented for Talent
 
 API keys provide a secure way for internal services and external integrations to access the TalentTrust API without requiring user authentication. API keys are separate from JWT user authentication and can be used for service-to-service communication.
 
+> **Route mounting note:** The management endpoints described below
+> (`POST/GET /api/v1/api-keys`, `GET/POST/DELETE /api/v1/api-keys/:id`, `.../rotate`)
+> are implemented in [`src/routes/apiKeys.routes.ts`](../src/routes/apiKeys.routes.ts)
+> but are **not currently registered** in [`src/app.ts`](../src/app.ts) or
+> [`src/index.ts`](../src/index.ts). If you are running this backend as-is, mount
+> the router before relying on these endpoints, e.g.:
+> ```ts
+> import apiKeysRouter from './routes/apiKeys.routes';
+> app.use('/api/v1', apiKeysRouter);
+> ```
+> This does not affect *consuming* an existing API key — `authenticateApiKey` /
+> `requireApiKeyScope` / `authenticateEither` are ordinary middleware you can
+> attach to any route regardless of whether the management router is mounted.
+
 ## Admin Scopes
 
 API keys used for admin-only surfaces (DLQ inspection, deploy operations) require one of the following scopes:
@@ -42,7 +56,7 @@ The following endpoints require either a JWT with `admin` role or an API key wit
 
 API keys are 64-character hex strings:
 ```
-abc123def456789012345678901234567890123456789012345678901234567890123456
+0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 
 ## Usage
@@ -50,7 +64,7 @@ abc123def456789012345678901234567890123456789012345678901234567890123456
 API keys should be sent in the `X-API-Key` header:
 ```http
 GET /api/v1/contracts
-X-API-Key: abc123def456789012345678901234567890123456789012345678901234567890123456
+X-API-Key: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 
 ## Scope Format
@@ -76,10 +90,37 @@ contracts:*        # Can perform any action on contracts
 
 ## API Endpoints
 
+### Authenticating to the management endpoints
+
+The `/api/v1/api-keys*` management endpoints below are protected by
+**user** authentication, not by an API key. They currently use the bearer-token
+scheme implemented in [`src/auth/authenticate.ts`](../src/auth/authenticate.ts)
+(`authenticateMiddleware`) plus the role-based access-control matrix in
+[`src/auth/roles.ts`](../src/auth/roles.ts) (`requirePermission('api-keys', <action>)`)
+— this is the same lightweight scheme documented in the root
+[README's Authentication section](../README.md#authentication) (e.g. the
+`demo-admin-token` / `demo-user-token` bearer values), **not** the production
+JWT stack described in [AUTH.md](../AUTH.md). A token is a base64-encoded
+JSON object of the shape `{ "userId": "u1", "role": "freelancer" }`, sent as
+`Authorization: Bearer <base64-token>`.
+
+Per the current access-control matrix, every role except `auditor` and
+`guest` (`admin`, `freelancer`, `client`) is granted full `create`/`read`/
+`update`/`delete` permission on the `api-keys` resource — so, in practice,
+access is narrowed by **per-key ownership**, not by role: `GET /:id`,
+`POST /:id/rotate`, and `DELETE /:id` all return `403 Access denied` unless
+the authenticated caller's `userId` matches the key's `created_by`, and
+`GET /api/v1/api-keys` only ever lists **active** keys created by the caller
+(other users' keys, and the caller's own deactivated keys, are never
+returned). A deactivated key also stops resolving on `GET /:id`,
+`POST /:id/rotate`, and `DELETE /:id` — those return `404 API key not found`
+rather than a "deactivated" status, because lookups are filtered to
+`is_active` keys.
+
 ### Create API Key
 ```http
 POST /api/v1/api-keys
-Authorization: Bearer <jwt-token>
+Authorization: Bearer <user-token>
 Content-Type: application/json
 
 {
@@ -108,7 +149,7 @@ Content-Type: application/json
 ### List API Keys
 ```http
 GET /api/v1/api-keys
-Authorization: Bearer <jwt-token>
+Authorization: Bearer <user-token>
 ```
 **Response:**
 ```json
@@ -132,13 +173,13 @@ Authorization: Bearer <jwt-token>
 ### Get API Key Details
 ```http
 GET /api/v1/api-keys/:id
-Authorization: Bearer <jwt-token>
+Authorization: Bearer <user-token>
 ```
 
 ### Rotate API Key
 ```http
 POST /api/v1/api-keys/:id/rotate
-Authorization: Bearer <jwt-token>
+Authorization: Bearer <user-token>
 ```
 **Response:**
 ```json
@@ -161,7 +202,7 @@ Authorization: Bearer <jwt-token>
 ### Deactivate API Key
 ```http
 DELETE /api/v1/api-keys/:id
-Authorization: Bearer <jwt-token>
+Authorization: Bearer <user-token>
 ```
 **Response:**
 ```json
@@ -244,21 +285,37 @@ Authorization: Bearer <jwt-token>
 
 ## Error Responses
 
-### Authentication Errors
+### Consuming an API key (`authenticateApiKey` / `requireApiKeyScope`)
+
 ```json
 { "error": "Missing X-API-Key header" }
 ```
 ```json
 { "error": "Invalid API key" }
 ```
-### Authorization Errors
 ```json
 { "error": "Forbidden: insufficient API key scope", "required": "contracts:read", "provided": ["users:read"] }
 ```
-### Validation Errors
+
+### Managing keys (`/api/v1/api-keys*` controllers)
+
 ```json
 { "error": "Invalid request body", "required": { "name": "string", "scope": "string[]" } }
 ```
+```json
+{ "error": "Invalid scope format", "invalidScopes": ["bad scope"], "validFormats": ["resource:action", "resource:*", "*:action", "*"] }
+```
+```json
+{ "error": "API key not found" }
+```
+```json
+{ "error": "Access denied" }
+```
+The last one is returned by `GET /:id`, `POST /:id/rotate`, and
+`DELETE /:id` when the authenticated caller did not create the key —
+ownership, not role, gates access to an individual key (see
+["Authenticating to the management endpoints"](#authenticating-to-the-management-endpoints)
+above).
 
 ## Implementation Details
 
@@ -355,6 +412,27 @@ app.get('/api/mixed',
   handler
 );
 ```
+
+### JWT-or-key fallback (`authenticateEither`)
+
+`authenticateEither` lets a single route accept **either** a human user (JWT)
+or a service integration (API key), which is useful for endpoints called both
+by the frontend and by internal/external automation. Its precedence is
+header-driven, not a "try both and see":
+
+1. If the request carries an `Authorization: Bearer <token>` header, it is
+   routed to the existing bearer/JWT middleware (`authenticateMiddleware`) —
+   API key headers are ignored in this case, even if also present.
+2. Otherwise, if the request carries an `X-API-Key` header, it is routed to
+   `authenticateApiKey`.
+3. If neither header is present, the request is rejected with `401` and the
+   message `"Authentication required. Provide either Authorization: Bearer <token> or X-API-Key header"`.
+
+Downstream handlers should not assume which path was taken — inspect
+`req.user` (JWT) vs. `req.apiKey` (API key) to know which principal
+authenticated the request. `requireApiKeyScope` only applies scope checks
+when `req.apiKey` is set; pair `authenticateEither` with role/permission
+checks (e.g. `requireRole`) if you also need to gate the JWT path.
 
 ## Migration Guide
 

--- a/src/auth/apiKeys.ts
+++ b/src/auth/apiKeys.ts
@@ -3,14 +3,14 @@
  * @description API key authentication utilities for TalentTrust.
  *
  * Provides secure API key generation, validation, and management.
- * API keys are hashed at rest using SHA-256 with a salt.
+ * API keys are hashed at rest using PBKDF2 (SHA-256, 10,000 iterations) with a salt.
  *
  * API keys are expected in the `X-API-Key` header:
  *   X-API-Key: <api-key>
  *
  * Security notes:
  *   - API keys are cryptographically generated using random bytes
- *   - Keys are hashed at rest using SHA-256 with a unique salt
+ *   - Keys are hashed at rest using PBKDF2 (SHA-256, 10,000 iterations) with a unique salt
  *   - Each key has optional expiration and scoping
  *   - Keys can be rotated and deactivated
  *   - Last usage is tracked for audit purposes


### PR DESCRIPTION
Closes #603.

## Summary

Expands `docs/api-keys.md` to fully cover the API key lifecycle (issue →
use → expire → revoke → rotate), the scope vocabulary, and how
`requireApiKeyScope` / `authenticateEither` enforce it — cross-checked
against the current implementation in `src/auth/apiKeys.ts`,
`src/auth/apiKeyMiddleware.ts`, `src/controllers/apiKeyController.ts`, and
`src/routes/apiKeys.routes.ts`.

While cross-checking the doc against the code (per the issue's "ensure
documented scopes match the code" / "validate examples reflect real
request/response shapes" guidance), a few real gaps and inaccuracies came
up, which this PR also fixes:

- **Route mounting**: `src/routes/apiKeys.routes.ts` is implemented but is
  not currently registered in `src/app.ts` or `src/index.ts`. Added a note
  up front so integrators don't assume the management endpoints are live
  out of the box, with the one-line fix to mount it.
- **Which auth actually guards the management endpoints**: they use the
  legacy bearer-token + RBAC middleware (`src/auth/authenticate.ts` +
  `requirePermission('api-keys', ...)` from `src/auth/roles.ts`), not the
  production JWT stack described in `AUTH.md`. Documented the token shape
  and cross-referenced the README's `demo-admin-token` / `demo-user-token`
  values, since the previous doc's `Authorization: Bearer <jwt-token>`
  examples implied real JWTs.
- **Ownership vs. role gating**: every non-`auditor`/`guest` role currently
  has full CRUD on the `api-keys` resource in the access-control matrix, so
  access to an individual key is actually gated by `created_by` ownership
  in the controller, not by role. Documented the resulting `403 Access
  denied` / `404 API key not found` behavior (including that a deactivated
  key 404s on `GET/rotate/DELETE :id` rather than reporting itself as
  inactive, since lookups filter on `is_active`).
- **`authenticateEither` precedence**: added prose explaining the
  `Authorization: Bearer` vs. `X-API-Key` header precedence and how to
  branch on `req.user` vs. `req.apiKey` downstream — the doc previously
  only showed a code snippet with no explanation.
- **Example key length**: the sample key used in "API Key Format" and
  "Usage" was 72 hex characters while the same section claims keys are
  64-character hex strings (`crypto.randomBytes(32).toString('hex')`).
  Replaced with a correctly-sized example.
- **TSDoc drift**: `src/auth/apiKeys.ts`'s module docblock said keys are
  "hashed at rest using SHA-256 with a salt" twice, but `hashApiKey`
  actually uses PBKDF2 (SHA-256, 10,000 iterations). Fixed the two
  comments to match the implementation — doc-only, no behavior change.

The README already links to `docs/api-keys.md` from its
"Authentication & Authorization" section and `docs/api-keys.md` already
linked back to `README.md#authentication`, so no changes were needed there.

## Notes on accuracy

- Everything documented was checked line-by-line against
  `src/auth/apiKeys.ts`, `src/auth/apiKeyMiddleware.ts`,
  `src/controllers/apiKeyController.ts`, `src/routes/apiKeys.routes.ts`,
  `src/database/index.ts`, and `src/auth/roles.ts`.
- Existing scope-reference and lifecycle sections (creation, hashing
  format, expiry/deactivation, rotation checklist) were already accurate
  and are left largely intact.

## Test plan

- [x] `npm run lint` — 0 errors (pre-existing warnings only, none from
      changed files).
- [x] `npx jest src/auth/__tests__/apiKeys.test.ts src/auth/apiKeyMiddleware.test.ts`
      — 46/46 passing, confirming the documented hashing/validation/scope
      behavior matches actual behavior.
- Doc-only changes otherwise; no new test coverage needed per the issue's
  suggested execution ("rely on existing API key tests to confirm
  documented behavior").

🤖 Generated with [Claude Code](https://claude.com/claude-code)