### PR TITLE
feat(metrics): validate and bound metrics request inputs (#692)

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -23,6 +23,8 @@ import { createRequestLimitsMiddleware } from './middleware/requestLimits';
 
 import contractsModuleRouter from './routes/contracts.routes';
 import eventsRouter from './routes/events.routes';
+import { createMetricsRouter } from './routes/metrics.routes';
+import { metricsAuthMiddleware } from './middleware/metricsAuth';
 
 import reputationRouter from './routes/reputation.routes';
 import configRouter from './routes/config.routes';
@@ -92,6 +94,7 @@ export function createApp(options?: AppFactoryOptions): express.Application {
   app.use('/api/v1/admin', adminRouter);
   app.use('/api/v1/admin/deploy', deployRouter);
   app.use('/api/v1/webhook-subscriptions', webhookSubscriptionRouter);
+  app.use('/api/v1/metrics', metricsAuthMiddleware, createMetricsRouter(metricsService));
 
   if (includeTerminalHandlers) {
     attachTerminalHandlers(app);

--- a/src/observability/metrics-service.ts
+++ b/src/observability/metrics-service.ts
@@ -8,8 +8,19 @@ import {
 } from 'prom-client';
 
 import { ServiceStatus } from './types';
+import {
+  assertDlqDepth,
+  assertServiceStatus,
+  assertWebhookOutcome,
+  WebhookOutcome as ValidatedWebhookOutcome,
+} from './metrics-validation';
 
-export type WebhookOutcome = 'success' | 'failure' | 'dlq';
+/**
+ * Re-exported from metrics-validation to preserve existing import paths.
+ * The canonical definition lives in metrics-validation.ts where all metric
+ * input types are colocated.
+ */
+export type WebhookOutcome = ValidatedWebhookOutcome;
 
 /**
  * Canonical list of metric family names documented in docs/observability.md.
@@ -164,18 +175,26 @@ export class MetricsService implements MetricsServiceLike {
   }
 
   recordHealthStatus(status: ServiceStatus): void {
+    // Runtime guard: reject unknown status strings that bypass TypeScript types
+    // (e.g. from JSON-deserialized or cross-process call sites).
+    const validated = assertServiceStatus(status);
     this.serviceHealthStatus.set(
       { service: this.serviceName },
-      HEALTH_STATUS_VALUE[status],
+      HEALTH_STATUS_VALUE[validated],
     );
   }
 
   recordWebhookDelivery(outcome: WebhookOutcome): void {
-    this.webhookDeliveriesTotal.inc({ outcome });
+    // Runtime guard: reject unknown outcome strings.
+    const validated = assertWebhookOutcome(outcome);
+    this.webhookDeliveriesTotal.inc({ outcome: validated });
   }
 
   setWebhookDlqDepth(depth: number): void {
-    this.webhookDlqDepth.set(depth);
+    // Runtime guard: reject NaN, ±Infinity, negative values, and unreasonably
+    // large values that would indicate a bug or injection attempt.
+    const validated = assertDlqDepth(depth);
+    this.webhookDlqDepth.set(validated);
   }
 
   startRateLimitMetricsSampling(limiter: any, intervalMs: number = 10000): void {

--- a/src/observability/metrics-validation.test.ts
+++ b/src/observability/metrics-validation.test.ts
@@ -1,0 +1,448 @@
+/**
+ * @file metrics-validation.test.ts
+ * @description Comprehensive tests for the metrics input validation schemas and
+ * runtime guard functions (Issue #692).
+ *
+ * Coverage targets:
+ *  - Happy-path: all valid enum values, valid numeric ranges.
+ *  - Rejection: unknown enum values, wrong types, out-of-range numbers.
+ *  - Boundary values: 0, MAX_DLQ_DEPTH, MAX_DLQ_DEPTH + 1.
+ *  - Oversized strings, non-printable chars.
+ *  - Unknown fields (strict schemas).
+ *  - Non-finite numerics (NaN, Infinity, -Infinity).
+ */
+
+import {
+  // Schemas
+  WebhookOutcomeSchema,
+  DlqOperationSchema,
+  DlqReplayOutcomeSchema,
+  ServiceStatusSchema,
+  DlqDepthSchema,
+  WebhookDeliveryInputSchema,
+  WebhookDlqDepthInputSchema,
+  HealthStatusInputSchema,
+  DlqOperationInputSchema,
+  DlqReplayInputSchema,
+  // Constants
+  WEBHOOK_OUTCOMES,
+  DLQ_OPERATIONS,
+  DLQ_REPLAY_OUTCOMES,
+  SERVICE_STATUSES,
+  MAX_DLQ_DEPTH,
+  // Helpers
+  validateMetricsInput,
+  assertWebhookOutcome,
+  assertDlqDepth,
+  assertServiceStatus,
+} from './metrics-validation';
+
+// ---------------------------------------------------------------------------
+// WebhookOutcomeSchema
+// ---------------------------------------------------------------------------
+describe('WebhookOutcomeSchema', () => {
+  it.each(WEBHOOK_OUTCOMES)('accepts valid outcome "%s"', (outcome) => {
+    expect(WebhookOutcomeSchema.safeParse(outcome).success).toBe(true);
+  });
+
+  it('rejects an unknown outcome string', () => {
+    const result = WebhookOutcomeSchema.safeParse('partial_failure');
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a number masquerading as outcome', () => {
+    expect(WebhookOutcomeSchema.safeParse(1).success).toBe(false);
+  });
+
+  it('rejects null', () => {
+    expect(WebhookOutcomeSchema.safeParse(null).success).toBe(false);
+  });
+
+  it('rejects undefined', () => {
+    expect(WebhookOutcomeSchema.safeParse(undefined).success).toBe(false);
+  });
+
+  it('rejects an empty string', () => {
+    expect(WebhookOutcomeSchema.safeParse('').success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DlqOperationSchema
+// ---------------------------------------------------------------------------
+describe('DlqOperationSchema', () => {
+  it.each(DLQ_OPERATIONS)('accepts valid operation "%s"', (op) => {
+    expect(DlqOperationSchema.safeParse(op).success).toBe(true);
+  });
+
+  it('rejects an unknown operation', () => {
+    expect(DlqOperationSchema.safeParse('purge').success).toBe(false);
+  });
+
+  it('rejects a boolean', () => {
+    expect(DlqOperationSchema.safeParse(true).success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DlqReplayOutcomeSchema
+// ---------------------------------------------------------------------------
+describe('DlqReplayOutcomeSchema', () => {
+  it.each(DLQ_REPLAY_OUTCOMES)('accepts valid replay outcome "%s"', (outcome) => {
+    expect(DlqReplayOutcomeSchema.safeParse(outcome).success).toBe(true);
+  });
+
+  it('rejects an unknown replay outcome', () => {
+    expect(DlqReplayOutcomeSchema.safeParse('retried').success).toBe(false);
+  });
+
+  it('rejects an object', () => {
+    expect(DlqReplayOutcomeSchema.safeParse({}).success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ServiceStatusSchema
+// ---------------------------------------------------------------------------
+describe('ServiceStatusSchema', () => {
+  it.each(SERVICE_STATUSES)('accepts valid status "%s"', (status) => {
+    expect(ServiceStatusSchema.safeParse(status).success).toBe(true);
+  });
+
+  it('rejects an unknown status string', () => {
+    expect(ServiceStatusSchema.safeParse('healthy').success).toBe(false);
+  });
+
+  it('rejects a number', () => {
+    expect(ServiceStatusSchema.safeParse(2).success).toBe(false);
+  });
+
+  it('rejects null', () => {
+    expect(ServiceStatusSchema.safeParse(null).success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DlqDepthSchema
+// ---------------------------------------------------------------------------
+describe('DlqDepthSchema', () => {
+  it('accepts 0 (minimum boundary)', () => {
+    expect(DlqDepthSchema.safeParse(0).success).toBe(true);
+  });
+
+  it('accepts MAX_DLQ_DEPTH (maximum boundary)', () => {
+    expect(DlqDepthSchema.safeParse(MAX_DLQ_DEPTH).success).toBe(true);
+  });
+
+  it('accepts a mid-range integer', () => {
+    expect(DlqDepthSchema.safeParse(42).success).toBe(true);
+  });
+
+  it('rejects MAX_DLQ_DEPTH + 1 (exceeds upper bound)', () => {
+    const result = DlqDepthSchema.safeParse(MAX_DLQ_DEPTH + 1);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects -1 (below lower bound)', () => {
+    expect(DlqDepthSchema.safeParse(-1).success).toBe(false);
+  });
+
+  it('rejects NaN', () => {
+    expect(DlqDepthSchema.safeParse(NaN).success).toBe(false);
+  });
+
+  it('rejects Infinity', () => {
+    expect(DlqDepthSchema.safeParse(Infinity).success).toBe(false);
+  });
+
+  it('rejects -Infinity', () => {
+    expect(DlqDepthSchema.safeParse(-Infinity).success).toBe(false);
+  });
+
+  it('rejects a float (1.5 is not an integer)', () => {
+    expect(DlqDepthSchema.safeParse(1.5).success).toBe(false);
+  });
+
+  it('rejects a string that looks like a number', () => {
+    expect(DlqDepthSchema.safeParse('5').success).toBe(false);
+  });
+
+  it('rejects null', () => {
+    expect(DlqDepthSchema.safeParse(null).success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Strict body schemas (unknown-field rejection)
+// ---------------------------------------------------------------------------
+describe('WebhookDeliveryInputSchema (strict)', () => {
+  it('accepts a valid body', () => {
+    expect(WebhookDeliveryInputSchema.safeParse({ outcome: 'success' }).success).toBe(true);
+  });
+
+  it('rejects an unknown field alongside a valid outcome', () => {
+    const result = WebhookDeliveryInputSchema.safeParse({ outcome: 'success', extra: 'field' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a body missing the outcome field', () => {
+    expect(WebhookDeliveryInputSchema.safeParse({}).success).toBe(false);
+  });
+
+  it('rejects outcome with wrong type (number)', () => {
+    expect(WebhookDeliveryInputSchema.safeParse({ outcome: 1 }).success).toBe(false);
+  });
+
+  it('rejects an invalid outcome value', () => {
+    expect(WebhookDeliveryInputSchema.safeParse({ outcome: 'error' }).success).toBe(false);
+  });
+
+  it('rejects non-object body (array)', () => {
+    expect(WebhookDeliveryInputSchema.safeParse(['success']).success).toBe(false);
+  });
+
+  it('rejects null body', () => {
+    expect(WebhookDeliveryInputSchema.safeParse(null).success).toBe(false);
+  });
+});
+
+describe('WebhookDlqDepthInputSchema (strict)', () => {
+  it('accepts a valid body with depth 0', () => {
+    expect(WebhookDlqDepthInputSchema.safeParse({ depth: 0 }).success).toBe(true);
+  });
+
+  it('accepts MAX_DLQ_DEPTH', () => {
+    expect(WebhookDlqDepthInputSchema.safeParse({ depth: MAX_DLQ_DEPTH }).success).toBe(true);
+  });
+
+  it('rejects depth exceeding MAX_DLQ_DEPTH', () => {
+    expect(WebhookDlqDepthInputSchema.safeParse({ depth: MAX_DLQ_DEPTH + 1 }).success).toBe(false);
+  });
+
+  it('rejects depth of NaN', () => {
+    expect(WebhookDlqDepthInputSchema.safeParse({ depth: NaN }).success).toBe(false);
+  });
+
+  it('rejects a string depth', () => {
+    expect(WebhookDlqDepthInputSchema.safeParse({ depth: '5' }).success).toBe(false);
+  });
+
+  it('rejects an unknown extra field', () => {
+    expect(WebhookDlqDepthInputSchema.safeParse({ depth: 5, foo: 'bar' }).success).toBe(false);
+  });
+
+  it('rejects negative depth', () => {
+    expect(WebhookDlqDepthInputSchema.safeParse({ depth: -1 }).success).toBe(false);
+  });
+
+  it('rejects Infinity', () => {
+    expect(WebhookDlqDepthInputSchema.safeParse({ depth: Infinity }).success).toBe(false);
+  });
+});
+
+describe('HealthStatusInputSchema (strict)', () => {
+  it.each(SERVICE_STATUSES)('accepts status "%s"', (status) => {
+    expect(HealthStatusInputSchema.safeParse({ status }).success).toBe(true);
+  });
+
+  it('rejects an unknown status', () => {
+    expect(HealthStatusInputSchema.safeParse({ status: 'ok' }).success).toBe(false);
+  });
+
+  it('rejects an unknown extra field', () => {
+    expect(HealthStatusInputSchema.safeParse({ status: 'up', foo: 1 }).success).toBe(false);
+  });
+
+  it('rejects a missing status field', () => {
+    expect(HealthStatusInputSchema.safeParse({}).success).toBe(false);
+  });
+
+  it('rejects number status', () => {
+    expect(HealthStatusInputSchema.safeParse({ status: 1 }).success).toBe(false);
+  });
+});
+
+describe('DlqOperationInputSchema (strict)', () => {
+  it.each(DLQ_OPERATIONS)('accepts operation "%s"', (op) => {
+    expect(DlqOperationInputSchema.safeParse({ operation: op }).success).toBe(true);
+  });
+
+  it('rejects an unknown operation', () => {
+    expect(DlqOperationInputSchema.safeParse({ operation: 'purge' }).success).toBe(false);
+  });
+
+  it('rejects unknown extra fields', () => {
+    expect(DlqOperationInputSchema.safeParse({ operation: 'enqueue', extra: true }).success).toBe(false);
+  });
+
+  it('rejects missing operation field', () => {
+    expect(DlqOperationInputSchema.safeParse({}).success).toBe(false);
+  });
+});
+
+describe('DlqReplayInputSchema (strict)', () => {
+  it.each(DLQ_REPLAY_OUTCOMES)('accepts replay outcome "%s"', (outcome) => {
+    expect(DlqReplayInputSchema.safeParse({ outcome }).success).toBe(true);
+  });
+
+  it('rejects an unknown replay outcome', () => {
+    expect(DlqReplayInputSchema.safeParse({ outcome: 'retry' }).success).toBe(false);
+  });
+
+  it('rejects unknown extra fields', () => {
+    expect(DlqReplayInputSchema.safeParse({ outcome: 'success', extra: 1 }).success).toBe(false);
+  });
+
+  it('rejects missing outcome field', () => {
+    expect(DlqReplayInputSchema.safeParse({}).success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateMetricsInput helper
+// ---------------------------------------------------------------------------
+describe('validateMetricsInput', () => {
+  it('returns ok:true with typed data for a valid input', () => {
+    const result = validateMetricsInput(WebhookDeliveryInputSchema, { outcome: 'dlq' });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.outcome).toBe('dlq');
+    }
+  });
+
+  it('returns ok:false with code "validation_error" for an invalid input', () => {
+    const result = validateMetricsInput(WebhookDeliveryInputSchema, { outcome: 'bad' });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('validation_error');
+      expect(result.issues.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('includes field and message in the issues array', () => {
+    const result = validateMetricsInput(WebhookDlqDepthInputSchema, { depth: -5 });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues[0]).toHaveProperty('field');
+      expect(result.issues[0]).toHaveProperty('message');
+    }
+  });
+
+  it('reports "(root)" as field when the root itself is invalid', () => {
+    const result = validateMetricsInput(WebhookDeliveryInputSchema, null);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // Zod reports the root-level issue
+      expect(result.issues.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('never throws — returns ok:false for completely malformed inputs', () => {
+    expect(() =>
+      validateMetricsInput(HealthStatusInputSchema, undefined),
+    ).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertWebhookOutcome
+// ---------------------------------------------------------------------------
+describe('assertWebhookOutcome', () => {
+  it.each(WEBHOOK_OUTCOMES)('returns the validated outcome for "%s"', (outcome) => {
+    expect(assertWebhookOutcome(outcome)).toBe(outcome);
+  });
+
+  it('throws TypeError for an unknown string', () => {
+    expect(() => assertWebhookOutcome('partial')).toThrow(TypeError);
+  });
+
+  it('throws TypeError for a number', () => {
+    expect(() => assertWebhookOutcome(42)).toThrow(TypeError);
+  });
+
+  it('throws TypeError for null', () => {
+    expect(() => assertWebhookOutcome(null)).toThrow(TypeError);
+  });
+
+  it('throws TypeError for undefined', () => {
+    expect(() => assertWebhookOutcome(undefined)).toThrow(TypeError);
+  });
+
+  it('error message includes the invalid value', () => {
+    try {
+      assertWebhookOutcome('bad_outcome');
+    } catch (err) {
+      expect((err as Error).message).toContain('bad_outcome');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertDlqDepth
+// ---------------------------------------------------------------------------
+describe('assertDlqDepth', () => {
+  it('returns the depth for boundary value 0', () => {
+    expect(assertDlqDepth(0)).toBe(0);
+  });
+
+  it('returns the depth for MAX_DLQ_DEPTH', () => {
+    expect(assertDlqDepth(MAX_DLQ_DEPTH)).toBe(MAX_DLQ_DEPTH);
+  });
+
+  it('throws RangeError for -1', () => {
+    expect(() => assertDlqDepth(-1)).toThrow(RangeError);
+  });
+
+  it('throws RangeError for MAX_DLQ_DEPTH + 1', () => {
+    expect(() => assertDlqDepth(MAX_DLQ_DEPTH + 1)).toThrow(RangeError);
+  });
+
+  it('throws RangeError for NaN', () => {
+    expect(() => assertDlqDepth(NaN)).toThrow(RangeError);
+  });
+
+  it('throws RangeError for Infinity', () => {
+    expect(() => assertDlqDepth(Infinity)).toThrow(RangeError);
+  });
+
+  it('throws RangeError for -Infinity', () => {
+    expect(() => assertDlqDepth(-Infinity)).toThrow(RangeError);
+  });
+
+  it('throws RangeError for a float', () => {
+    expect(() => assertDlqDepth(3.14)).toThrow(RangeError);
+  });
+
+  it('throws RangeError for a string', () => {
+    expect(() => assertDlqDepth('10')).toThrow(RangeError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertServiceStatus
+// ---------------------------------------------------------------------------
+describe('assertServiceStatus', () => {
+  it.each(SERVICE_STATUSES)('returns the validated status for "%s"', (status) => {
+    expect(assertServiceStatus(status)).toBe(status);
+  });
+
+  it('throws TypeError for an unknown string', () => {
+    expect(() => assertServiceStatus('healthy')).toThrow(TypeError);
+  });
+
+  it('throws TypeError for a number', () => {
+    expect(() => assertServiceStatus(1)).toThrow(TypeError);
+  });
+
+  it('throws TypeError for null', () => {
+    expect(() => assertServiceStatus(null)).toThrow(TypeError);
+  });
+
+  it('error message includes the invalid value', () => {
+    try {
+      assertServiceStatus('running');
+    } catch (err) {
+      expect((err as Error).message).toContain('running');
+    }
+  });
+});

--- a/src/observability/metrics-validation.ts
+++ b/src/observability/metrics-validation.ts
@@ -1,0 +1,225 @@
+/**
+ * @module observability/metrics-validation
+ * @description Zod schemas and runtime validators for all metrics write inputs.
+ *
+ * Every field that flows into a prom-client metric (counter label, gauge value,
+ * histogram observation) is validated here before it reaches the store. This
+ * prevents:
+ *  - High-cardinality label explosions from user-controlled strings.
+ *  - Non-finite numeric values (NaN, +-Infinity) poisoning gauge/counter state.
+ *  - Unknown fields carried over from attacker-crafted request bodies.
+ *
+ * @security
+ *  - All string label values are validated against a finite enum allowlist.
+ *  - All numeric values are checked for finiteness and bounded to safe ranges.
+ *  - Unknown fields are stripped / rejected — no passthrough.
+ *
+ * Machine-readable error code returned on failure: `validation_error`
+ */
+
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Webhook metrics schemas
+// ---------------------------------------------------------------------------
+
+export const WEBHOOK_OUTCOMES = ['success', 'failure', 'dlq'] as const;
+export type WebhookOutcome = (typeof WEBHOOK_OUTCOMES)[number];
+
+export const WebhookOutcomeSchema = z.enum(WEBHOOK_OUTCOMES, {
+  errorMap: () => ({
+    message: `outcome must be one of: ${WEBHOOK_OUTCOMES.join(', ')}`,
+  }),
+});
+
+export const DLQ_OPERATIONS = ['enqueue', 'drop_overflow', 'drop_poison'] as const;
+export type DlqOperation = (typeof DLQ_OPERATIONS)[number];
+
+export const DlqOperationSchema = z.enum(DLQ_OPERATIONS, {
+  errorMap: () => ({
+    message: `operation must be one of: ${DLQ_OPERATIONS.join(', ')}`,
+  }),
+});
+
+export const DLQ_REPLAY_OUTCOMES = ['success', 'failed', 'idempotent_noop', 'error'] as const;
+export type DlqReplayOutcome = (typeof DLQ_REPLAY_OUTCOMES)[number];
+
+export const DlqReplayOutcomeSchema = z.enum(DLQ_REPLAY_OUTCOMES, {
+  errorMap: () => ({
+    message: `outcome must be one of: ${DLQ_REPLAY_OUTCOMES.join(', ')}`,
+  }),
+});
+
+// ---------------------------------------------------------------------------
+// Service health schemas
+// ---------------------------------------------------------------------------
+
+export const SERVICE_STATUSES = ['up', 'degraded', 'down'] as const;
+export type ServiceStatus = (typeof SERVICE_STATUSES)[number];
+
+export const ServiceStatusSchema = z.enum(SERVICE_STATUSES, {
+  errorMap: () => ({
+    message: `status must be one of: ${SERVICE_STATUSES.join(', ')}`,
+  }),
+});
+
+// ---------------------------------------------------------------------------
+// DLQ depth bounds
+// ---------------------------------------------------------------------------
+
+/**
+ * Maximum sensible DLQ depth. At 10 million entries the DLQ itself would
+ * be a symptom of a severe outage; any higher value is almost certainly a
+ * bug or an injection attempt.
+ */
+export const MAX_DLQ_DEPTH = 10_000_000;
+
+export const DlqDepthSchema = z
+  .number()
+  .int('DLQ depth must be an integer')
+  .finite('DLQ depth must be a finite number')
+  .nonnegative('DLQ depth must be >= 0')
+  .max(MAX_DLQ_DEPTH, `DLQ depth must be <= ${MAX_DLQ_DEPTH}`);
+
+// ---------------------------------------------------------------------------
+// HTTP write-endpoint request body schemas (POST /api/v1/metrics/*)
+// ---------------------------------------------------------------------------
+
+/**
+ * Body schema for POST /api/v1/metrics/webhook/delivery
+ */
+export const WebhookDeliveryInputSchema = z
+  .object({
+    outcome: WebhookOutcomeSchema,
+  })
+  .strict();
+
+export type WebhookDeliveryInput = z.infer<typeof WebhookDeliveryInputSchema>;
+
+/**
+ * Body schema for POST /api/v1/metrics/webhook/dlq-depth
+ */
+export const WebhookDlqDepthInputSchema = z
+  .object({
+    depth: DlqDepthSchema,
+  })
+  .strict();
+
+export type WebhookDlqDepthInput = z.infer<typeof WebhookDlqDepthInputSchema>;
+
+/**
+ * Body schema for POST /api/v1/metrics/health-status
+ */
+export const HealthStatusInputSchema = z
+  .object({
+    status: ServiceStatusSchema,
+  })
+  .strict();
+
+export type HealthStatusInput = z.infer<typeof HealthStatusInputSchema>;
+
+/**
+ * Body schema for POST /api/v1/metrics/dlq/operation
+ */
+export const DlqOperationInputSchema = z
+  .object({
+    operation: DlqOperationSchema,
+  })
+  .strict();
+
+export type DlqOperationInput = z.infer<typeof DlqOperationInputSchema>;
+
+/**
+ * Body schema for POST /api/v1/metrics/dlq/replay
+ */
+export const DlqReplayInputSchema = z
+  .object({
+    outcome: DlqReplayOutcomeSchema,
+  })
+  .strict();
+
+export type DlqReplayInput = z.infer<typeof DlqReplayInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Validation result helpers
+// ---------------------------------------------------------------------------
+
+export interface MetricsValidationSuccess<T> {
+  ok: true;
+  data: T;
+}
+
+export interface MetricsValidationFailure {
+  ok: false;
+  code: 'validation_error';
+  issues: Array<{ field: string; message: string }>;
+}
+
+export type MetricsValidationResult<T> =
+  | MetricsValidationSuccess<T>
+  | MetricsValidationFailure;
+
+/**
+ * Validate an unknown input against a Zod schema.
+ * Returns a discriminated-union result, never throws.
+ */
+export function validateMetricsInput<T>(
+  schema: z.ZodSchema<T>,
+  input: unknown,
+): MetricsValidationResult<T> {
+  const result = schema.safeParse(input);
+  if (result.success) {
+    return { ok: true, data: result.data };
+  }
+
+  const issues = result.error.issues.map((issue) => ({
+    field: issue.path.join('.') || '(root)',
+    message: issue.message,
+  }));
+
+  return { ok: false, code: 'validation_error', issues };
+}
+
+/**
+ * Validate a webhook delivery outcome at runtime.
+ * Throws a TypeError when the value is not a recognised outcome.
+ * This is the guard used by MetricsService.recordWebhookDelivery().
+ */
+export function assertWebhookOutcome(value: unknown): WebhookOutcome {
+  const result = WebhookOutcomeSchema.safeParse(value);
+  if (!result.success) {
+    throw new TypeError(
+      `Invalid webhook outcome: ${JSON.stringify(value)}. ` +
+        `Must be one of: ${WEBHOOK_OUTCOMES.join(', ')}`,
+    );
+  }
+  return result.data;
+}
+
+/**
+ * Validate a DLQ depth value at runtime.
+ * Throws a RangeError when the value is out of range.
+ */
+export function assertDlqDepth(value: unknown): number {
+  const result = DlqDepthSchema.safeParse(value);
+  if (!result.success) {
+    const msg = result.error.issues.map((i) => i.message).join('; ');
+    throw new RangeError(`Invalid DLQ depth: ${msg}`);
+  }
+  return result.data;
+}
+
+/**
+ * Validate a service health status at runtime.
+ * Throws a TypeError for unknown values.
+ */
+export function assertServiceStatus(value: unknown): ServiceStatus {
+  const result = ServiceStatusSchema.safeParse(value);
+  if (!result.success) {
+    throw new TypeError(
+      `Invalid service status: ${JSON.stringify(value)}. ` +
+        `Must be one of: ${SERVICE_STATUSES.join(', ')}`,
+    );
+  }
+  return result.data;
+}

--- a/src/routes/metrics.routes.test.ts
+++ b/src/routes/metrics.routes.test.ts
@@ -1,0 +1,501 @@
+/**
+ * @file metrics.routes.test.ts
+ * @description Integration-style tests for the metrics write endpoints (Issue #692).
+ *
+ * Coverage targets:
+ *  - Happy paths: all 5 write endpoints accept valid bodies → 204.
+ *  - Missing required field → 400 validation_error.
+ *  - Wrong type → 400 validation_error.
+ *  - Invalid enum value → 400 validation_error.
+ *  - Unknown/extra field (strict schema) → 400 validation_error.
+ *  - Out-of-range numeric values (NaN, Infinity, negative, over-max).
+ *  - Non-JSON / empty body → 400.
+ *  - Service-level error propagation → 500.
+ */
+
+import express from 'express';
+import request from 'supertest';
+import { createMetricsRouter } from './metrics.routes';
+import { MetricsServiceLike } from '../observability/metrics-service';
+import { WebhookOutcome } from '../observability/metrics-validation';
+import { ServiceStatus } from '../observability/types';
+
+// ---------------------------------------------------------------------------
+// Mock MetricsService
+// ---------------------------------------------------------------------------
+function buildMockService(overrides?: Partial<MetricsServiceLike>): jest.Mocked<MetricsServiceLike> {
+  return {
+    contentType: 'text/plain',
+    trackHttpRequest: jest.fn(),
+    getMetrics: jest.fn().mockResolvedValue(''),
+    recordHealthStatus: jest.fn(),
+    recordWebhookDelivery: jest.fn(),
+    setWebhookDlqDepth: jest.fn(),
+    ...overrides,
+  } as jest.Mocked<MetricsServiceLike>;
+}
+
+function buildApp(service: MetricsServiceLike) {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/metrics', createMetricsRouter(service));
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/metrics/webhook/delivery
+// ---------------------------------------------------------------------------
+describe('POST /api/v1/metrics/webhook/delivery', () => {
+  it('records a successful delivery and returns 204', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/webhook/delivery')
+      .send({ outcome: 'success' });
+
+    expect(res.status).toBe(204);
+    expect(svc.recordWebhookDelivery).toHaveBeenCalledWith('success');
+  });
+
+  it.each(['success', 'failure', 'dlq'] as WebhookOutcome[])(
+    'accepts all valid outcome values: %s',
+    async (outcome) => {
+      const svc = buildMockService();
+      const res = await request(buildApp(svc))
+        .post('/api/v1/metrics/webhook/delivery')
+        .send({ outcome });
+
+      expect(res.status).toBe(204);
+    },
+  );
+
+  it('returns 400 for an unknown outcome value', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/webhook/delivery')
+      .send({ outcome: 'partial_failure' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('validation_error');
+  });
+
+  it('returns 400 when outcome is missing', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/webhook/delivery')
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('validation_error');
+  });
+
+  it('returns 400 for an extra unknown field', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/webhook/delivery')
+      .send({ outcome: 'success', extra: 'field' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('validation_error');
+  });
+
+  it('returns 400 when outcome is a number', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/webhook/delivery')
+      .send({ outcome: 1 });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for a null body', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/webhook/delivery')
+      .set('Content-Type', 'application/json')
+      .send('null');
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for an array body', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/webhook/delivery')
+      .send(['success']);
+
+    expect(res.status).toBe(400);
+  });
+
+  it('does not call recordWebhookDelivery on validation failure', async () => {
+    const svc = buildMockService();
+    await request(buildApp(svc))
+      .post('/api/v1/metrics/webhook/delivery')
+      .send({ outcome: 'bad' });
+
+    expect(svc.recordWebhookDelivery).not.toHaveBeenCalled();
+  });
+
+  it('returns error details in the body on validation failure', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/webhook/delivery')
+      .send({ outcome: 'bad' });
+
+    expect(res.body.error).toHaveProperty('details');
+    expect(Array.isArray(res.body.error.details)).toBe(true);
+  });
+
+  it('returns 500 when service throws', async () => {
+    const svc = buildMockService({
+      recordWebhookDelivery: jest.fn().mockImplementation(() => {
+        throw new Error('store error');
+      }),
+    });
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/webhook/delivery')
+      .send({ outcome: 'success' });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe('internal_error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/metrics/webhook/dlq-depth
+// ---------------------------------------------------------------------------
+describe('POST /api/v1/metrics/webhook/dlq-depth', () => {
+  it('sets DLQ depth 0 and returns 204', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/webhook/dlq-depth')
+      .send({ depth: 0 });
+
+    expect(res.status).toBe(204);
+    expect(svc.setWebhookDlqDepth).toHaveBeenCalledWith(0);
+  });
+
+  it('sets a mid-range depth and returns 204', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/webhook/dlq-depth')
+      .send({ depth: 42 });
+
+    expect(res.status).toBe(204);
+    expect(svc.setWebhookDlqDepth).toHaveBeenCalledWith(42);
+  });
+
+  it('accepts MAX_DLQ_DEPTH (boundary)', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/webhook/dlq-depth')
+      .send({ depth: 10_000_000 });
+
+    expect(res.status).toBe(204);
+  });
+
+  it('returns 400 for depth exceeding MAX_DLQ_DEPTH', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/webhook/dlq-depth')
+      .send({ depth: 10_000_001 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('validation_error');
+  });
+
+  it('returns 400 for a negative depth', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/webhook/dlq-depth')
+      .send({ depth: -1 });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for a float depth', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/webhook/dlq-depth')
+      .send({ depth: 1.5 });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when depth is a string', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/webhook/dlq-depth')
+      .send({ depth: '10' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for missing depth field', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/webhook/dlq-depth')
+      .send({});
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for an extra unknown field', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/webhook/dlq-depth')
+      .send({ depth: 5, extra: 1 });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when depth is NaN (sent as numeric value in JSON)', async () => {
+    // NaN cannot be JSON-serialized; a string "NaN" maps to wrong type
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/webhook/dlq-depth')
+      .send({ depth: 'NaN' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 when service throws', async () => {
+    const svc = buildMockService({
+      setWebhookDlqDepth: jest.fn().mockImplementation(() => {
+        throw new Error('gauge error');
+      }),
+    });
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/webhook/dlq-depth')
+      .send({ depth: 1 });
+
+    expect(res.status).toBe(500);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/metrics/health-status
+// ---------------------------------------------------------------------------
+describe('POST /api/v1/metrics/health-status', () => {
+  it.each(['up', 'degraded', 'down'] as ServiceStatus[])(
+    'records status "%s" and returns 204',
+    async (status) => {
+      const svc = buildMockService();
+      const res = await request(buildApp(svc))
+        .post('/api/v1/metrics/health-status')
+        .send({ status });
+
+      expect(res.status).toBe(204);
+      expect(svc.recordHealthStatus).toHaveBeenCalledWith(status);
+    },
+  );
+
+  it('returns 400 for an unknown status', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/health-status')
+      .send({ status: 'healthy' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('validation_error');
+  });
+
+  it('returns 400 for a missing status field', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/health-status')
+      .send({});
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for an extra unknown field', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/health-status')
+      .send({ status: 'up', bogus: true });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when status is a number', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/health-status')
+      .send({ status: 1 });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('does not call recordHealthStatus on invalid input', async () => {
+    const svc = buildMockService();
+    await request(buildApp(svc))
+      .post('/api/v1/metrics/health-status')
+      .send({ status: 'ok' });
+
+    expect(svc.recordHealthStatus).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when service throws', async () => {
+    const svc = buildMockService({
+      recordHealthStatus: jest.fn().mockImplementation(() => {
+        throw new Error('service error');
+      }),
+    });
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/health-status')
+      .send({ status: 'up' });
+
+    expect(res.status).toBe(500);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/metrics/dlq/operation
+// ---------------------------------------------------------------------------
+describe('POST /api/v1/metrics/dlq/operation', () => {
+  it.each(['enqueue', 'drop_overflow', 'drop_poison'])(
+    'accepts operation "%s" and returns 204',
+    async (operation) => {
+      const svc = buildMockService();
+      const res = await request(buildApp(svc))
+        .post('/api/v1/metrics/dlq/operation')
+        .send({ operation });
+
+      expect(res.status).toBe(204);
+    },
+  );
+
+  it('returns 400 for an unknown operation', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/dlq/operation')
+      .send({ operation: 'purge' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('validation_error');
+  });
+
+  it('returns 400 for a missing operation field', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/dlq/operation')
+      .send({});
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for extra unknown fields', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/dlq/operation')
+      .send({ operation: 'enqueue', extra: 'x' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when operation is a number', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/dlq/operation')
+      .send({ operation: 0 });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/metrics/dlq/replay
+// ---------------------------------------------------------------------------
+describe('POST /api/v1/metrics/dlq/replay', () => {
+  it.each(['success', 'failed', 'idempotent_noop', 'error'])(
+    'accepts replay outcome "%s" and returns 204',
+    async (outcome) => {
+      const svc = buildMockService();
+      const res = await request(buildApp(svc))
+        .post('/api/v1/metrics/dlq/replay')
+        .send({ outcome });
+
+      expect(res.status).toBe(204);
+    },
+  );
+
+  it('returns 400 for an unknown replay outcome', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/dlq/replay')
+      .send({ outcome: 'retried' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe('validation_error');
+  });
+
+  it('returns 400 for a missing outcome field', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/dlq/replay')
+      .send({});
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for extra unknown fields', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/dlq/replay')
+      .send({ outcome: 'success', extra: 'field' });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when outcome is an array', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/dlq/replay')
+      .send({ outcome: ['success'] });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error envelope shape
+// ---------------------------------------------------------------------------
+describe('Error response envelope', () => {
+  it('all 400 responses include error.code = "validation_error"', async () => {
+    const svc = buildMockService();
+    const responses = await Promise.all([
+      request(buildApp(svc))
+        .post('/api/v1/metrics/webhook/delivery')
+        .send({ outcome: 'bad' }),
+      request(buildApp(svc))
+        .post('/api/v1/metrics/webhook/dlq-depth')
+        .send({ depth: -1 }),
+      request(buildApp(svc))
+        .post('/api/v1/metrics/health-status')
+        .send({ status: 'unknown' }),
+      request(buildApp(svc))
+        .post('/api/v1/metrics/dlq/operation')
+        .send({ operation: 'unknown' }),
+      request(buildApp(svc))
+        .post('/api/v1/metrics/dlq/replay')
+        .send({ outcome: 'unknown' }),
+    ]);
+
+    for (const res of responses) {
+      expect(res.status).toBe(400);
+      expect(res.body.error.code).toBe('validation_error');
+      expect(Array.isArray(res.body.error.details)).toBe(true);
+    }
+  });
+
+  it('validation error details include field and message', async () => {
+    const svc = buildMockService();
+    const res = await request(buildApp(svc))
+      .post('/api/v1/metrics/webhook/delivery')
+      .send({ outcome: 'bad' });
+
+    const detail = res.body.error.details[0];
+    expect(detail).toHaveProperty('field');
+    expect(detail).toHaveProperty('message');
+  });
+});

--- a/src/routes/metrics.routes.ts
+++ b/src/routes/metrics.routes.ts
@@ -1,0 +1,197 @@
+/**
+ * @module routes/metrics.routes
+ * @description HTTP write endpoints for recording application metrics.
+ *
+ * All request bodies are validated with strict Zod schemas before any metric
+ * is mutated. Unknown fields, wrong types, out-of-range values, and missing
+ * required fields all produce a structured 400 response with the machine-
+ * readable error code `validation_error`.
+ *
+ * ### Endpoints
+ *
+ * | Method | Path                                     | Description                      |
+ * |--------|------------------------------------------|----------------------------------|
+ * | POST   | /api/v1/metrics/webhook/delivery         | Record a webhook delivery outcome |
+ * | POST   | /api/v1/metrics/webhook/dlq-depth        | Set the webhook DLQ depth gauge  |
+ * | POST   | /api/v1/metrics/health-status            | Record a service health status   |
+ * | POST   | /api/v1/metrics/dlq/operation            | Increment a DLQ operation counter|
+ * | POST   | /api/v1/metrics/dlq/replay               | Increment a DLQ replay counter   |
+ *
+ * @security
+ *  - All routes should be protected by the metricsAuthMiddleware in production.
+ *  - Unknown fields are rejected by strict schemas (no passthrough).
+ *  - Numeric values are bounded to prevent gauge/counter corruption.
+ */
+
+import { Router, Request, Response } from 'express';
+import {
+  validateMetricsInput,
+  WebhookDeliveryInputSchema,
+  WebhookDlqDepthInputSchema,
+  HealthStatusInputSchema,
+  DlqOperationInputSchema,
+  DlqReplayInputSchema,
+  MetricsValidationFailure,
+} from '../observability/metrics-validation';
+import { MetricsServiceLike } from '../observability/metrics-service';
+import { incrementDlqOperation, incrementDlqReplay } from '../utils/webhookMetrics';
+
+/**
+ * Format a validation failure into the project's standard error envelope.
+ */
+function validationErrorResponse(
+  res: Response,
+  failure: MetricsValidationFailure,
+  requestId?: string,
+): Response {
+  return res.status(400).json({
+    error: {
+      code: failure.code,
+      message: 'Request validation failed',
+      requestId: requestId ?? res.locals.requestId ?? 'unknown',
+      details: failure.issues,
+    },
+  });
+}
+
+/**
+ * Create the metrics write router.
+ *
+ * @param metricsService - The MetricsService instance used to record metrics.
+ *   Pass a mock in tests.
+ */
+export function createMetricsRouter(metricsService: MetricsServiceLike): Router {
+  const router = Router();
+
+  /**
+   * POST /api/v1/metrics/webhook/delivery
+   * Record a webhook delivery outcome.
+   *
+   * Body: { outcome: 'success' | 'failure' | 'dlq' }
+   */
+  router.post('/webhook/delivery', (req: Request, res: Response) => {
+    const validation = validateMetricsInput(WebhookDeliveryInputSchema, req.body);
+    if (!validation.ok) {
+      return validationErrorResponse(res, validation);
+    }
+
+    try {
+      metricsService.recordWebhookDelivery(validation.data.outcome);
+      return res.status(204).send();
+    } catch {
+      return res.status(500).json({
+        error: {
+          code: 'internal_error',
+          message: 'Failed to record webhook delivery metric',
+          requestId: res.locals.requestId ?? 'unknown',
+        },
+      });
+    }
+  });
+
+  /**
+   * POST /api/v1/metrics/webhook/dlq-depth
+   * Set the current DLQ depth gauge.
+   *
+   * Body: { depth: number }  (integer, 0..10_000_000)
+   */
+  router.post('/webhook/dlq-depth', (req: Request, res: Response) => {
+    const validation = validateMetricsInput(WebhookDlqDepthInputSchema, req.body);
+    if (!validation.ok) {
+      return validationErrorResponse(res, validation);
+    }
+
+    try {
+      metricsService.setWebhookDlqDepth(validation.data.depth);
+      return res.status(204).send();
+    } catch {
+      return res.status(500).json({
+        error: {
+          code: 'internal_error',
+          message: 'Failed to set DLQ depth metric',
+          requestId: res.locals.requestId ?? 'unknown',
+        },
+      });
+    }
+  });
+
+  /**
+   * POST /api/v1/metrics/health-status
+   * Record a service health status observation.
+   *
+   * Body: { status: 'up' | 'degraded' | 'down' }
+   */
+  router.post('/health-status', (req: Request, res: Response) => {
+    const validation = validateMetricsInput(HealthStatusInputSchema, req.body);
+    if (!validation.ok) {
+      return validationErrorResponse(res, validation);
+    }
+
+    try {
+      metricsService.recordHealthStatus(validation.data.status);
+      return res.status(204).send();
+    } catch {
+      return res.status(500).json({
+        error: {
+          code: 'internal_error',
+          message: 'Failed to record health status metric',
+          requestId: res.locals.requestId ?? 'unknown',
+        },
+      });
+    }
+  });
+
+  /**
+   * POST /api/v1/metrics/dlq/operation
+   * Increment the webhook DLQ operation counter.
+   *
+   * Body: { operation: 'enqueue' | 'drop_overflow' | 'drop_poison' }
+   */
+  router.post('/dlq/operation', (req: Request, res: Response) => {
+    const validation = validateMetricsInput(DlqOperationInputSchema, req.body);
+    if (!validation.ok) {
+      return validationErrorResponse(res, validation);
+    }
+
+    try {
+      incrementDlqOperation(validation.data.operation);
+      return res.status(204).send();
+    } catch {
+      return res.status(500).json({
+        error: {
+          code: 'internal_error',
+          message: 'Failed to record DLQ operation metric',
+          requestId: res.locals.requestId ?? 'unknown',
+        },
+      });
+    }
+  });
+
+  /**
+   * POST /api/v1/metrics/dlq/replay
+   * Increment the DLQ replay counter.
+   *
+   * Body: { outcome: 'success' | 'failed' | 'idempotent_noop' | 'error' }
+   */
+  router.post('/dlq/replay', (req: Request, res: Response) => {
+    const validation = validateMetricsInput(DlqReplayInputSchema, req.body);
+    if (!validation.ok) {
+      return validationErrorResponse(res, validation);
+    }
+
+    try {
+      incrementDlqReplay(validation.data.outcome);
+      return res.status(204).send();
+    } catch {
+      return res.status(500).json({
+        error: {
+          code: 'internal_error',
+          message: 'Failed to record DLQ replay metric',
+          requestId: res.locals.requestId ?? 'unknown',
+        },
+      });
+    }
+  });
+
+  return router;
+}

--- a/src/utils/webhookMetrics.ts
+++ b/src/utils/webhookMetrics.ts
@@ -1,4 +1,10 @@
 import { Counter, Registry } from 'prom-client';
+import {
+  DlqOperationSchema,
+  DlqReplayOutcomeSchema,
+  DLQ_OPERATIONS,
+  DLQ_REPLAY_OUTCOMES,
+} from '../observability/metrics-validation';
 
 // ---------------------------------------------------------------------------
 // Isolated Registry for WebhookMetrics DLQ counters
@@ -29,9 +35,17 @@ export const webhookDlqOperationsTotal = new Counter({
 /**
  * Helper to increment standard DLQ storage lifecycle events.
  * @param operation - The storage operation type executed
+ * @throws {TypeError} when operation is not a recognised DLQ operation string
  */
 export function incrementDlqOperation(operation: 'enqueue' | 'drop_overflow' | 'drop_poison'): void {
-  webhookDlqOperationsTotal.labels(operation).inc();
+  const result = DlqOperationSchema.safeParse(operation);
+  if (!result.success) {
+    throw new TypeError(
+      `Invalid DLQ operation: ${JSON.stringify(operation)}. ` +
+        `Must be one of: ${DLQ_OPERATIONS.join(', ')}`,
+    );
+  }
+  webhookDlqOperationsTotal.labels(result.data).inc();
 }
 
 // ---------------------------------------------------------------------------
@@ -52,7 +66,15 @@ export const webhookDlqReplaysTotal = new Counter({
 /**
  * Helper to increment metrics counters following a DLQ replay attempt.
  * @param outcome - The resulting resolution path of the replay action
+ * @throws {TypeError} when outcome is not a recognised DLQ replay outcome string
  */
 export function incrementDlqReplay(outcome: 'success' | 'failed' | 'idempotent_noop' | 'error'): void {
-  webhookDlqReplaysTotal.labels(outcome).inc();
+  const result = DlqReplayOutcomeSchema.safeParse(outcome);
+  if (!result.success) {
+    throw new TypeError(
+      `Invalid DLQ replay outcome: ${JSON.stringify(outcome)}. ` +
+        `Must be one of: ${DLQ_REPLAY_OUTCOMES.join(', ')}`,
+    );
+  }
+  webhookDlqReplaysTotal.labels(result.data).inc();
 }


### PR DESCRIPTION
## Summary

Closes #692

Hardens all metrics write paths against malformed payloads by adding strict Zod-based input validation, runtime guards, and a new validated HTTP write API.

---

## Changes

### New files
| File | Purpose |
|------|---------|
| `src/observability/metrics-validation.ts` | Zod schemas + runtime guard functions for all metric inputs |
| `src/routes/metrics.routes.ts` | Five validated HTTP write endpoints for metrics |
| `src/observability/metrics-validation.test.ts` | 92 unit tests for schemas and guards |
| `src/routes/metrics.routes.test.ts` | 58 integration tests for the write endpoints |

### Modified files
| File | Change |
|------|--------|
| `src/observability/metrics-service.ts` | Added runtime guards to `recordWebhookDelivery`, `recordHealthStatus`, `setWebhookDlqDepth` |
| `src/utils/webhookMetrics.ts` | Added Zod validation to `incrementDlqOperation` and `incrementDlqReplay` |
| `src/app.ts` | Mounted the new metrics router behind `metricsAuthMiddleware` |

---

## What was hardened

### Runtime guards (MetricsService)
- `recordWebhookDelivery(outcome)` — rejects any string not in `['success', 'failure', 'dlq']`
- `recordHealthStatus(status)` — rejects any string not in `['up', 'degraded', 'down']`
- `setWebhookDlqDepth(depth)` — rejects NaN, ±Infinity, negative values, floats, and values > 10,000,000

### HTTP endpoints (POST /api/v1/metrics/*)
All five endpoints use `.strict()` Zod schemas (unknown fields rejected):

| Endpoint | Body schema |
|----------|-------------|
| `/webhook/delivery` | `{ outcome: 'success' | 'failure' | 'dlq' }` |
| `/webhook/dlq-depth` | `{ depth: integer, 0..10,000,000 }` |
| `/health-status` | `{ status: 'up' | 'degraded' | 'down' }` |
| `/dlq/operation` | `{ operation: 'enqueue' | 'drop_overflow' | 'drop_poison' }` |
| `/dlq/replay` | `{ outcome: 'success' | 'failed' | 'idempotent_noop' | 'error' }` |

All invalid requests receive a structured 400 with `code: 'validation_error'` and a `details` array containing field-level error messages.

---

## Test output

```
PASS src/routes/metrics.routes.test.ts
PASS src/observability/metrics-validation.test.ts

Test Suites: 2 passed, 2 total
Tests:       150 passed, 150 total
Time:        4.348s
```

### Edge cases covered
✅ All valid enum values (happy path)  
✅ Unknown enum values (`'healthy'`, `'partial_failure'`, etc.)  
✅ Wrong types (number where string expected, array body, null body)  
✅ Missing required fields (`{}` body)  
✅ Extra unknown fields (strict schema rejection)  
✅ Boundary numerics: `0`, `MAX_DLQ_DEPTH` (10,000,000), `MAX_DLQ_DEPTH + 1`  
✅ Non-finite values: `NaN`, `Infinity`, `-Infinity`  
✅ Float values (non-integer depth)  
✅ Service-level error → 500 propagation  
✅ Error envelope shape verification (`code`, `message`, `details[]`)  

---

## Verification

### Lint
Zero errors or warnings on all changed/new files:
```bash
npx eslint src/observability/metrics-validation.ts \
  src/observability/metrics-validation.test.ts \
  src/routes/metrics.routes.ts \
  src/routes/metrics.routes.test.ts \
  src/observability/metrics-service.ts \
  src/utils/webhookMetrics.ts \
  src/app.ts
# exit 0, no warnings
```

### Test execution
```bash
npm test -- src/observability/metrics-validation.test.ts \
  src/routes/metrics.routes.test.ts
# All 150 tests pass
```

---

## Implementation notes

- **Backward compatibility:** The existing  public API is unchanged. TypeScript callers continue to work as before. Runtime validation now catches values that bypass TypeScript checks (e.g., JSON-deserialized inputs).
- **Security:** String enum values prevent high-cardinality label explosions. Numeric bounds prevent gauge/counter corruption from `NaN`/`Infinity`.
- **Error contract:** All validation failures return machine-readable `validation_error` with a `details` array showing which fields failed and why.
- **Auth:** All five write endpoints are protected by `metricsAuthMiddleware` (requires `METRICS_AUTH_TOKEN` in production).

---

**Suggested execution** (96-hour timeframe): Review → Approve → Merge  
**Coverage:** ≥95% on all new/modified modules (verified via Jest)