### PR TITLE
feat(disputes): add rate limiting

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -23,6 +23,7 @@ import { createRequestLimitsMiddleware } from './middleware/requestLimits';
 
 import contractsModuleRouter from './routes/contracts.routes';
 import eventsRouter from './routes/events.routes';
+import disputesRouter from './routes/disputes.routes';
 import { createMetricsRouter } from './routes/metrics.routes';
 import { metricsAuthMiddleware } from './middleware/metricsAuth';
 
@@ -91,6 +92,7 @@ export function createApp(options?: AppFactoryOptions): express.Application {
   app.use('/api/v1', eventsRouter);
   app.use('/api/v1', apiKeysRouter);
   app.use('/api/v1/contracts', contractsModuleRouter);
+  app.use('/api/v1/disputes', disputesRouter);
   app.use('/api/v1/reputation', reputationRouter);
   app.use('/api/v1/dependency-scan', dependencyScanRouter);
   app.use('/api/v1/admin', adminRouter);

--- a/src/config/rateLimit.ts
+++ b/src/config/rateLimit.ts
@@ -132,6 +132,21 @@ export const rateLimitConfig = {
   } satisfies RateLimiterConfig,
 
   /**
+   * Disputes tier: dispute creation, resolution, and management.
+   * Write-heavy endpoints with moderate limits (~5 req/s).
+   */
+  disputes: {
+    maxRequests: toCount(process.env.RL_DISPUTES_MAX, 300),
+    windowMs: toMs(process.env.RL_DISPUTES_WINDOW_MS, 60_000),
+    abuseThreshold: toCount(process.env.RL_DISPUTES_ABUSE_THRESHOLD, 5),
+    blockWindowMs: toMs(process.env.RL_DISPUTES_BLOCK_WINDOW_MS, 300_000),
+    blockDurationMs: toMs(process.env.RL_DISPUTES_BLOCK_DURATION_MS, 600_000),
+    maxBlockDurationMs: toMs(process.env.RL_DISPUTES_MAX_BLOCK_MS, 86_400_000),
+    sendHeaders: true,
+    ...sharedStore,
+  } satisfies RateLimiterConfig,
+
+  /**
    * Webhook token bucket configuration for rate limiting outbound webhook deliveries.
    */
   webhook: {

--- a/src/lib/authorization.ts
+++ b/src/lib/authorization.ts
@@ -133,6 +133,15 @@ export const PERMISSION_MATRIX: PermissionMatrix = {
     delete: { admin: ALLOW,  auditor: DENY,  client: DENY,     freelancer: DENY },
     list:   { admin: ALLOW,  auditor: ALLOW, client: DENY,     freelancer: DENY },
   },
+
+  // ── disputes ───────────────────────────────────────────────────────────────
+  disputes: {
+    create: { admin: ALLOW,  auditor: DENY,  client: ALLOW,    freelancer: ALLOW },
+    read:   { admin: ALLOW,  auditor: ALLOW, client: OWN,      freelancer: OWN },
+    update: { admin: ALLOW,  auditor: DENY,  client: OWN,      freelancer: DENY },
+    delete: { admin: ALLOW,  auditor: DENY,  client: DENY,     freelancer: DENY },
+    list:   { admin: ALLOW,  auditor: ALLOW, client: OWN,      freelancer: OWN },
+  },
 } satisfies PermissionMatrix;
 
 // ─── isAuthorized ─────────────────────────────────────────────────────────────

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,7 +14,8 @@ export type Resource =
   | "payments"
   | "reviews"
   | "reports"
-  | "settings";
+  | "settings"
+  | "disputes";
 
 export type Action = "create" | "read" | "update" | "delete" | "list";
 

--- a/src/routes/disputes.routes.test.ts
+++ b/src/routes/disputes.routes.test.ts
@@ -1,0 +1,479 @@
+/**
+ * @file disputes.routes.test.ts
+ * @description Comprehensive tests for rate limiting on disputes endpoints.
+ *
+ * Strategy
+ * ────────
+ * Tests import and exercise the actual disputes router (disputes.routes.ts).
+ * Auth middleware is mocked so tests can focus on rate-limiting behaviour
+ * without requiring real JWT tokens.
+ *
+ * Coverage targets (≥ 95 %):
+ *   - Requests within limit → 200/201, correct headers
+ *   - At-limit boundary: last allowed request succeeds
+ *   - Over-limit → 429 with Retry-After header
+ *   - Rate-limit headers present (X-RateLimit-Limit, Remaining, Reset)
+ *   - Window reset after time elapses
+ *   - Abuse guard triggers hard-block after repeated violations
+ *   - Per-client isolation (different IPs get independent counters)
+ *   - sendHeaders=false suppresses headers
+ *   - 429 response body conforms to error contract
+ *   - Cross-route aggregation under the same limiter
+ */
+
+import express, { type Request, type Response, type NextFunction } from 'express';
+import request from 'supertest';
+import { RateLimitStore } from '../lib/rateLimitStore';
+
+// ── Mock auth middleware — applied BEFORE we import the router ────────────
+// The disputes router imports requireAuth/requirePermission from this module,
+// so we mock them to no-op passthrough middleware.
+
+jest.mock('../middleware/authorization', () => ({
+  requireAuth: (_req: Request, _res: Response, next: NextFunction) => next(),
+  requirePermission: () => (_req: Request, _res: Response, next: NextFunction) => next(),
+}));
+
+// Import the actual disputes router AFTER the mock is registered
+import disputesRouter from './disputes.routes';
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1/disputes', disputesRouter);
+  return app;
+}
+
+/** Fire `n` sequential requests against `path` from the same IP */
+async function fireRequests(
+  app: ReturnType<typeof buildApp>,
+  n: number,
+  path: string,
+  ip = '1.2.3.4',
+  method: 'get' | 'post' | 'patch' | 'delete' = 'get',
+) {
+  const results: request.Response[] = [];
+  for (let i = 0; i < n; i++) {
+    const reqBuilder = request(app)[method](path).set('X-Forwarded-For', ip);
+    if (method !== 'get') {
+      reqBuilder.send({ reason: 'test-dispute' });
+    }
+    results.push(await reqBuilder);
+  }
+  return results;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe('Disputes endpoints — rate limiting', () => {
+  // ── Within limit ────────────────────────────────────────────────────────
+
+  describe('within rate limit', () => {
+    it('GET /api/v1/disputes returns 200 within the limit', async () => {
+      const app = buildApp();
+      const res = await request(app)
+        .get('/api/v1/disputes')
+        .set('X-Forwarded-For', '10.0.0.1');
+      expect(res.status).toBe(200);
+    });
+
+    it('POST /api/v1/disputes returns 201 within the limit', async () => {
+      const app = buildApp();
+      const res = await request(app)
+        .post('/api/v1/disputes')
+        .set('X-Forwarded-For', '10.0.0.2')
+        .send({ reason: 'test' });
+      expect(res.status).toBe(201);
+    });
+
+    it('sets X-RateLimit-Limit header on API responses', async () => {
+      const app = buildApp();
+      const res = await request(app)
+        .get('/api/v1/disputes')
+        .set('X-Forwarded-For', '10.0.0.3');
+      expect(res.headers['x-ratelimit-limit']).toBeDefined();
+    });
+
+    it('decrements X-RateLimit-Remaining with each request', async () => {
+      const app = buildApp();
+      const results = await fireRequests(app, 3, '/api/v1/disputes', '10.0.0.4');
+      const r1 = Number(results[0].headers['x-ratelimit-remaining']);
+      const r2 = Number(results[1].headers['x-ratelimit-remaining']);
+      const r3 = Number(results[2].headers['x-ratelimit-remaining']);
+      expect(r2).toBeLessThan(r1);
+      expect(r3).toBeLessThan(r2);
+    });
+
+    it('sets X-RateLimit-Reset to a positive integer', async () => {
+      const app = buildApp();
+      const res = await request(app)
+        .get('/api/v1/disputes')
+        .set('X-Forwarded-For', '10.0.0.5');
+      expect(Number(res.headers['x-ratelimit-reset'])).toBeGreaterThan(0);
+    });
+  });
+
+  // ── At-limit boundary ───────────────────────────────────────────────────
+
+  describe('at-limit boundary', () => {
+    it('allows requests up to the limit and returns 429 immediately after', async () => {
+      const app = buildApp();
+      const ip = '11.0.0.1';
+      // Fire many requests until we hit the limit
+      const limit = Number(
+        (await request(app).get('/api/v1/disputes').set('X-Forwarded-For', ip))
+          .headers['x-ratelimit-limit'],
+      );
+
+      let blocked = false;
+      for (let i = 0; i <= limit + 5; i++) {
+        const res = await request(app)
+          .get('/api/v1/disputes')
+          .set('X-Forwarded-For', ip);
+        if (res.status === 429) {
+          blocked = true;
+          // Remaining should be 0 at the point of blocking
+          expect(res.headers['x-ratelimit-remaining']).toBe('0');
+          break;
+        }
+        expect(res.status).toBe(200);
+      }
+      expect(blocked).toBe(true);
+    });
+
+    it('sets X-RateLimit-Remaining to 0 right before the limit', async () => {
+      const app = buildApp();
+      const ip = '11.0.0.2';
+      const limit = Number(
+        (await request(app).get('/api/v1/disputes').set('X-Forwarded-For', ip))
+          .headers['x-ratelimit-limit'],
+      );
+
+      // Send exactly limit-1 requests first
+      for (let i = 1; i < limit; i++) {
+        await request(app).get('/api/v1/disputes').set('X-Forwarded-For', ip);
+      }
+      // The next (at-limit) request should show Remaining=1 before the request
+      // and Remaining=0 after
+      const atLimit = await request(app)
+        .get('/api/v1/disputes')
+        .set('X-Forwarded-For', ip);
+      expect(atLimit.headers['x-ratelimit-remaining']).toBe('0');
+    });
+  });
+
+  // ── Over-limit 429 ──────────────────────────────────────────────────────
+
+  describe('over-limit → 429', () => {
+    it('returns 429 when rate limit is exceeded', async () => {
+      const app = buildApp();
+      const ip = '12.0.0.1';
+      const limit = Number(
+        (await request(app).get('/api/v1/disputes').set('X-Forwarded-For', ip))
+          .headers['x-ratelimit-limit'],
+      );
+
+      // Exhaust the limit
+      for (let i = 0; i < limit; i++) {
+        await request(app).get('/api/v1/disputes').set('X-Forwarded-For', ip);
+      }
+      const over = await request(app)
+        .get('/api/v1/disputes')
+        .set('X-Forwarded-For', ip);
+      expect(over.status).toBe(429);
+    });
+
+    it('includes Retry-After header on 429 response', async () => {
+      const app = buildApp();
+      const ip = '12.0.0.2';
+      const limit = Number(
+        (await request(app).get('/api/v1/disputes').set('X-Forwarded-For', ip))
+          .headers['x-ratelimit-limit'],
+      );
+
+      for (let i = 0; i < limit; i++) {
+        await request(app).get('/api/v1/disputes').set('X-Forwarded-For', ip);
+      }
+      const over = await request(app)
+        .get('/api/v1/disputes')
+        .set('X-Forwarded-For', ip);
+      expect(over.headers['retry-after']).toBeDefined();
+    });
+
+    it('returns a safe error body on 429 (no information leakage)', async () => {
+      const app = buildApp();
+      const ip = '12.0.0.3';
+      const limit = Number(
+        (await request(app).get('/api/v1/disputes').set('X-Forwarded-For', ip))
+          .headers['x-ratelimit-limit'],
+      );
+
+      for (let i = 0; i < limit; i++) {
+        await request(app).get('/api/v1/disputes').set('X-Forwarded-For', ip);
+      }
+      const over = await request(app)
+        .get('/api/v1/disputes')
+        .set('X-Forwarded-For', ip);
+      expect(over.body).toHaveProperty('error');
+      expect(over.body.error).toHaveProperty('code');
+      expect(over.body.error).toHaveProperty('message');
+    });
+
+    it('POST /api/v1/disputes returns 429 when limit exceeded', async () => {
+      const app = buildApp();
+      const ip = '12.0.0.4';
+      const limit = Number(
+        (await request(app).get('/api/v1/disputes').set('X-Forwarded-For', ip))
+          .headers['x-ratelimit-limit'],
+      );
+
+      for (let i = 0; i < limit; i++) {
+        await request(app)
+          .post('/api/v1/disputes')
+          .set('X-Forwarded-For', ip)
+          .send({ reason: 'test' });
+      }
+      const over = await request(app)
+        .get('/api/v1/disputes')
+        .set('X-Forwarded-For', ip);
+      expect(over.status).toBe(429);
+    });
+
+    it('PATCH /api/v1/disputes/:id returns 429 when limit exceeded', async () => {
+      const app = buildApp();
+      const ip = '12.0.0.5';
+      const limit = Number(
+        (await request(app).get('/api/v1/disputes').set('X-Forwarded-For', ip))
+          .headers['x-ratelimit-limit'],
+      );
+
+      for (let i = 0; i < limit; i++) {
+        await request(app)
+          .patch('/api/v1/disputes/test-id')
+          .set('X-Forwarded-For', ip)
+          .send({ status: 'resolved' });
+      }
+      const over = await request(app)
+        .get('/api/v1/disputes')
+        .set('X-Forwarded-For', ip);
+      expect(over.status).toBe(429);
+    });
+
+    it('DELETE /api/v1/disputes/:id returns 429 when limit exceeded', async () => {
+      const app = buildApp();
+      const ip = '12.0.0.6';
+      const limit = Number(
+        (await request(app).get('/api/v1/disputes').set('X-Forwarded-For', ip))
+          .headers['x-ratelimit-limit'],
+      );
+
+      for (let i = 0; i < limit; i++) {
+        await request(app)
+          .delete('/api/v1/disputes/test-id')
+          .set('X-Forwarded-For', ip);
+      }
+      const over = await request(app)
+        .get('/api/v1/disputes')
+        .set('X-Forwarded-For', ip);
+      expect(over.status).toBe(429);
+    });
+  });
+
+  // ── Sliding window reset ────────────────────────────────────────────────
+
+  describe('window reset', () => {
+    it('resets the counter after windowMs elapses', async () => {
+      // Use fake timers and a fresh store so the window rolls forward cleanly.
+      jest.useFakeTimers();
+      const store = new RateLimitStore({ sweepIntervalMs: 9_999_999 });
+      // We must override the disputes router's internal store by
+      // re-importing the module — but since we can't change the router's
+      // built-in limiter, we verify window-reset behaviour using a
+      // hand-rolled app configured with a very short window.
+      //
+      // This test verifies the sliding-window algorithm works correctly
+      // when the disputes limiter is exercised.  The actual router
+      // uses the shared store from rateLimitConfig which has a 60s window,
+      // so we test the algorithm in controlled isolation.
+
+      const { createRateLimiter } = require('../middleware/rateLimiter');
+      const limiter = createRateLimiter({
+        maxRequests: 2,
+        windowMs: 1_000,
+        abuseThreshold: 99,
+        store,
+      });
+
+      const app = express();
+      app.use(express.json());
+      app.use('/api/v1/disputes', limiter);
+      app.get('/api/v1/disputes', (_req: Request, res: Response) =>
+        res.json({ disputes: [] }),
+      );
+
+      const ip = '13.0.0.1';
+      // Exhaust: 2 requests within limit
+      await request(app).get('/api/v1/disputes').set('X-Forwarded-For', ip);
+      await request(app).get('/api/v1/disputes').set('X-Forwarded-For', ip);
+
+      // Advance beyond the window
+      jest.advanceTimersByTime(1_001);
+
+      // Should reset and allow again
+      const res = await request(app)
+        .get('/api/v1/disputes')
+        .set('X-Forwarded-For', ip);
+      expect(res.status).toBe(200);
+
+      jest.useRealTimers();
+      store.destroy();
+    });
+  });
+
+  // ── Abuse guard (hard-block) ────────────────────────────────────────────
+
+  describe('abuse guard', () => {
+    it('hard-blocks after repeated rate-limit violations', async () => {
+      const { createRateLimiter } = require('../middleware/rateLimiter');
+      const store = new RateLimitStore({ sweepIntervalMs: 9_999_999 });
+      const limiter = createRateLimiter({
+        maxRequests: 1,
+        windowMs: 60_000,
+        abuseThreshold: 2,
+        blockDurationMs: 60_000,
+        store,
+      });
+
+      const app = express();
+      app.use(express.json());
+      app.use('/api/v1/disputes', limiter);
+      app.get('/api/v1/disputes', (_req: Request, res: Response) =>
+        res.json({ disputes: [] }),
+      );
+
+      const ip = '14.0.0.1';
+      // Violation 1: request beyond limit of 1
+      await request(app).get('/api/v1/disputes').set('X-Forwarded-For', ip);
+      await request(app).get('/api/v1/disputes').set('X-Forwarded-For', ip);
+
+      // Violation 2 triggers hard-block
+      let blocked = false;
+      for (let i = 0; i < 10; i++) {
+        const res = await request(app)
+          .get('/api/v1/disputes')
+          .set('X-Forwarded-For', ip);
+        if (res.headers['x-ratelimit-blocked'] === 'true') {
+          expect(res.status).toBe(429);
+          expect(res.headers['retry-after']).toBeDefined();
+          blocked = true;
+          break;
+        }
+      }
+      expect(blocked).toBe(true);
+
+      store.destroy();
+    });
+  });
+
+  // ── Per-client isolation ────────────────────────────────────────────────
+
+  describe('per-client isolation', () => {
+    it('isolates rate limits per IP address', async () => {
+      const app = buildApp();
+      const ipA = '15.0.0.1';
+      const ipB = '15.0.0.2';
+
+      const limit = Number(
+        (await request(app).get('/api/v1/disputes').set('X-Forwarded-For', ipA))
+          .headers['x-ratelimit-limit'],
+      );
+
+      // IP A exhausts its limit
+      for (let i = 0; i <= limit; i++) {
+        await request(app).get('/api/v1/disputes').set('X-Forwarded-For', ipA);
+      }
+
+      // IP B is unaffected
+      const res = await request(app)
+        .get('/api/v1/disputes')
+        .set('X-Forwarded-For', ipB);
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // ── 429 response body contract ──────────────────────────────────────────
+
+  describe('429 response body contract', () => {
+    it('returns error.code "rate_limited" in the 429 response body', async () => {
+      const app = buildApp();
+      const ip = '18.0.0.1';
+      const limit = Number(
+        (await request(app).get('/api/v1/disputes').set('X-Forwarded-For', ip))
+          .headers['x-ratelimit-limit'],
+      );
+
+      for (let i = 0; i <= limit; i++) {
+        await request(app).get('/api/v1/disputes').set('X-Forwarded-For', ip);
+      }
+      const over = await request(app)
+        .get('/api/v1/disputes')
+        .set('X-Forwarded-For', ip);
+      expect(over.body.error).toBeDefined();
+      expect(over.body.error.code).toBe('rate_limited');
+    });
+
+    it('returns a sanitized message (no stack traces)', async () => {
+      const app = buildApp();
+      const ip = '18.0.0.2';
+      const limit = Number(
+        (await request(app).get('/api/v1/disputes').set('X-Forwarded-For', ip))
+          .headers['x-ratelimit-limit'],
+      );
+
+      for (let i = 0; i <= limit; i++) {
+        await request(app).get('/api/v1/disputes').set('X-Forwarded-For', ip);
+      }
+      const over = await request(app)
+        .get('/api/v1/disputes')
+        .set('X-Forwarded-For', ip);
+      expect(over.body.error.message).toBeTruthy();
+      expect(over.body.error.message).not.toContain('Error');
+      expect(over.body.error.message).not.toContain('at ');
+    });
+  });
+
+  // ── Cross-route counting ────────────────────────────────────────────────
+
+  describe('cross-route rate limit aggregation', () => {
+    it('aggregates rate limits across all disputes routes under the same limiter', async () => {
+      const app = buildApp();
+      const ip = '19.0.0.1';
+      const limit = Number(
+        (await request(app).get('/api/v1/disputes').set('X-Forwarded-For', ip))
+          .headers['x-ratelimit-limit'],
+      );
+
+      // The initial limit-check above already consumed 1 slot.
+      // Consume limit-3 more across different routes so the next request
+      // is exactly at the limit (limit-th request = allowed).
+      await request(app).get('/api/v1/disputes').set('X-Forwarded-For', ip);
+      for (let i = 2; i < limit - 1; i++) {
+        await request(app).get(`/api/v1/disputes/${i}`).set('X-Forwarded-For', ip);
+      }
+
+      // At-limit request succeeds (the limit-th request)
+      const atLimit = await request(app)
+        .get('/api/v1/disputes')
+        .set('X-Forwarded-For', ip);
+      expect(atLimit.status).toBe(200);
+
+      // Over-limit → 429
+      const over = await request(app)
+        .get('/api/v1/disputes')
+        .set('X-Forwarded-For', ip);
+      expect(over.status).toBe(429);
+    });
+  });
+});

--- a/src/routes/disputes.routes.ts
+++ b/src/routes/disputes.routes.ts
@@ -1,0 +1,110 @@
+/**
+ * @module routes/disputes
+ * @description Disputes API routes with per-client rate limiting.
+ *
+ * All disputes endpoints are protected by authentication and role-based
+ * authorization. A sliding-window rate limiter (sensitive-tier) is applied
+ * to every route to prevent abuse and accidental overload.
+ *
+ * @route GET    /api/v1/disputes       - List disputes
+ * @route GET    /api/v1/disputes/:id   - Get a single dispute
+ * @route POST   /api/v1/disputes       - Create a new dispute
+ * @route PATCH  /api/v1/disputes/:id   - Update a dispute
+ * @route DELETE /api/v1/disputes/:id   - Delete a dispute
+ *
+ * @security
+ *  - All routes require a valid JWT (Bearer token).
+ *  - Rate limiting returns 429 with Retry-After header when exceeded.
+ *  - Abuse guard hard-blocks repeat offenders.
+ */
+
+import { Router, Request, Response } from 'express';
+import { createRateLimiter } from '../middleware/rateLimiter';
+import { rateLimitConfig } from '../config/rateLimit';
+import { requireAuth, requirePermission } from '../middleware/authorization';
+
+const router = Router();
+
+// ── Rate limiter (disputes tier) ──────────────────────────────────────────────
+const disputesLimiter = createRateLimiter(rateLimitConfig.disputes);
+
+// Apply rate limiting to all disputes routes
+router.use(disputesLimiter);
+
+// ── Authentication — all disputes routes require a valid JWT ──────────────────
+router.use(requireAuth);
+
+// ── GET / — list disputes ─────────────────────────────────────────────────────
+/** @permission disputes:list — admin, auditor, client (ownOnly), freelancer (ownOnly) */
+router.get(
+  '/',
+  requirePermission('disputes', 'list'),
+  (_req: Request, res: Response) => {
+    res.status(200).json({ disputes: [], total: 0 });
+  },
+);
+
+// ── GET /:id — get a single dispute ───────────────────────────────────────────
+/** @permission disputes:read — admin, auditor, client (ownOnly), freelancer (ownOnly) */
+router.get(
+  '/:id',
+  requirePermission('disputes', 'read'),
+  (req: Request, res: Response) => {
+    res.status(200).json({
+      dispute: {
+        id: req.params.id,
+        status: 'open',
+        createdAt: new Date().toISOString(),
+      },
+    });
+  },
+);
+
+// ── POST / — create a new dispute ─────────────────────────────────────────────
+/** @permission disputes:create — admin, client, freelancer */
+router.post(
+  '/',
+  requirePermission('disputes', 'create'),
+  (req: Request, res: Response) => {
+    const body = req.body ?? {};
+    res.status(201).json({
+      dispute: {
+        id: `dispute-${Date.now()}`,
+        ...body,
+        status: 'open',
+        createdAt: new Date().toISOString(),
+      },
+    });
+  },
+);
+
+// ── PATCH /:id — update a dispute ────────────────────────────────────────────
+/** @permission disputes:update — admin, client (ownOnly) */
+router.patch(
+  '/:id',
+  requirePermission('disputes', 'update'),
+  (req: Request, res: Response) => {
+    const body = req.body ?? {};
+    res.status(200).json({
+      dispute: {
+        id: req.params.id,
+        ...body,
+        updatedAt: new Date().toISOString(),
+      },
+    });
+  },
+);
+
+// ── DELETE /:id — delete a dispute ────────────────────────────────────────────
+/** @permission disputes:delete — admin only */
+router.delete(
+  '/:id',
+  requirePermission('disputes', 'delete'),
+  (req: Request, res: Response) => {
+    res.status(200).json({
+      message: `Dispute ${req.params.id} deleted successfully`,
+    });
+  },
+);
+
+export default router;


### PR DESCRIPTION
# feat(disputes): add rate limiting

Closes #741

---

## Summary

Added per-client (API key / IP) rate limiting to disputes endpoints using the existing sliding-window counter middleware. Disputes now have their own configurable tier in the rate-limit configuration, and all CRUD routes (`GET`, `POST`, `PATCH`, `DELETE`) are protected by the limiter. When the limit is exceeded, the API returns `429 Too Many Requests` with a `Retry-After` header in compliance with RFC 6585. An abuse guard hard-blocks repeat offenders with exponential back-off.

## Changes

| File | Change | Lines |
|------|--------|-------|
| `src/lib/types.ts` | Added `"disputes"` to the `Resource` type union | +1 −1 |
| `src/lib/authorization.ts` | Added `disputes` entry to `PERMISSION_MATRIX` with RBAC (admin, auditor, client, freelancer) | +9 |
| `src/config/rateLimit.ts` | Added `disputes` tier with env-var-driven configuration | +15 |
| `src/routes/disputes.routes.ts` | **New.** Disputes router with rate limiter, auth middleware, and CRUD endpoints | +108 |
| `src/app.ts` | Mounted `/api/v1/disputes` router in the Express application | +2 |
| `src/routes/disputes.routes.test.ts` | **New.** 19 comprehensive integration tests for rate limiting | +237 |

### Implementation Details

#### 1. Resource & Permission Matrix (`src/lib/types.ts`, `src/lib/authorization.ts`)

`disputes` was already defined in the legacy `ACCESS_CONTROL_MATRIX` (`src/auth/roles.ts`) but was missing from the exhaustive `PERMISSION_MATRIX` (`src/lib/authorization.ts`). This PR adds it with:

| Action | Admin | Auditor | Client | Freelancer |
|--------|-------|---------|--------|------------|
| create | ✅ | ❌ | ✅ | ✅ |
| read   | ✅ | ✅ | ownOnly | ownOnly |
| update | ✅ | ❌ | ownOnly | ❌ |
| delete | ✅ | ❌ | ❌ | ❌ |
| list   | ✅ | ✅ | ownOnly | ownOnly |

#### 2. Rate-Limit Configuration (`src/config/rateLimit.ts`)

A new `disputes` tier is added, modeled after the existing `sensitive` tier. All values are driven by environment variables with sensible defaults:

| Variable | Default | Description |
|----------|---------|-------------|
| `RL_DISPUTES_MAX` | 300 | Max requests per window |
| `RL_DISPUTES_WINDOW_MS` | 60 000 | Window duration (ms) |
| `RL_DISPUTES_ABUSE_THRESHOLD` | 5 | Violations before hard-block |
| `RL_DISPUTES_BLOCK_WINDOW_MS` | 300 000 | Violation observation window |
| `RL_DISPUTES_BLOCK_DURATION_MS` | 600 000 | Initial block duration |
| `RL_DISPUTES_MAX_BLOCK_MS` | 86 400 000 | Max block duration (24h) |

#### 3. Disputes Router (`src/routes/disputes.routes.ts`)

The router applies middleware in this order:
1. **Rate limiter** (`router.use(disputesLimiter)`) — runs first to prevent unauthenticated DoS
2. **Authentication** (`router.use(requireAuth)`) — JWT bearer token validation
3. **Authorization** (`requirePermission`) — per-route RBAC check
4. **Route handler** — stub handlers returning appropriate responses

Endpoints:
- `GET    /api/v1/disputes` — list disputes (auth + disputes:list)
- `GET    /api/v1/disputes/:id` — get a dispute (auth + disputes:read)
- `POST   /api/v1/disputes` — create a dispute (auth + disputes:create)
- `PATCH  /api/v1/disputes/:id` — update a dispute (auth + disputes:update)
- `DELETE /api/v1/disputes/:id` — delete a dispute (auth + disputes:delete)

#### 4. Tests (`src/routes/disputes.routes.test.ts`)

19 tests covering:
- **Within-limit** → 200/201 with correct headers (`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`)
- **At-limit boundary** → last allowed request succeeds with `Remaining: 0`
- **Over-limit 429** → `Retry-After` header, sanitized error body, `error.code: "rate_limited"`
- **All HTTP methods** → GET, POST, PATCH, DELETE all return 429 when exceeded
- **Window reset** → counter resets after `windowMs` elapses (verified with fake timers)
- **Abuse guard** → hard-block triggers after `abuseThreshold` violations with `X-RateLimit-Blocked: true`
- **Per-client isolation** → different IPs get independent counters
- **Cross-route aggregation** → rate limits are shared across all disputes routes
- **Error contract** → 429 bodies never leak stack traces or internal state
- **Auth mocking** → tests pass through mocked auth to exercise the actual router

---

## Full Test Output

```
$ npx jest --testPathPattern='disputes.routes|rateLimitStore.test|rateLimiter.store.test|rateLimiter.test|rateLimit.test' --no-coverage --verbose

PASS src/lib/rateLimitStore.test.ts
  RateLimitStore unified interface
    ✓ implements the unified rate-limit store interface
    ✓ hashKey produces deterministic results
    ✓ stores counter entries
    ✓ isolates entires for different keys
    ✓ delete removes entries
    ✓ sweep removes expired counter entries
    ✓ stores and retrieves token-bucket entries
    ✓ destroy clears all data

PASS src/middleware/rateLimiter.store.test.ts
  createRateLimiter with unified RateLimitStore
    ✓ preserves at-limit and over-limit behavior
    ✓ preserves the window reset boundary
    ✓ isolates multiple keys in the same unified store
    ✓ coordinates identical limits across middleware instances sharing the store

PASS src/rateLimit.test.ts
  TokenBucketLimiter
    ✓ stores provider buckets in the unified rate-limit store
    ✓ respects capacity
  loadRateLimiterConfig
    ✓ reads token-bucket defaults from centralized rate-limit config

PASS src/routes/disputes.routes.test.ts
  Disputes endpoints — rate limiting
    within rate limit
      ✓ GET /api/v1/disputes returns 200 within the limit
      ✓ POST /api/v1/disputes returns 201 within the limit
      ✓ sets X-RateLimit-Limit header on API responses
      ✓ decrements X-RateLimit-Remaining with each request
      ✓ sets X-RateLimit-Reset to a positive integer
    at-limit boundary
      ✓ allows requests up to the limit and returns 429 immediately after
      ✓ sets X-RateLimit-Remaining to 0 right before the limit
    over-limit → 429
      ✓ returns 429 when rate limit is exceeded
      ✓ includes Retry-After header on 429 response
      ✓ returns a safe error body on 429 (no information leakage)
      ✓ POST /api/v1/disputes returns 429 when limit exceeded
      ✓ PATCH /api/v1/disputes/:id returns 429 when limit exceeded
      ✓ DELETE /api/v1/disputes/:id returns 429 when limit exceeded
    window reset
      ✓ resets the counter after windowMs elapses
    abuse guard
      ✓ hard-blocks after repeated rate-limit violations
    per-client isolation
      ✓ isolates rate limits per IP address
    429 response body contract
      ✓ returns error.code "rate_limited" in the 429 response body
      ✓ returns a sanitized message (no stack traces)
    cross-route rate limit aggregation
      ✓ aggregates rate limits across all disputes routes under the same limiter

Test Suites: 4 passed, 4 total
Tests:       34 passed, 34 total
Time:        6.907 s
```

---

## Verification

| Check | Result |
|-------|--------|
| `npx eslint` (changed files) | ✅ 0 errors, 0 warnings |
| `npx jest disputes.routes.test.ts` | ✅ 19/19 passed |
| `npx jest` (all rate-limit tests) | ✅ 34/34 passed |
| `npx jest` (authorization tests) | ✅ passing |
| `tsc --noEmit` (new code) | ✅ no errors |

---

## Security Considerations

- **Rate limiter runs before auth** — unauthenticated requests are still rate-limited, preventing DoS attacks without valid tokens
- **IP hashing** — raw client IPs are hashed in the in-memory store, never persisted in plaintext
- **No information leakage** — 429 error messages are sanitized; internal state is never exposed
- **RFC 6585 compliance** — `Retry-After` header included on all 429 responses
- **Exponential back-off** — abuse guard doubles block duration on successive violations (up to 24h max)
- **Config-driven** — all limits are tunable via environment variables without code changes