### PR TITLE
feat(health): add cursor pagination to probes listing endpoint

### DIFF
--- a/src/health/index.ts
+++ b/src/health/index.ts
@@ -1,5 +1,13 @@
 export { buildHealthRouter } from "./router";
-export type { HealthRouterOptions } from "./router";
+export type { HealthRouterOptions, MetricsService } from "./router";
 export { runHealthCheck } from "./checker";
 export { dbProbe, envProbe, redisProbe, stellarRpcProbe } from "./probes";
-export type { HealthResponse, ProbeResult, Probe } from "./types";
+export type { HealthResponse, PaginatedHealthResponse, ProbeResult, Probe } from "./types";
+export {
+  encodeCursor,
+  decodeCursor,
+  paginateItems,
+  clampPageSize,
+  DEFAULT_HEALTH_PAGE_SIZE,
+  MAX_HEALTH_PAGE_SIZE,
+} from "./pagination";

--- a/src/health/pagination.test.ts
+++ b/src/health/pagination.test.ts
@@ -1,0 +1,499 @@
+/**
+ * @file health/pagination.test.ts
+ * @description Comprehensive tests for cursor-based pagination logic and the
+ * paginated /health endpoint.
+ *
+ * Covers:
+ * - encodeCursor / decodeCursor round-trips
+ * - decodeCursor with invalid / tampered / out-of-range inputs
+ * - clampPageSize bounds
+ * - paginateItems — empty set, single item, exact-page boundary, over-limit
+ *   clamp, last page, multi-page traversal
+ * - HTTP-level integration via buildHealthRouter:
+ *   - default page size
+ *   - ?limit= parameter (valid, over-max clamped, invalid)
+ *   - ?cursor= parameter (valid, invalid, tampered, out-of-range)
+ *   - empty probe set
+ *   - exact-page boundary (no nextCursor on last page)
+ *   - existing verbose filter still works across pages
+ *   - item shape is unchanged
+ *   - full traversal collects all probes exactly once
+ */
+
+import express from "express";
+import request from "supertest";
+import { buildHealthRouter } from "./router";
+import { Probe } from "./types";
+import {
+  encodeCursor,
+  decodeCursor,
+  clampPageSize,
+  paginateItems,
+  DEFAULT_HEALTH_PAGE_SIZE,
+  MAX_HEALTH_PAGE_SIZE,
+} from "./pagination";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeProbe(name: string): Probe {
+  return async () => ({ name, ok: true, latencyMs: 1 });
+}
+
+/** Build N probes named probe-0 … probe-(N-1). */
+function makeProbes(n: number): Probe[] {
+  return Array.from({ length: n }, (_, i) => makeProbe(`probe-${i}`));
+}
+
+function buildApp(probes: Probe[]) {
+  const app = express();
+  app.use("/health", buildHealthRouter(probes));
+  return app;
+}
+
+// ─── encodeCursor / decodeCursor ──────────────────────────────────────────────
+
+describe("encodeCursor / decodeCursor", () => {
+  it("round-trips index 0", () => {
+    const cursor = encodeCursor(0);
+    const result = decodeCursor(cursor, 100);
+    expect(result).toEqual({ ok: true, index: 0 });
+  });
+
+  it("round-trips a mid-range index", () => {
+    const cursor = encodeCursor(42);
+    const result = decodeCursor(cursor, 100);
+    expect(result).toEqual({ ok: true, index: 42 });
+  });
+
+  it("round-trips an index equal to totalItems (valid empty-last-page)", () => {
+    const cursor = encodeCursor(10);
+    const result = decodeCursor(cursor, 10);
+    expect(result).toEqual({ ok: true, index: 10 });
+  });
+
+  it("rejects a cursor with index > totalItems", () => {
+    const cursor = encodeCursor(11);
+    const result = decodeCursor(cursor, 10);
+    expect(result).toEqual({ ok: false, error: "cursor_out_of_range" });
+  });
+
+  it("rejects a completely invalid string", () => {
+    const result = decodeCursor("not-a-cursor", 10);
+    expect(result.ok).toBe(false);
+    expect((result as { ok: false; error: string }).error).toBe("invalid_cursor");
+  });
+
+  it("rejects a base64-encoded non-JSON string", () => {
+    const garbage = Buffer.from("hello world").toString("base64url");
+    const result = decodeCursor(garbage, 10);
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects a tampered cursor (wrong JSON structure)", () => {
+    const tampered = Buffer.from(JSON.stringify({ offset: 5 })).toString("base64url");
+    const result = decodeCursor(tampered, 10);
+    expect(result).toEqual({ ok: false, error: "invalid_cursor" });
+  });
+
+  it("rejects a cursor with a negative index", () => {
+    const bad = Buffer.from(JSON.stringify({ index: -1 })).toString("base64url");
+    const result = decodeCursor(bad, 10);
+    expect(result).toEqual({ ok: false, error: "invalid_cursor" });
+  });
+
+  it("rejects a cursor with a floating-point index", () => {
+    const bad = Buffer.from(JSON.stringify({ index: 2.5 })).toString("base64url");
+    const result = decodeCursor(bad, 10);
+    expect(result).toEqual({ ok: false, error: "invalid_cursor" });
+  });
+
+  it("rejects a cursor with a string index", () => {
+    const bad = Buffer.from(JSON.stringify({ index: "5" })).toString("base64url");
+    const result = decodeCursor(bad, 10);
+    expect(result).toEqual({ ok: false, error: "invalid_cursor" });
+  });
+
+  it("rejects a cursor that is null JSON", () => {
+    const bad = Buffer.from("null").toString("base64url");
+    const result = decodeCursor(bad, 10);
+    expect(result).toEqual({ ok: false, error: "invalid_cursor" });
+  });
+
+  it("produces a URL-safe string (no +, /, or = padding)", () => {
+    for (let i = 0; i < 50; i++) {
+      const cursor = encodeCursor(i);
+      expect(cursor).not.toMatch(/[+/=]/);
+    }
+  });
+});
+
+// ─── clampPageSize ────────────────────────────────────────────────────────────
+
+describe("clampPageSize", () => {
+  it("returns the value unchanged when within range", () => {
+    expect(clampPageSize(20)).toBe(20);
+  });
+
+  it("clamps a value above MAX_HEALTH_PAGE_SIZE to the max", () => {
+    expect(clampPageSize(MAX_HEALTH_PAGE_SIZE + 1)).toBe(MAX_HEALTH_PAGE_SIZE);
+  });
+
+  it("clamps a value below 1 to 1", () => {
+    expect(clampPageSize(0)).toBe(1);
+  });
+
+  it("accepts exactly 1", () => {
+    expect(clampPageSize(1)).toBe(1);
+  });
+
+  it("accepts exactly MAX_HEALTH_PAGE_SIZE", () => {
+    expect(clampPageSize(MAX_HEALTH_PAGE_SIZE)).toBe(MAX_HEALTH_PAGE_SIZE);
+  });
+
+  it("clamps very large numbers to the max", () => {
+    expect(clampPageSize(Number.MAX_SAFE_INTEGER)).toBe(MAX_HEALTH_PAGE_SIZE);
+  });
+});
+
+// ─── paginateItems ────────────────────────────────────────────────────────────
+
+describe("paginateItems", () => {
+  it("returns an empty items array and null nextCursor for an empty input", () => {
+    const result = paginateItems([], 0, 10);
+    expect(result.items).toHaveLength(0);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it("returns all items when count < limit and no cursor", () => {
+    const items = [1, 2, 3];
+    const result = paginateItems(items, 0, 10);
+    expect(result.items).toEqual([1, 2, 3]);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it("returns the first page when count === limit (exact boundary)", () => {
+    const items = [1, 2, 3];
+    const result = paginateItems(items, 0, 3);
+    expect(result.items).toEqual([1, 2, 3]);
+    expect(result.nextCursor).toBeNull(); // exactly filled — no more items
+  });
+
+  it("returns a nextCursor when there are more items than the limit", () => {
+    const items = [1, 2, 3, 4, 5];
+    const result = paginateItems(items, 0, 3);
+    expect(result.items).toEqual([1, 2, 3]);
+    expect(result.nextCursor).not.toBeNull();
+  });
+
+  it("second page items are correct and nextCursor is null on last page", () => {
+    const items = [1, 2, 3, 4, 5];
+    const firstPage = paginateItems(items, 0, 3);
+    const cursor = firstPage.nextCursor as string;
+
+    const decoded = decodeCursor(cursor, items.length);
+    expect(decoded.ok).toBe(true);
+    const secondPage = paginateItems(items, (decoded as { ok: true; index: number }).index, 3);
+
+    expect(secondPage.items).toEqual([4, 5]);
+    expect(secondPage.nextCursor).toBeNull();
+  });
+
+  it("returns correct limit after clamping an over-limit request", () => {
+    const items = [1, 2];
+    const result = paginateItems(items, 0, MAX_HEALTH_PAGE_SIZE + 50);
+    expect(result.limit).toBe(MAX_HEALTH_PAGE_SIZE);
+  });
+
+  it("startIndex at end of array yields empty page with null cursor", () => {
+    const items = [1, 2, 3];
+    const result = paginateItems(items, 3, 10);
+    expect(result.items).toHaveLength(0);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it("full traversal collects all items exactly once", () => {
+    const items = Array.from({ length: 7 }, (_, i) => i);
+    const pageSize = 3;
+    const collected: number[] = [];
+    let startIndex = 0;
+
+    for (let page = 0; page < 10; page++) {
+      const result = paginateItems(items, startIndex, pageSize);
+      collected.push(...result.items);
+      if (result.nextCursor === null) break;
+      const decoded = decodeCursor(result.nextCursor, items.length);
+      expect(decoded.ok).toBe(true);
+      startIndex = (decoded as { ok: true; index: number }).index;
+    }
+
+    expect(collected).toEqual(items);
+  });
+});
+
+// ─── HTTP integration — buildHealthRouter ────────────────────────────────────
+
+describe("GET /health — cursor pagination (HTTP)", () => {
+  // ── Empty probe set ────────────────────────────────────────────────────────
+
+  it("returns empty probes, null nextCursor for empty probe set", async () => {
+    const res = await request(buildApp([])).get("/health");
+    expect(res.status).toBe(200);
+    expect(res.body.probes).toHaveLength(0);
+    expect(res.body.nextCursor).toBeNull();
+  });
+
+  // ── Default page size ──────────────────────────────────────────────────────
+
+  it("returns at most DEFAULT_HEALTH_PAGE_SIZE probes when limit is omitted", async () => {
+    const probes = makeProbes(DEFAULT_HEALTH_PAGE_SIZE + 5);
+    const res = await request(buildApp(probes)).get("/health");
+    expect(res.status).toBe(200);
+    expect(res.body.probes).toHaveLength(DEFAULT_HEALTH_PAGE_SIZE);
+    expect(res.body.nextCursor).not.toBeNull();
+    expect(res.body.limit).toBe(DEFAULT_HEALTH_PAGE_SIZE);
+  });
+
+  it("returns all probes when total < DEFAULT_HEALTH_PAGE_SIZE", async () => {
+    const probes = makeProbes(5);
+    const res = await request(buildApp(probes)).get("/health");
+    expect(res.status).toBe(200);
+    expect(res.body.probes).toHaveLength(5);
+    expect(res.body.nextCursor).toBeNull();
+  });
+
+  // ── ?limit= parameter ─────────────────────────────────────────────────────
+
+  it("respects ?limit= within range", async () => {
+    const probes = makeProbes(10);
+    const res = await request(buildApp(probes)).get("/health?limit=3");
+    expect(res.status).toBe(200);
+    expect(res.body.probes).toHaveLength(3);
+    expect(res.body.limit).toBe(3);
+    expect(res.body.nextCursor).not.toBeNull();
+  });
+
+  it("clamps ?limit= above MAX_HEALTH_PAGE_SIZE to the max", async () => {
+    const probes = makeProbes(5);
+    const res = await request(buildApp(probes)).get(
+      `/health?limit=${MAX_HEALTH_PAGE_SIZE + 50}`,
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.limit).toBe(MAX_HEALTH_PAGE_SIZE);
+  });
+
+  it("returns 400 for ?limit=0", async () => {
+    const res = await request(buildApp(makeProbes(3))).get("/health?limit=0");
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+
+  it("returns 400 for a non-integer ?limit=", async () => {
+    const res = await request(buildApp(makeProbes(3))).get("/health?limit=abc");
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+  });
+
+  it("returns 400 for a negative ?limit=", async () => {
+    const res = await request(buildApp(makeProbes(3))).get("/health?limit=-5");
+    expect(res.status).toBe(400);
+  });
+
+  // ── Exact-page boundary (no nextCursor on last page) ──────────────────────
+
+  it("nextCursor is null when total probes === limit (exact boundary)", async () => {
+    const probes = makeProbes(5);
+    const res = await request(buildApp(probes)).get("/health?limit=5");
+    expect(res.status).toBe(200);
+    expect(res.body.probes).toHaveLength(5);
+    expect(res.body.nextCursor).toBeNull();
+  });
+
+  it("nextCursor is present when total probes === limit + 1", async () => {
+    const probes = makeProbes(6);
+    const res = await request(buildApp(probes)).get("/health?limit=5");
+    expect(res.status).toBe(200);
+    expect(res.body.probes).toHaveLength(5);
+    expect(res.body.nextCursor).not.toBeNull();
+  });
+
+  // ── ?cursor= navigation ────────────────────────────────────────────────────
+
+  it("second page via cursor returns correct probes", async () => {
+    const probes = makeProbes(7);
+    const firstRes = await request(buildApp(probes)).get("/health?limit=4");
+    expect(firstRes.status).toBe(200);
+    expect(firstRes.body.probes).toHaveLength(4);
+
+    const cursor = firstRes.body.nextCursor as string;
+    expect(cursor).toBeTruthy();
+
+    const secondRes = await request(buildApp(probes)).get(
+      `/health?limit=4&cursor=${cursor}`,
+    );
+    expect(secondRes.status).toBe(200);
+    expect(secondRes.body.probes).toHaveLength(3);
+    expect(secondRes.body.nextCursor).toBeNull();
+  });
+
+  it("full traversal via cursors collects all probes exactly once", async () => {
+    const n = 11;
+    const probes = makeProbes(n);
+    const app = buildApp(probes);
+    const collectedNames: string[] = [];
+    let cursor: string | null = null;
+
+    for (let page = 0; page < 20; page++) {
+      const url = cursor ? `/health?limit=4&cursor=${cursor}` : "/health?limit=4";
+      const res = await request(app).get(url);
+      expect(res.status).toBe(200);
+
+      for (const probe of res.body.probes as { name: string }[]) {
+        collectedNames.push(probe.name);
+      }
+
+      cursor = res.body.nextCursor as string | null;
+      if (cursor === null) break;
+    }
+
+    expect(collectedNames).toHaveLength(n);
+    expect(collectedNames).toEqual(Array.from({ length: n }, (_, i) => `probe-${i}`));
+  });
+
+  it("returns 400 for an invalid cursor string", async () => {
+    const res = await request(buildApp(makeProbes(5))).get(
+      "/health?cursor=not-a-valid-cursor",
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+    expect(res.body.error.details[0].message).toBe("invalid_cursor");
+  });
+
+  it("returns 400 for a tampered cursor (altered JSON payload)", async () => {
+    const tampered = Buffer.from(JSON.stringify({ index: 99999 })).toString("base64url");
+    const res = await request(buildApp(makeProbes(5))).get(
+      `/health?cursor=${tampered}`,
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("validation_error");
+    expect(res.body.error.details[0].message).toBe("cursor_out_of_range");
+  });
+
+  it("returns 400 for an empty cursor string", async () => {
+    // The schema rejects an empty string before the router logic runs.
+    const res = await request(buildApp(makeProbes(5))).get("/health?cursor=");
+    expect(res.status).toBe(400);
+  });
+
+  // ── Item shape is unchanged ────────────────────────────────────────────────
+
+  it("probe items retain name, ok, and latencyMs fields", async () => {
+    const probes = makeProbes(2);
+    const res = await request(buildApp(probes)).get("/health");
+    expect(res.status).toBe(200);
+    for (const probe of res.body.probes as Record<string, unknown>[]) {
+      expect(typeof probe.name).toBe("string");
+      expect(typeof probe.ok).toBe("boolean");
+      expect(typeof probe.latencyMs).toBe("number");
+    }
+  });
+
+  // ── Existing filters work across pages ────────────────────────────────────
+
+  it("verbose=true still works on paginated pages (non-production)", async () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "test";
+
+    const verboseProbe: Probe = async () => ({
+      name: "test",
+      ok: false,
+      detail: "connection refused",
+      latencyMs: 1,
+    });
+    const app = express();
+    app.use("/health", buildHealthRouter([verboseProbe]));
+
+    const res = await request(app).get("/health?verbose=true");
+    process.env.NODE_ENV = originalEnv;
+
+    expect(res.status).toBe(503);
+    const failedProbe = res.body.probes.find(
+      (p: Record<string, unknown>) => !p.ok,
+    );
+    expect(failedProbe?.detail).toBe("connection refused");
+  });
+
+  it("details are still stripped when verbose is not set (paginated)", async () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "test";
+
+    const verboseProbe: Probe = async () => ({
+      name: "test",
+      ok: false,
+      detail: "secret topology info",
+      latencyMs: 1,
+    });
+    const app = express();
+    app.use("/health", buildHealthRouter([verboseProbe]));
+
+    const res = await request(app).get("/health?limit=1");
+    process.env.NODE_ENV = originalEnv;
+
+    for (const p of res.body.probes as Record<string, unknown>[]) {
+      expect(p.detail).toBeUndefined();
+    }
+  });
+
+  it("details are stripped in production even with verbose=true on a paginated page", async () => {
+    const original = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+
+    const verboseProbe: Probe = async () => ({
+      name: "test",
+      ok: false,
+      detail: "internal error",
+      latencyMs: 1,
+    });
+    const app = express();
+    app.use("/health", buildHealthRouter([verboseProbe]));
+
+    const res = await request(app).get("/health?verbose=true&limit=10");
+    process.env.NODE_ENV = original;
+
+    for (const p of res.body.probes as Record<string, unknown>[]) {
+      expect(p.detail).toBeUndefined();
+    }
+  });
+
+  // ── Response envelope ─────────────────────────────────────────────────────
+
+  it("response includes status, service, timestamp, uptimeSeconds, probes, nextCursor, limit", async () => {
+    const res = await request(buildApp(makeProbes(3))).get("/health");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("status");
+    expect(res.body).toHaveProperty("service");
+    expect(res.body).toHaveProperty("timestamp");
+    expect(res.body).toHaveProperty("uptimeSeconds");
+    expect(res.body).toHaveProperty("probes");
+    expect(res.body).toHaveProperty("nextCursor");
+    expect(res.body).toHaveProperty("limit");
+  });
+
+  it("returns 503 when a probe fails and still paginates correctly", async () => {
+    const failProbe: Probe = async () => ({
+      name: "broken",
+      ok: false,
+      latencyMs: 0,
+    });
+    const app = buildApp([failProbe]);
+    const res = await request(app).get("/health?limit=1");
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe("degraded");
+    expect(res.body.probes).toHaveLength(1);
+    expect(res.body.nextCursor).toBeNull();
+  });
+
+  it("Cache-Control is no-store on paginated responses", async () => {
+    const res = await request(buildApp(makeProbes(3))).get("/health?limit=2");
+    expect(res.headers["cache-control"]).toBe("no-store");
+  });
+});

--- a/src/health/pagination.ts
+++ b/src/health/pagination.ts
@@ -1,0 +1,137 @@
+/**
+ * @module health/pagination
+ * @description Opaque cursor-based pagination for the health probes listing.
+ *
+ * Design decisions:
+ * - Cursors are opaque: Base64-encoded JSON `{ index: number }`. Clients
+ *   must not construct or mutate them; they are treated as strings.
+ * - The cursor points to the *start* of the next page (exclusive offset).
+ *   A `null` nextCursor means there are no more items.
+ * - Default page size is {@link DEFAULT_HEALTH_PAGE_SIZE}; hard cap is
+ *   {@link MAX_HEALTH_PAGE_SIZE}. A requested limit above the cap is
+ *   clamped silently (the response includes the effective limit used).
+ * - An unrecognised or tampered cursor returns a {@link CursorError} so the
+ *   router can reject it with 400 before running any probe logic.
+ */
+
+/** Default number of probes returned per page when `limit` is omitted. */
+export const DEFAULT_HEALTH_PAGE_SIZE = 20;
+
+/** Hard upper bound on probes returned per page. Over-limit values are clamped. */
+export const MAX_HEALTH_PAGE_SIZE = 100;
+
+// ─── Cursor encoding / decoding ───────────────────────────────────────────────
+
+interface CursorPayload {
+  /** Zero-based array index of the first item on the next page. */
+  index: number;
+}
+
+/**
+ * Encode an opaque cursor from a numeric offset.
+ *
+ * @param index - Zero-based index of the first item on the **next** page.
+ * @returns URL-safe Base64 string.
+ */
+export function encodeCursor(index: number): string {
+  const payload: CursorPayload = { index };
+  return Buffer.from(JSON.stringify(payload)).toString("base64url");
+}
+
+/** Discriminated-union result of {@link decodeCursor}. */
+export type CursorResult =
+  | { ok: true; index: number }
+  | { ok: false; error: CursorError };
+
+export type CursorError = "invalid_cursor" | "cursor_out_of_range";
+
+/**
+ * Decode and validate an opaque cursor string.
+ *
+ * Returns `{ ok: false }` instead of throwing so callers can convert the
+ * failure to an HTTP 400 without try/catch boilerplate.
+ *
+ * @param raw       - The raw cursor string from the query parameter.
+ * @param totalItems - Total number of items in the full dataset; used to
+ *                    validate the decoded offset is in range.
+ */
+export function decodeCursor(
+  raw: string,
+  totalItems: number,
+): CursorResult {
+  try {
+    const json = Buffer.from(raw, "base64url").toString("utf8");
+    const parsed: unknown = JSON.parse(json);
+
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      typeof (parsed as CursorPayload).index !== "number" ||
+      !Number.isInteger((parsed as CursorPayload).index) ||
+      (parsed as CursorPayload).index < 0
+    ) {
+      return { ok: false, error: "invalid_cursor" };
+    }
+
+    const { index } = parsed as CursorPayload;
+
+    // An index equal to totalItems is valid: it means "start of an empty
+    // last page" which simply yields zero items and no nextCursor.
+    if (index > totalItems) {
+      return { ok: false, error: "cursor_out_of_range" };
+    }
+
+    return { ok: true, index };
+  } catch {
+    return { ok: false, error: "invalid_cursor" };
+  }
+}
+
+// ─── Clamp helper ─────────────────────────────────────────────────────────────
+
+/**
+ * Clamp a requested page size to the allowed range [1, MAX_HEALTH_PAGE_SIZE].
+ *
+ * @param requested - Caller-supplied limit (already a positive integer).
+ */
+export function clampPageSize(requested: number): number {
+  return Math.min(Math.max(1, requested), MAX_HEALTH_PAGE_SIZE);
+}
+
+// ─── Page slice ───────────────────────────────────────────────────────────────
+
+/** Result of a successful {@link paginateItems} call. */
+export interface PageResult<T> {
+  /** Items for the current page. */
+  items: T[];
+  /**
+   * Opaque cursor for the next page, or `null` when this is the last page.
+   */
+  nextCursor: string | null;
+  /** Effective page size used (after clamping). */
+  limit: number;
+}
+
+/**
+ * Slice an array into a cursor-addressed page.
+ *
+ * @param allItems   - Full, ordered dataset.
+ * @param startIndex - Zero-based index of the first item to include.
+ * @param limit      - Desired number of items; will be clamped.
+ */
+export function paginateItems<T>(
+  allItems: T[],
+  startIndex: number,
+  limit: number,
+): PageResult<T> {
+  const effectiveLimit = clampPageSize(limit);
+  const slice = allItems.slice(startIndex, startIndex + effectiveLimit);
+  const nextIndex = startIndex + slice.length;
+  const hasMore = nextIndex < allItems.length;
+
+  return {
+    items: slice,
+    nextCursor: hasMore ? encodeCursor(nextIndex) : null,
+    limit: effectiveLimit,
+  };
+}

--- a/src/health/router.ts
+++ b/src/health/router.ts
@@ -8,15 +8,49 @@
  * - HTTP 200 for "ok", 503 for "degraded" so load-balancers can act on it.
  * - Cache-Control: no-store prevents stale health data from caches.
  * - Query parameters are validated against {@link HealthQuerySchema} so that
- *   unknown keys are rejected and `verbose` is constrained to "true"/"false".
+ *   unknown keys are rejected and `verbose`, `limit`, and `cursor` are
+ *   validated before any probe logic runs.
+ *
+ * Pagination notes:
+ * - The `probes` array is cursor-paginated with a default page size of
+ *   {@link DEFAULT_HEALTH_PAGE_SIZE} and a hard cap of
+ *   {@link MAX_HEALTH_PAGE_SIZE}.
+ * - Cursors are opaque Base64url strings. Clients must not construct them.
+ * - An invalid cursor is rejected with HTTP 400.
+ * - Existing filters (verbose) continue to work across pages unchanged.
+ * - The item shape of each probe is not changed.
  */
 
 import { Router, Request, Response } from "express";
 import { runHealthCheck } from "./checker";
-import { Probe, HealthResponse } from "./types";
+import { Probe, ProbeResult, PaginatedHealthResponse } from "./types";
 import { logger as rootLogger } from "../logger";
 import { validateQuery } from "../middleware/validation";
-import { HealthQuerySchema } from "./validation";
+import { HealthQuerySchema, DEFAULT_HEALTH_PAGE_SIZE } from "./validation";
+import {
+  decodeCursor,
+  paginateItems,
+  clampPageSize,
+} from "./pagination";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/** Optional metrics service passed to {@link buildHealthRouter}. */
+export interface MetricsService {
+  recordHealthStatus(status: "up" | "degraded" | "down"): void;
+}
+
+/** Full options object accepted by {@link buildHealthRouter}. */
+export interface HealthRouterOptions {
+  /** List of probes to run. Defaults to the built-in probe registry. */
+  probes?: Probe[];
+  /** Optional metrics service for recording health status gauges. */
+  metricsService?: MetricsService;
+  /** Optional logger override (defaults to the root application logger). */
+  log?: typeof rootLogger;
+}
+
+// ─── Builder ──────────────────────────────────────────────────────────────────
 
 /**
  * Build the health router.
@@ -35,21 +69,21 @@ export function buildHealthRouter(
   router.get("/", validateQuery(HealthQuerySchema), async (req: Request, res: Response) => {
     res.setHeader("Cache-Control", "no-store");
 
+    // ── Run all probes ───────────────────────────────────────────────────────
     const start = process.hrtime.bigint();
     const result = await runHealthCheck(opts.probes);
     const durationNs = process.hrtime.bigint() - start;
     const durationMs = Number(durationNs) / 1_000_000;
 
-    // Map health status to the service-health-status gauge value.
+    // ── Metrics ──────────────────────────────────────────────────────────────
     const serviceStatus: "up" | "degraded" | "down" =
       result.status === "ok" ? "up" : "degraded";
 
-    // Record the health status gauge when a metrics service is available.
     if (opts.metricsService) {
       opts.metricsService.recordHealthStatus(serviceStatus);
     }
 
-    // Structured log — no PII, no probe details in production.
+    // ── Structured log (full probe set, no PII) ──────────────────────────────
     const probeSummary = result.probes.map((p: ProbeResult) => ({
       name: p.name,
       ok: p.ok ?? p.status === "up",
@@ -65,30 +99,76 @@ export function buildHealthRouter(
       probes: probeSummary,
     });
 
-    // Respect the `verbose` query param — include detail strings when
-    // verbose=true is explicitly requested (non-production only).
+    // ── Decode pagination parameters ─────────────────────────────────────────
+    // After validateQuery, req.query fields are Zod-transformed values.
+    // limit: number | undefined (undefined when omitted, number after transform)
+    // cursor: string | undefined
+    const rawLimit = req.query['limit'];
+    const rawCursor = req.query['cursor'];
+
+    // rawLimit is a number after Zod transform, or undefined if omitted.
+    // Fall back to DEFAULT_HEALTH_PAGE_SIZE when missing.
+    const requestedLimit =
+      typeof rawLimit === 'number' && rawLimit >= 1
+        ? rawLimit
+        : DEFAULT_HEALTH_PAGE_SIZE;
+    const effectiveLimit = clampPageSize(requestedLimit);
+
+    let startIndex = 0;
+
+    if (typeof rawCursor === 'string' && rawCursor.length > 0) {
+      const decoded = decodeCursor(rawCursor, result.probes.length);
+      if (!decoded.ok) {
+        return res.status(400).json({
+          error: {
+            code: "validation_error",
+            message:
+              decoded.error === "cursor_out_of_range"
+                ? "Cursor is out of range for the current dataset"
+                : "Cursor is invalid or has been tampered with",
+            requestId:
+              typeof res.locals.requestId === "string"
+                ? res.locals.requestId
+                : "unknown",
+            details: [{ path: ["cursor"], message: decoded.error, code: decoded.error }],
+          },
+        });
+      }
+      startIndex = decoded.index;
+    }
+
+    // ── Paginate ─────────────────────────────────────────────────────────────
+    const page = paginateItems(result.probes, startIndex, effectiveLimit);
+
+    // ── Sanitise probe details ───────────────────────────────────────────────
     const isVerbose = req.query['verbose'] === 'true';
     const isProduction = process.env.NODE_ENV === "production";
 
-    // Strip probe details in production to avoid topology leakage.
-    // Outside production, details are stripped unless verbose=true is set.
-    const sanitized: HealthResponse =
+    const sanitizeProbe = (p: ProbeResult): ProbeResult =>
       isProduction || !isVerbose
-        ? {
-            ...result,
-            probes: result.probes.map(({ name, ok, latencyMs }) => ({
-              name,
-              ok,
-              latencyMs,
-            })),
-          }
-        : result;
+        ? { name: p.name, ok: p.ok, latencyMs: p.latencyMs }
+        : p;
 
-    res.status(sanitized.status === "ok" ? 200 : 503).json(sanitized);
+    const sanitizedProbes = page.items.map(sanitizeProbe);
+
+    // ── Build response ───────────────────────────────────────────────────────
+    const response: PaginatedHealthResponse = {
+      status: result.status,
+      service: result.service,
+      timestamp: result.timestamp,
+      uptimeSeconds: result.uptimeSeconds,
+      probes: sanitizedProbes,
+      nextCursor: page.nextCursor,
+      limit: page.limit,
+    };
+
+    res.status(response.status === "ok" ? 200 : 503).json(response);
   });
 
   return router;
 }
+
+// ─── Private helpers ──────────────────────────────────────────────────────────
 
 /**
  * Normalise the flexible constructor signature into a full options object.
@@ -100,5 +180,9 @@ function normalizeOptions(
   if (Array.isArray(input)) {
     return { probes: input };
   }
-  return { probes: input?.probes, metricsService: input?.metricsService, log: input?.log };
+  return {
+    probes: input?.probes,
+    metricsService: input?.metricsService,
+    log: input?.log,
+  };
 }

--- a/src/health/types.ts
+++ b/src/health/types.ts
@@ -33,5 +33,21 @@ export interface HealthResponse {
   probes: ProbeResult[];
 }
 
+/**
+ * Paginated health response payload.
+ *
+ * Extends {@link HealthResponse} with cursor-pagination metadata.
+ * The `probes` array is bounded to the requested page size.
+ */
+export interface PaginatedHealthResponse extends HealthResponse {
+  /**
+   * Opaque cursor to pass as `?cursor=` on the next request.
+   * `null` when this is the last (or only) page.
+   */
+  nextCursor: string | null;
+  /** Effective page size used for this response (after clamping). */
+  limit: number;
+}
+
 /** A probe is any async function returning a ProbeResult. */
 export type Probe = () => Promise<ProbeResult>;

--- a/src/health/validation.ts
+++ b/src/health/validation.ts
@@ -11,6 +11,7 @@
  */
 
 import { z } from 'zod';
+import { MAX_HEALTH_PAGE_SIZE, DEFAULT_HEALTH_PAGE_SIZE } from './pagination';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -114,8 +115,8 @@ export const HealthWriteBodySchema = z
 /**
  * Schema for the GET /health query parameters.
  *
- * Only the `verbose` parameter is accepted. Unknown query parameters
- * are rejected to prevent probing internal behaviour via arbitrary keys.
+ * Accepts `verbose`, `limit`, and `cursor` for cursor-based pagination.
+ * Unknown query parameters are rejected to prevent probing internal behaviour.
  */
 export const HealthQuerySchema = z
   .object({
@@ -127,6 +128,39 @@ export const HealthQuerySchema = z
       .enum(['true', 'false'], {
         errorMap: () => ({ message: 'verbose must be "true" or "false"' }),
       })
+      .optional(),
+
+    /**
+     * Maximum number of probes to return in this page.
+     * Must be a positive integer between 1 and MAX_HEALTH_PAGE_SIZE (100).
+     * Values above the cap are clamped to the cap.
+     * Defaults to DEFAULT_HEALTH_PAGE_SIZE (20) when omitted.
+     */
+    limit: z
+      .preprocess(
+        (v) =>
+          v === undefined || v === '' || v === null
+            ? String(DEFAULT_HEALTH_PAGE_SIZE)
+            : v,
+        z
+          .string()
+          .regex(/^\d+$/, 'limit must be a positive integer')
+          .transform((s) => Number(s))
+          .refine(
+            (n) => n >= 1,
+            'limit must be at least 1',
+          ),
+      )
+      .optional(),
+
+    /**
+     * Opaque cursor from a previous response's `nextCursor` field.
+     * When omitted the first page is returned.
+     * Must be a non-empty string (format is opaque to clients).
+     */
+    cursor: z
+      .string()
+      .min(1, 'cursor must not be empty')
       .optional(),
   })
   .strict();
@@ -141,3 +175,6 @@ export type HealthWriteBody = z.infer<typeof HealthWriteBodySchema>;
 
 /** TypeScript type inferred from {@link HealthQuerySchema}. */
 export type HealthQuery = z.infer<typeof HealthQuerySchema>;
+
+/** Convenience re-exports so consumers don't need to import from pagination.ts directly. */
+export { MAX_HEALTH_PAGE_SIZE, DEFAULT_HEALTH_PAGE_SIZE } from './pagination';


### PR DESCRIPTION
closes #696 
This PR adds cursor-based pagination to the health listing endpoint to improve scalability and prevent unbounded responses as the dataset grows.

Changes Made
Implemented opaque cursor-based pagination for the health listing endpoint.
Added a bounded default page size with a maximum page size limit.
Implemented stable nextCursor generation for consistent pagination across requests.
Ensured existing filtering functionality continues to work correctly when navigating between pages.
Preserved the existing response item structure to maintain backward compatibility.
Why

Previously, the health listing endpoint returned an unbounded array, which could lead to performance degradation and increased memory usage as more health records are added. Cursor pagination provides a scalable and efficient way to retrieve large datasets while maintaining consistent ordering.

Testing
Verified the endpoint returns the default page size when no limit is specified.
Verified the maximum page size is enforced.
Confirmed nextCursor is returned when additional records are available.
Confirmed existing filters continue to work correctly across paginated requests.
Verified the response item shape remains unchanged.

