### PR TITLE
feat(auth): add cursor pagination

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -25,7 +25,6 @@ module.exports = {
     'validate.middleware.test.ts',
     'src/auth/__tests__/roles.test.ts',
     'src/config/config.test.ts',
-    'src/controllers/__tests__/apiKeyController.test.ts',
     'src/httpClient.test.ts',
     'src/index.test.ts',
     'src/logger.test.ts',

--- a/src/app.ts
+++ b/src/app.ts
@@ -25,6 +25,7 @@ import contractsModuleRouter from './routes/contracts.routes';
 import eventsRouter from './routes/events.routes';
 
 import reputationRouter from './routes/reputation.routes';
+import apiKeysRouter from './routes/apiKeys.routes';
 import configRouter from './routes/config.routes';
 import dependencyScanRouter from './routes/dependency-scan.routes';
 import { adminRouter } from './routes/admin.routes';
@@ -86,6 +87,7 @@ export function createApp(options?: AppFactoryOptions): express.Application {
   app.use('/health', readinessHealthRouter);
   app.use('/api/config', configRouter);
   app.use('/api/v1', eventsRouter);
+  app.use('/api/v1', apiKeysRouter);
   app.use('/api/v1/contracts', contractsModuleRouter);
   app.use('/api/v1/reputation', reputationRouter);
   app.use('/api/v1/dependency-scan', dependencyScanRouter);

--- a/src/controllers/__tests__/apiKeyController.test.ts
+++ b/src/controllers/__tests__/apiKeyController.test.ts
@@ -92,6 +92,134 @@ describe('API Key Controller', () => {
 
       expect(response.status).toBe(401);
     });
+
+    it('should include pagination metadata on an unfilled first page', async () => {
+      const response = await request(app)
+        .get('/api/v1/api-keys')
+        .set('Authorization', `Bearer ${userToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.hasNextPage).toBe(false);
+      expect(response.body.nextCursor).toBeNull();
+      expect(response.body.limit).toBe(20);
+    });
+  });
+
+  describe('GET /api/v1/api-keys — pagination', () => {
+    const { createApiKey } = require('../../auth/apiKeys');
+
+    /** Creates `count` sequential keys for `test-user`, oldest first. */
+    async function seedKeys(count: number): Promise<void> {
+      for (let i = 0; i < count; i++) {
+        await createApiKey({
+          name: `Key ${i}`,
+          scope: ['contracts:read'],
+          createdBy: 'test-user'
+        });
+      }
+    }
+
+    it('returns an empty page when the user has no keys', async () => {
+      const response = await request(app)
+        .get('/api/v1/api-keys')
+        .set('Authorization', `Bearer ${userToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.apiKeys).toEqual([]);
+      expect(response.body.total).toBe(0);
+      expect(response.body.hasNextPage).toBe(false);
+      expect(response.body.nextCursor).toBeNull();
+    });
+
+    it('paginates across pages without duplicates or omissions', async () => {
+      await seedKeys(5);
+
+      const seen: string[] = [];
+      let cursor: string | undefined;
+      let pages = 0;
+
+      do {
+        const response: any = await request(app)
+          .get('/api/v1/api-keys')
+          .query({ limit: 2, ...(cursor ? { cursor } : {}) })
+          .set('Authorization', `Bearer ${userToken}`);
+
+        expect(response.status).toBe(200);
+        expect(response.body.apiKeys.length).toBeLessThanOrEqual(2);
+        seen.push(...response.body.apiKeys.map((k: { id: string }) => k.id));
+        cursor = response.body.nextCursor ?? undefined;
+        pages++;
+      } while (cursor && pages < 10);
+
+      expect(seen).toHaveLength(5);
+      expect(new Set(seen).size).toBe(5); // no duplicates across pages
+    });
+
+    it('returns hasNextPage=false and nextCursor=null exactly at the page boundary', async () => {
+      await seedKeys(4);
+
+      const response = await request(app)
+        .get('/api/v1/api-keys')
+        .query({ limit: 4 })
+        .set('Authorization', `Bearer ${userToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.apiKeys).toHaveLength(4);
+      expect(response.body.hasNextPage).toBe(false);
+      expect(response.body.nextCursor).toBeNull();
+    });
+
+    it('clamps an over-limit request to the maximum page size instead of erroring', async () => {
+      await seedKeys(3);
+
+      const response = await request(app)
+        .get('/api/v1/api-keys')
+        .query({ limit: 100000 })
+        .set('Authorization', `Bearer ${userToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.limit).toBe(100);
+      expect(response.body.apiKeys).toHaveLength(3);
+    });
+
+    it('rejects a malformed cursor with 400', async () => {
+      const response = await request(app)
+        .get('/api/v1/api-keys')
+        .query({ cursor: 'not-a-valid-cursor!!!' })
+        .set('Authorization', `Bearer ${userToken}`);
+
+      expect(response.status).toBe(400);
+      expect(response.body).toHaveProperty('error');
+    });
+
+    it('rejects a well-formed but tampered cursor payload with 400', async () => {
+      const tampered = Buffer.from(JSON.stringify({ foo: 'bar' }), 'utf8').toString('base64url');
+
+      const response = await request(app)
+        .get('/api/v1/api-keys')
+        .query({ cursor: tampered })
+        .set('Authorization', `Bearer ${userToken}`);
+
+      expect(response.status).toBe(400);
+    });
+
+    it('keeps the owner filter applied across pages (does not leak other users keys)', async () => {
+      await seedKeys(2);
+      await createApiKey({
+        name: 'Other User Key',
+        scope: ['contracts:read'],
+        createdBy: 'someone-else'
+      });
+
+      const response = await request(app)
+        .get('/api/v1/api-keys')
+        .query({ limit: 10 })
+        .set('Authorization', `Bearer ${userToken}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.apiKeys).toHaveLength(2);
+      expect(response.body.apiKeys.every((k: { name: string }) => k.name !== 'Other User Key')).toBe(true);
+    });
   });
 
   describe('GET /api/v1/api-keys/:id', () => {
@@ -150,7 +278,8 @@ describe('API Key Controller', () => {
     it('should rotate API key', async () => {
       const response = await request(app)
         .post(`/api/v1/api-keys/${keyId}/rotate`)
-        .set('Authorization', `Bearer ${userToken}`);
+        .set('Authorization', `Bearer ${userToken}`)
+        .send({});
 
       expect(response.status).toBe(200);
       expect(response.body).toHaveProperty('message');
@@ -163,14 +292,16 @@ describe('API Key Controller', () => {
     it('should return 404 for non-existent key', async () => {
       const response = await request(app)
         .post('/api/v1/api-keys/non-existent/rotate')
-        .set('Authorization', `Bearer ${userToken}`);
+        .set('Authorization', `Bearer ${userToken}`)
+        .send({});
 
       expect(response.status).toBe(404);
     });
 
     it('should require authentication', async () => {
       const response = await request(app)
-        .post(`/api/v1/api-keys/${keyId}/rotate`);
+        .post(`/api/v1/api-keys/${keyId}/rotate`)
+        .send({});
 
       expect(response.status).toBe(401);
     });

--- a/src/controllers/apiKeyController.ts
+++ b/src/controllers/apiKeyController.ts
@@ -6,10 +6,11 @@
  * These endpoints should be protected by JWT authentication (not API key auth).
  */
 
-import { Request, Response } from 'express';
+import { Response } from 'express';
 import { createApiKey, rotateApiKey, deactivateApiKey } from '../auth/apiKeys';
 import { database } from '../database';
 import { AuthenticatedRequest } from '../auth/authenticate';
+import { decodeCursor } from '../contracts/cursor.repository';
 
 /**
  * Create a new API key.
@@ -80,7 +81,11 @@ export async function createApiKeyController(req: AuthenticatedRequest, res: Res
 
 /**
  * List API keys for the authenticated user.
- * 
+ *
+ * Cursor-paginated: `?limit=<n>` (1-100, default 20) bounds the page size and
+ * `?cursor=<opaque>` resumes from the previous page's `nextCursor`. Existing
+ * filters (owned-by-caller, active-only) apply identically across pages.
+ *
  * @route GET /api/v1/api-keys
  * @access Private (requires JWT authentication)
  */
@@ -91,13 +96,26 @@ export async function listApiKeysController(req: AuthenticatedRequest, res: Resp
       return;
     }
 
-    const db = await (database as any).loadDatabase();
-    const userKeys = db.api_keys.filter((key: any) => 
-      key.created_by === req.user!.userId && key.is_active
-    );
+    // Malformed/negative/over-max values are bounded rather than rejected —
+    // see DatabaseService#listApiKeysPage for the clamp policy.
+    const rawLimit = req.query['limit'];
+    const limit = rawLimit !== undefined ? Number(rawLimit) : undefined;
+
+    const rawCursor = req.query['cursor'];
+    const cursor = typeof rawCursor === 'string' && rawCursor.length > 0 ? rawCursor : undefined;
+    if (cursor !== undefined) {
+      try {
+        decodeCursor(cursor);
+      } catch (err) {
+        res.status(400).json({ error: (err as Error).message });
+        return;
+      }
+    }
+
+    const pageResult = await database.listApiKeysPage(req.user.userId, { limit, cursor });
 
     // Remove sensitive data
-    const safeKeys = userKeys.map((key: any) => ({
+    const safeKeys = pageResult.data.map((key) => ({
       id: key.id,
       name: key.name,
       scope: key.scope,
@@ -110,7 +128,10 @@ export async function listApiKeysController(req: AuthenticatedRequest, res: Resp
 
     res.json({
       apiKeys: safeKeys,
-      total: safeKeys.length
+      total: safeKeys.length,
+      nextCursor: pageResult.nextCursor,
+      hasNextPage: pageResult.hasNextPage,
+      limit: pageResult.limit
     });
   } catch (error) {
     console.error('Error listing API keys:', error);

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1,6 +1,9 @@
 import { promises as fs } from 'fs';
 import * as path from 'path';
 import { Database, ContractMetadata, Contract, User, ApiKey } from './schema';
+import { decodeCursor, encodeCursor } from '../contracts/cursor.repository';
+import type { CursorPage, CursorPaginationInput } from '../contracts/cursor.types';
+import { MAX_PAGE_LIMIT, DEFAULT_PAGE_LIMIT } from '../utils/pagination';
 
 const DB_PATH = path.join(__dirname, '../../data/database.json');
 
@@ -212,6 +215,52 @@ class DatabaseService {
   async getApiKeyBySelector(selector: string): Promise<ApiKey | null> {
     const db = await this.loadDatabase();
     return db.api_keys.find(key => key.key_selector === selector && key.is_active) || null;
+  }
+
+  /**
+   * Returns a cursor-paginated, newest-first page of active API keys created by `userId`.
+   *
+   * Ordering is stable (created_at DESC, id DESC as tie-breaker) so that concurrent
+   * inserts never shift already-issued cursors. `limit` is bounded to
+   * [1, MAX_PAGE_LIMIT] and silently clamped rather than rejected; omitted or
+   * non-positive values fall back to DEFAULT_PAGE_LIMIT. An invalid `cursor`
+   * throws and must be handled by the caller.
+   */
+  async listApiKeysPage(userId: string, input: CursorPaginationInput = {}): Promise<CursorPage<ApiKey>> {
+    const db = await this.loadDatabase();
+    const limit =
+      input.limit !== undefined && Number.isFinite(input.limit) && input.limit >= 1
+        ? Math.min(Math.trunc(input.limit), MAX_PAGE_LIMIT)
+        : DEFAULT_PAGE_LIMIT;
+
+    let filtered = db.api_keys.filter(
+      key => key.created_by === userId && key.is_active
+    );
+
+    filtered.sort((a, b) => {
+      const dateA = new Date(a.created_at).getTime();
+      const dateB = new Date(b.created_at).getTime();
+      if (dateB !== dateA) return dateB - dateA;
+      return b.id.localeCompare(a.id);
+    });
+
+    if (input.cursor) {
+      const pos = decodeCursor(input.cursor);
+      filtered = filtered.filter(key => {
+        const createdAt = new Date(key.created_at).toISOString();
+        return createdAt < pos.createdAt || (createdAt === pos.createdAt && key.id < pos.id);
+      });
+    }
+
+    const hasNextPage = filtered.length > limit;
+    const data = filtered.slice(0, limit);
+    const lastItem = data.at(-1);
+    const nextCursor =
+      hasNextPage && lastItem
+        ? encodeCursor({ createdAt: new Date(lastItem.created_at).toISOString(), id: lastItem.id })
+        : null;
+
+    return { data, nextCursor, hasNextPage, limit };
   }
 
   async updateApiKey(id: string, updates: Partial<Pick<ApiKey, 'name' | 'scope' | 'expires_at' | 'is_active' | 'last_used_at' | 'key_selector'>>): Promise<ApiKey | null> {

--- a/src/routes/apiKeys.routes.ts
+++ b/src/routes/apiKeys.routes.ts
@@ -56,9 +56,18 @@ router.post(
 
 /**
  * @route   GET /api/v1/api-keys
- * @desc    List all API keys for the authenticated user
+ * @desc    List active API keys for the authenticated user, newest first.
+ *          Cursor-paginated via opaque `nextCursor` tokens so results stay
+ *          stable across pages even as new keys are created concurrently.
  * @access  Private (requires JWT authentication)
+ * @query   limit  - Page size, 1-100 (default 20). Out-of-range values are
+ *                   clamped rather than rejected.
+ * @query   cursor - Opaque cursor from the previous page's `nextCursor`.
+ *                   Omit for the first page. A malformed cursor returns 400.
  * @example
+ * // Request
+ * GET /api/v1/api-keys?limit=20
+ *
  * // Response
  * {
  *   "apiKeys": [
@@ -73,7 +82,10 @@ router.post(
  *       "isActive": true
  *     }
  *   ],
- *   "total": 1
+ *   "total": 1,
+ *   "nextCursor": null,
+ *   "hasNextPage": false,
+ *   "limit": 20
  * }
  */
 router.get(


### PR DESCRIPTION
Closes #681

---

## Summary
- Adds opaque-cursor pagination to the API key listing endpoint (`GET /api/v1/api-keys`), which previously returned every key for a user in one unbounded array.
- `DatabaseService.listApiKeysPage` returns a newest-first page (stable `created_at DESC, id DESC` ordering) with an opaque `nextCursor`; `limit` is clamped to `[1, 100]` (default 20) rather than rejected. Existing owner/active-only filters apply identically across pages. Item shape is unchanged — the response envelope just gains `nextCursor`, `hasNextPage`, and `limit` alongside the existing `apiKeys`/`total`.
- Also restores `apiKeys.routes` mounting in `app.ts` and re-enables `apiKeyController.test.ts` in `jest.config.js` — both had been dropped/disabled during an earlier force-merge (see the `3bc3926` CI-restoration commit), leaving this endpoint unreachable. Fixed 3 pre-existing `rotate` tests that 415'd once the route became reachable again (global content-type middleware needs a body/content-type header on POST).

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 2713/2722 passed (9 pre-existing failures across 4 unrelated suites, confirmed present on `main` before this change)
- [x] `npm run build` — succeeds
- [x] Edge cases covered: empty result set, exact-page boundary, over-limit clamp, malformed cursor, tampered cursor payload, cross-page owner-filter isolation

### npm run build
talenttrust-backend@0.1.0 build
tsc -p tsconfig.build.json

(no output — clean compile)



### npm run lint
talenttrust-backend@0.1.0 lint
eslint src

✖ 52 problems (0 errors, 52 warnings)
(all warnings pre-existing, in files untouched by this change)



### npm test
PASS src/controllers/tests/apiKeyController.test.ts (22 tests)

Test Suites: 4 failed, 148 passed, 152 total
Tests:       9 failed, 2713 passed, 2722 total
Snapshots:   0 total
Time:        86.552 s

Failing suites (pre-existing on main, unrelated to this change — verified via
git stash comparison): src/hooks/escrow.hooks.test.ts,
src/observability/metrics-service.test.ts, src/middleware/metricsAuth.test.ts,
src/utils/webhookMetrics.test.ts


## Known pre-existing CI failures (unrelated to this PR)

Job 89478426351 (and any similar run) will show 4 failing suites / 9 failing tests:
- `src/hooks/escrow.hooks.test.ts` — TS7006 implicit-any compile errors
- `src/observability/metrics-service.test.ts` — route-label metric assertion
- `src/middleware/metricsAuth.test.ts` — `crypto.timingSafeEqual` spy failure
- `src/utils/webhookMetrics.test.ts` — DLQ counter metric lookups

These are **not caused by this change**. Verified by stashing this PR's diff and
running the full suite against `main` directly: the same 9 tests fail with
identical errors, and none of the touched files (`escrow.hooks.ts`,
`metrics-service.ts`, `metricsAuth.ts`, `webhookMetrics.ts`) were modified here.

Root causes appear to be pre-existing test-isolation issues (shared Prometheus
registry state bleeding across test files, a `crypto.timingSafeEqual` spy that's
sensitive to run order) plus a couple of stale TS7006 compile errors in
`escrow.hooks.test.ts`. Tracking as a separate follow-up rather than fixing here
to keep this PR scoped to auth-listing pagination.
