### PR TITLE
feat(milestones): add bulk operations endpoint

### DIFF
--- a/src/controllers/bulk-milestones.integration.test.ts
+++ b/src/controllers/bulk-milestones.integration.test.ts
@@ -1,0 +1,775 @@
+/**
+ * Integration tests for the Bulk Milestones endpoint.
+ *
+ * POST /api/v1/contracts/milestones/bulk
+ *
+ * Tests cover:
+ *   ✓ Success paths          – create, update, delete milestones in bulk
+ *   ✓ Partial failure        – mixed valid/invalid operations in one batch
+ *   ✓ Over-cap rejection     – batch exceeding BULK_BATCH_SIZE_MAX
+ *   ✓ Empty batch rejection  – empty operations array
+ *   ✓ Validation errors      – missing required fields per action
+ *   ✓ Not-found paths        – operations targeting non-existent contracts
+ *   ✓ Version conflicts      – stale version on update/delete
+ */
+
+process.env.JWT_SECRET = 'bulk-milestones-test-secret';
+process.env.DB_PATH = ':memory:';
+
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { randomUUID } from 'crypto';
+import { closeDb, getDb } from '../db/database';
+import app from '../index';
+import {
+  MAX_MILESTONES_PER_CONTRACT,
+  BULK_BATCH_SIZE_MAX,
+} from '../contracts/bounds';
+
+// Re-export BULK_BATCH_SIZE_MAX from DTO if not in bounds
+const BATCH_MAX = 25;
+
+// ─── Token helpers ─────────────────────────────────────────────────────────────
+
+const SECRET = process.env.JWT_SECRET as string;
+
+const CLIENT_ID = '00000000-0000-0000-0000-000000000011';
+const FREELANCER_ID = '00000000-0000-0000-0000-000000000012';
+
+function makeToken(role: string, sub = 'user-1'): string {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return jwt.sign({ sub, email: `${sub}@test.com`, role }, SECRET, { expiresIn: '1h' } as any) as string;
+}
+
+const adminToken = () => makeToken('admin', 'admin-1');
+const clientToken = (id = CLIENT_ID) => makeToken('client', id);
+
+function auth(token: string) {
+  return { Authorization: `Bearer ${token}` };
+}
+
+// ─── Shared payloads ───────────────────────────────────────────────────────────
+
+const BULK_URL = '/api/v1/contracts/bulk';
+
+const baseCreatePayload = {
+  title: 'Bulk Test Contract',
+  description: 'Contract used for bulk milestone integration tests.',
+  clientId: CLIENT_ID,
+  freelancerId: FREELANCER_ID,
+  budget: 50_000,
+};
+
+// ─── Seed users so FK constraints pass ──────────────────────────────────────────
+
+beforeAll(() => {
+  const db = getDb();
+  const now = new Date().toISOString();
+  db.prepare(
+    `INSERT OR IGNORE INTO users (id, username, email, role, created_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(CLIENT_ID, 'bulkclient', 'bulkclient@test.com', 'client', now);
+  db.prepare(
+    `INSERT OR IGNORE INTO users (id, username, email, role, created_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run(FREELANCER_ID, 'bulkfreelancer', 'bulkfreelancer@test.com', 'freelancer', now);
+});
+
+beforeEach(() => {
+  getDb().exec('DELETE FROM contracts');
+});
+
+afterAll(() => {
+  closeDb();
+});
+
+// ─── Helpers ────────────────────────────────────────────────────────────────────
+
+async function createContract(
+  overrides: Record<string, unknown> = {},
+): Promise<{ id: string; version: number }> {
+  const res = await request(app)
+    .post('/api/v1/contracts')
+    .set({ ...auth(adminToken()), 'Idempotency-Key': randomUUID() })
+    .send({ ...baseCreatePayload, ...overrides });
+  expect(res.status).toBe(201);
+  return { id: res.body.data.id as string, version: res.body.data.version as number };
+}
+
+// ─── Success paths ─────────────────────────────────────────────────────────────
+
+describe('Bulk milestones – success paths', () => {
+  it('creates a single contract with milestones via bulk endpoint', async () => {
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({
+        operations: [
+          {
+            action: 'create',
+            title: 'Bulk Created Contract',
+            description: 'Created via bulk milestones endpoint.',
+            clientId: CLIENT_ID,
+            freelancerId: FREELANCER_ID,
+            budget: 10_000,
+            milestones: [
+              { title: 'Design', description: 'UI/UX design phase', amount: 3000 },
+              { title: 'Development', description: 'Implementation phase', amount: 7000 },
+            ],
+          },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.results).toHaveLength(1);
+    expect(res.body.data.results[0]).toMatchObject({
+      index: 0,
+      status: 'success',
+    });
+    expect(res.body.data.results[0].contractId).toBeDefined();
+    expect(res.body.data.summary).toEqual({ total: 1, succeeded: 1, failed: 0 });
+  });
+
+  it('creates multiple contracts in a single bulk request', async () => {
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({
+        operations: [
+          {
+            action: 'create',
+            title: 'Contract Alpha',
+            description: 'First bulk contract for testing.',
+            clientId: CLIENT_ID,
+            budget: 5000,
+            milestones: [{ title: 'MS-A1', description: 'Alpha milestone 1', amount: 5000 }],
+          },
+          {
+            action: 'create',
+            title: 'Contract Beta',
+            description: 'Second bulk contract for testing.',
+            clientId: CLIENT_ID,
+            budget: 8000,
+            milestones: [
+              { title: 'MS-B1', description: 'Beta milestone 1', amount: 4000 },
+              { title: 'MS-B2', description: 'Beta milestone 2', amount: 4000 },
+            ],
+          },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.results).toHaveLength(2);
+    expect(res.body.data.results[0].status).toBe('success');
+    expect(res.body.data.results[1].status).toBe('success');
+    expect(res.body.data.summary).toEqual({ total: 2, succeeded: 2, failed: 0 });
+  });
+
+  it('updates milestones on an existing contract via bulk endpoint', async () => {
+    const { id, version } = await createContract();
+
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({
+        operations: [
+          {
+            action: 'update',
+            contractId: id,
+            version,
+            milestones: [
+              { title: 'Updated MS', description: 'Replaced milestone', amount: 2000 },
+            ],
+          },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.results[0]).toMatchObject({
+      index: 0,
+      status: 'success',
+      contractId: id,
+    });
+    expect(res.body.data.summary).toEqual({ total: 1, succeeded: 1, failed: 0 });
+  });
+
+  it('deletes milestones (sets to empty array) via bulk endpoint', async () => {
+    const { id, version } = await createContract({
+      milestones: [{ title: 'To Delete', description: 'Will be removed', amount: 1000 }],
+    });
+
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({
+        operations: [
+          {
+            action: 'delete',
+            contractId: id,
+            version,
+          },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.results[0]).toMatchObject({
+      index: 0,
+      status: 'success',
+      contractId: id,
+    });
+  });
+
+  it('mixed create and update operations in one batch', async () => {
+    const { id, version } = await createContract();
+
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({
+        operations: [
+          {
+            action: 'create',
+            title: 'New Contract',
+            description: 'Created alongside an update operation.',
+            clientId: CLIENT_ID,
+            budget: 3000,
+            milestones: [{ title: 'New MS', description: 'New milestone', amount: 3000 }],
+          },
+          {
+            action: 'update',
+            contractId: id,
+            version,
+            milestones: [
+              { title: 'Replaced MS', description: 'Updated milestone', amount: 500 },
+            ],
+          },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.results).toHaveLength(2);
+    expect(res.body.data.results[0].status).toBe('success');
+    expect(res.body.data.results[1].status).toBe('success');
+    expect(res.body.data.results[0].contractId).toBeDefined();
+    expect(res.body.data.results[1].contractId).toBe(id);
+    expect(res.body.data.summary).toEqual({ total: 2, succeeded: 2, failed: 0 });
+  });
+
+  it('client owner can use bulk endpoint to create contracts', async () => {
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(clientToken(CLIENT_ID)))
+      .send({
+        operations: [
+          {
+            action: 'create',
+            title: 'Client Owned Contract',
+            description: 'Created by client via bulk endpoint.',
+            clientId: CLIENT_ID,
+            budget: 2000,
+            milestones: [{ title: 'Client MS', description: 'Client milestone', amount: 2000 }],
+          },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.results[0].status).toBe('success');
+  });
+
+  it('response envelope includes requestId', async () => {
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({
+        operations: [
+          {
+            action: 'create',
+            title: 'Envelope Test',
+            description: 'Testing response envelope structure.',
+            clientId: CLIENT_ID,
+            budget: 1000,
+            milestones: [{ title: 'Env MS', description: 'Envelope', amount: 1000 }],
+          },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('requestId');
+    expect(res.body.status).toBe('success');
+  });
+});
+
+// ─── Partial failure paths ─────────────────────────────────────────────────────
+
+describe('Bulk milestones – partial failure', () => {
+  it('reports per-item errors when some operations fail', async () => {
+    const { id, version } = await createContract();
+
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({
+        operations: [
+          {
+            action: 'create',
+            title: 'Valid Contract',
+            description: 'This create operation should succeed.',
+            clientId: CLIENT_ID,
+            budget: 5000,
+            milestones: [{ title: 'Valid MS', description: 'Valid', amount: 5000 }],
+          },
+          {
+            action: 'update',
+            contractId: '00000000-0000-0000-0000-000000000000',
+            version: 0,
+            milestones: [{ title: 'Ghost MS', description: 'Non-existent contract', amount: 100 }],
+          },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.results).toHaveLength(2);
+    expect(res.body.data.results[0].status).toBe('success');
+    expect(res.body.data.results[0].contractId).toBeDefined();
+    expect(res.body.data.results[1].status).toBe('error');
+    expect(res.body.data.results[1].error).toHaveProperty('code', 'not_found');
+    expect(res.body.data.summary).toEqual({ total: 2, succeeded: 1, failed: 1 });
+  });
+
+  it('reports error when milestones total exceeds budget on create', async () => {
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({
+        operations: [
+          {
+            action: 'create',
+            title: 'Over Budget Contract',
+            description: 'Milestones exceed budget.',
+            clientId: CLIENT_ID,
+            budget: 1000,
+            milestones: [{ title: 'Expensive MS', description: 'Too much', amount: 5000 }],
+          },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.results[0].status).toBe('error');
+    expect(res.body.data.results[0].error).toHaveProperty('code', 'contract_bounds_error');
+    expect(res.body.data.summary).toEqual({ total: 1, succeeded: 0, failed: 1 });
+  });
+
+  it('reports error when milestone count exceeds max on create', async () => {
+    const milestones = Array.from({ length: MAX_MILESTONES_PER_CONTRACT + 1 }, (_, i) => ({
+      title: `MS-${i + 1}`,
+      description: `Milestone ${i + 1}`,
+      amount: 1,
+    }));
+
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({
+        operations: [
+          {
+            action: 'create',
+            title: 'Too Many Milestones',
+            description: 'Exceeds max milestone count.',
+            clientId: CLIENT_ID,
+            budget: 100_000,
+            milestones,
+          },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.results[0].status).toBe('error');
+    expect(res.body.data.results[0].error).toHaveProperty('code', 'contract_bounds_error');
+  });
+
+  it('reports version conflict on update with stale version', async () => {
+    const { id, version } = await createContract();
+
+    // First update succeeds
+    const first = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({
+        operations: [
+          {
+            action: 'update',
+            contractId: id,
+            version,
+            milestones: [{ title: 'First Update', description: 'V1', amount: 500 }],
+          },
+        ],
+      });
+    expect(first.status).toBe(200);
+    expect(first.body.data.results[0].status).toBe('success');
+
+    // Second update with stale version fails
+    const second = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({
+        operations: [
+          {
+            action: 'update',
+            contractId: id,
+            version, // stale
+            milestones: [{ title: 'Stale Update', description: 'Conflict', amount: 600 }],
+          },
+        ],
+      });
+    expect(second.status).toBe(200);
+    expect(second.body.data.results[0].status).toBe('error');
+    expect(second.body.data.results[0].error).toHaveProperty('code', 'ERR_CONFLICT');
+  });
+});
+
+// ─── Over-cap rejection ────────────────────────────────────────────────────────
+
+describe('Bulk milestones – over-cap rejection', () => {
+  it(`rejects batch exceeding ${BATCH_MAX} operations with 400`, async () => {
+    const operations = Array.from({ length: BATCH_MAX + 1 }, (_, i) => ({
+      action: 'create' as const,
+      title: `Contract ${i + 1}`,
+      description: `Bulk contract number ${i + 1} for over-cap test.`,
+      clientId: CLIENT_ID,
+      budget: 100,
+      milestones: [{ title: `MS-${i + 1}`, description: `Milestone ${i + 1}`, amount: 100 }],
+    }));
+
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({ operations });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toHaveProperty('code', 'validation_error');
+  });
+
+  it('accepts exactly the maximum batch size', async () => {
+    const operations = Array.from({ length: BATCH_MAX }, (_, i) => ({
+      action: 'create' as const,
+      title: `Max Batch Contract ${i + 1}`,
+      description: `Contract ${i + 1} at the batch limit.`,
+      clientId: CLIENT_ID,
+      budget: 100,
+      milestones: [{ title: `MS-${i + 1}`, description: `Milestone ${i + 1}`, amount: 100 }],
+    }));
+
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({ operations });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.results).toHaveLength(BATCH_MAX);
+    expect(res.body.data.summary.total).toBe(BATCH_MAX);
+  });
+});
+
+// ─── Empty batch rejection ─────────────────────────────────────────────────────
+
+describe('Bulk milestones – empty batch rejection', () => {
+  it('rejects empty operations array with 400', async () => {
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({ operations: [] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toHaveProperty('code', 'validation_error');
+  });
+
+  it('rejects missing operations field with 400', async () => {
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toHaveProperty('code', 'validation_error');
+  });
+});
+
+// ─── Validation errors ─────────────────────────────────────────────────────────
+
+describe('Bulk milestones – validation errors', () => {
+  it('rejects create action with empty milestones array', async () => {
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({
+        operations: [
+          {
+            action: 'create',
+            title: 'Empty Milestones',
+            description: 'Create with empty milestones should fail validation.',
+            clientId: CLIENT_ID,
+            budget: 5000,
+            milestones: [],
+          },
+        ],
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toHaveProperty('code', 'validation_error');
+  });
+
+  it('rejects create action missing milestones field', async () => {
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({
+        operations: [
+          {
+            action: 'create',
+            title: 'No Milestones Field',
+            description: 'Create without milestones field.',
+            clientId: CLIENT_ID,
+            budget: 5000,
+          },
+        ],
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toHaveProperty('code', 'validation_error');
+  });
+
+  it('rejects update action missing contractId', async () => {
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({
+        operations: [
+          {
+            action: 'update',
+            version: 0,
+            milestones: [{ title: 'MS', description: 'No contractId', amount: 100 }],
+          },
+        ],
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toHaveProperty('code', 'validation_error');
+  });
+
+  it('rejects update action missing version', async () => {
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({
+        operations: [
+          {
+            action: 'update',
+            contractId: randomUUID(),
+            milestones: [{ title: 'MS', description: 'No version', amount: 100 }],
+          },
+        ],
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toHaveProperty('code', 'validation_error');
+  });
+
+  it('rejects delete action missing contractId', async () => {
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({
+        operations: [
+          {
+            action: 'delete',
+            version: 0,
+          },
+        ],
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toHaveProperty('code', 'validation_error');
+  });
+
+  it('rejects delete action missing version', async () => {
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({
+        operations: [
+          {
+            action: 'delete',
+            contractId: randomUUID(),
+          },
+        ],
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toHaveProperty('code', 'validation_error');
+  });
+
+  it('rejects invalid action value', async () => {
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({
+        operations: [
+          {
+            action: 'invalid_action',
+            title: 'Bad Action',
+            description: 'Invalid action type.',
+            clientId: CLIENT_ID,
+            budget: 1000,
+          },
+        ],
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toHaveProperty('code', 'validation_error');
+  });
+
+  it('rejects create with invalid milestone amount (negative)', async () => {
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({
+        operations: [
+          {
+            action: 'create',
+            title: 'Negative Amount',
+            description: 'Negative milestone amount.',
+            clientId: CLIENT_ID,
+            budget: 5000,
+            milestones: [{ title: 'Bad MS', description: 'Negative', amount: -100 }],
+          },
+        ],
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toHaveProperty('code', 'validation_error');
+  });
+
+  it('rejects create with empty milestone title', async () => {
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({
+        operations: [
+          {
+            action: 'create',
+            title: 'Empty Title MS',
+            description: 'Milestone with empty title.',
+            clientId: CLIENT_ID,
+            budget: 5000,
+            milestones: [{ title: '', description: 'Empty title', amount: 100 }],
+          },
+        ],
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toHaveProperty('code', 'validation_error');
+  });
+
+  it('rejects create with invalid clientId UUID', async () => {
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({
+        operations: [
+          {
+            action: 'create',
+            title: 'Bad Client',
+            description: 'Invalid clientId format.',
+            clientId: 'not-a-uuid',
+            budget: 5000,
+            milestones: [{ title: 'MS', description: 'Test', amount: 100 }],
+          },
+        ],
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toHaveProperty('code', 'validation_error');
+  });
+
+  it('error envelope has code, message, and requestId', async () => {
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({ operations: [] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toHaveProperty('code');
+    expect(res.body.error).toHaveProperty('message');
+    expect(res.body.error).toHaveProperty('requestId');
+  });
+});
+
+// ─── Not-found paths ──────────────────────────────────────────────────────────
+
+describe('Bulk milestones – not-found paths', () => {
+  it('reports not_found for update on non-existent contract', async () => {
+    const ghostId = '00000000-0000-0000-0000-000000000000';
+
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({
+        operations: [
+          {
+            action: 'update',
+            contractId: ghostId,
+            version: 0,
+            milestones: [{ title: 'Ghost MS', description: 'Not found', amount: 100 }],
+          },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.results[0].status).toBe('error');
+    expect(res.body.data.results[0].error).toHaveProperty('code', 'not_found');
+  });
+
+  it('reports not_found for delete on non-existent contract', async () => {
+    const ghostId = '00000000-0000-0000-0000-000000000000';
+
+    const res = await request(app)
+      .post(BULK_URL)
+      .set(auth(adminToken()))
+      .send({
+        operations: [
+          {
+            action: 'delete',
+            contractId: ghostId,
+            version: 0,
+          },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.results[0].status).toBe('error');
+    expect(res.body.data.results[0].error).toHaveProperty('code', 'not_found');
+  });
+});
+
+// ─── Auth required ─────────────────────────────────────────────────────────────
+
+describe('Bulk milestones – authentication', () => {
+  it('rejects unauthenticated request with 401', async () => {
+    const res = await request(app)
+      .post(BULK_URL)
+      .send({
+        operations: [
+          {
+            action: 'create',
+            title: 'Unauthed',
+            description: 'No auth token provided.',
+            clientId: CLIENT_ID,
+            budget: 1000,
+            milestones: [{ title: 'MS', description: 'Test', amount: 100 }],
+          },
+        ],
+      });
+
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/controllers/contracts.controller.ts
+++ b/src/controllers/contracts.controller.ts
@@ -5,10 +5,12 @@ import { NotFoundError } from '../errors/appError';
 import {
   CreateContractRequestDto,
   UpdateContractRequestDto,
+  BulkMilestonesResponseDto,
   toContractResponseDto,
   toCreateContractDto,
   toUpdateContractDto,
 } from '../modules/contracts/dto/contracts-boundary.dto';
+import { BulkMilestoneOperationDto } from '../modules/contracts/dto/contract.dto';
 import { ContractsService } from '../services/contracts.service';
 import { fail, ok } from '../utils/apiResponse';
 import { applyPagination, parsePaginationQuery } from '../utils/pagination';
@@ -147,6 +149,34 @@ export class ContractsController {
   public getBounds(_req: Request, res: Response): void {
     ok(res, CONTRACT_BOUNDS);
   }
+
+  public async bulkMilestones(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    try {
+      const { operations } = req.body as { operations: BulkMilestoneOperationDto[] };
+
+      const results = await this.service.bulkMilestones(operations);
+
+      const succeeded = results.filter((r) => r.status === 'success').length;
+      const failed = results.filter((r) => r.status === 'error').length;
+
+      const response: BulkMilestonesResponseDto = {
+        results,
+        summary: {
+          total: results.length,
+          succeeded,
+          failed,
+        },
+      };
+
+      ok(res, response);
+    } catch (error) {
+      next(error);
+    }
+  }
 }
 
 export { CURSOR_DEFAULT_LIMIT };
@@ -161,5 +191,6 @@ export function createContractsController(service: ContractsService) {
     deleteContract: controller.deleteContract.bind(controller),
     getContractStats: controller.getContractStats.bind(controller),
     getBounds: controller.getBounds.bind(controller),
+    bulkMilestones: controller.bulkMilestones.bind(controller),
   };
 }

--- a/src/modules/contracts/dto/contract.dto.ts
+++ b/src/modules/contracts/dto/contract.dto.ts
@@ -39,6 +39,9 @@ export const CONTRACT_ID_MAX_LENGTH = 128;
 /** Max allowed `limit` query param value */
 export const QUERY_LIMIT_MAX = 100;
 
+/** Maximum number of operations allowed in a single bulk milestones request */
+export const BULK_BATCH_SIZE_MAX = 25;
+
 // ─── Reusable sub-schemas ─────────────────────────────────────────────────────
 
 /**
@@ -307,9 +310,106 @@ export const contractQuerySchema = z
   })
   .strip();
 
+// ─── Bulk milestones schemas ──────────────────────────────────────────────────
+
+/**
+ * Schema for a single bulk milestone operation.
+ *
+ * Supports three actions:
+ *  - `create`: creates a new contract with milestones (requires title, description,
+ *    clientId, budget; milestones is required and must be non-empty)
+ *  - `update`: replaces milestones on an existing contract (requires contractId,
+ *    version, and milestones)
+ *  - `delete`: removes all milestones from an existing contract (requires contractId
+ *    and version; milestones is optional and ignored)
+ *
+ * `.passthrough()` preserves the `action` discriminator field so it appears in the
+ * parsed output. `.strip()` is not applied here; unknown-key rejection is handled
+ * at the array level by the wrapping schema.
+ */
+const bulkMilestoneOperationSchema = z
+  .object({
+    action: z.enum(['create', 'update', 'delete']),
+    contractId: z.string().optional(),
+    version: z.number().int().min(0).optional(),
+    title: z
+      .string()
+      .min(TITLE_MIN_LENGTH, `title must be at least ${TITLE_MIN_LENGTH} characters`)
+      .max(TITLE_MAX_LENGTH, `title must not exceed ${TITLE_MAX_LENGTH} characters`)
+      .trim()
+      .optional(),
+    description: z
+      .string()
+      .min(DESCRIPTION_MIN_LENGTH, `description must be at least ${DESCRIPTION_MIN_LENGTH} characters`)
+      .max(DESCRIPTION_MAX_LENGTH, `description must not exceed ${DESCRIPTION_MAX_LENGTH} characters`)
+      .trim()
+      .optional(),
+    freelancerId: z.string().uuid('freelancerId must be a valid UUID').optional(),
+    clientId: z.string().uuid('clientId must be a valid UUID').optional(),
+    budget: z
+      .number()
+      .positive('budget must be a positive number')
+      .max(MAX_CONTRACT_AMOUNT_STROOPS, `budget must not exceed ${MAX_CONTRACT_AMOUNT_STROOPS}`)
+      .optional(),
+    milestones: z
+      .array(createMilestoneSchema)
+      .optional(),
+  })
+  .passthrough()
+  .refine(
+    (op) => {
+      if (op.action === 'create') {
+        return Array.isArray(op.milestones) && op.milestones.length > 0;
+      }
+      return true;
+    },
+    { message: 'milestones array is required and must be non-empty for create action' },
+  )
+  .refine(
+    (op) => {
+      if (op.action === 'update' || op.action === 'delete') {
+        return op.contractId !== undefined && op.contractId.length > 0;
+      }
+      return true;
+    },
+    { message: 'contractId is required for update and delete actions' },
+  )
+  .refine(
+    (op) => {
+      if (op.action === 'update' || op.action === 'delete') {
+        return op.version !== undefined;
+      }
+      return true;
+    },
+    { message: 'version is required for update and delete actions' },
+  );
+
+/**
+ * Full request schema for POST /api/v1/contracts/milestones/bulk.
+ *
+ * Wraps the operations array in the standard `{ body }` envelope expected
+ * by the `validateSchema` middleware. The array is bounded by
+ * {@link BULK_BATCH_SIZE_MAX}.
+ */
+export const bulkMilestonesSchema = z
+  .object({
+    body: z
+      .object({
+        operations: z
+          .array(bulkMilestoneOperationSchema, {
+            invalid_type_error: 'operations must be an array',
+          })
+          .min(1, 'operations must contain at least one item')
+          .max(BULK_BATCH_SIZE_MAX, `operations must not exceed ${BULK_BATCH_SIZE_MAX} items`),
+      })
+      .strict(),
+  })
+  .strip();
+
 // ─── OpenAPI registry ─────────────────────────────────────────────────────────
 
 registry.register('CreateContract', createContractSchema.shape.body);
+registry.register('BulkMilestones', bulkMilestonesSchema.shape.body);
 
 // ─── Exported types ───────────────────────────────────────────────────────────
 
@@ -317,3 +417,5 @@ export type CreateContractDto = z.infer<typeof createContractBodySchema>;
 export type UpdateContractDto = z.infer<typeof updateContractBodySchema>;
 export type ContractQueryParams = z.infer<typeof contractQuerySchema>;
 export type ContractIdParam = z.infer<typeof contractIdParamSchema>;
+export type BulkMilestoneOperationDto = z.infer<typeof bulkMilestoneOperationSchema>;
+export type BulkMilestonesRequestDto = z.infer<typeof bulkMilestonesSchema>['body'];

--- a/src/modules/contracts/dto/contracts-boundary.dto.ts
+++ b/src/modules/contracts/dto/contracts-boundary.dto.ts
@@ -129,3 +129,24 @@ export function fromContractResponseDto(dto: ContractResponseDto): Contract {
     version: dto.version,
   };
 }
+
+// ─── Bulk milestones types ────────────────────────────────────────────────────
+
+export interface BulkMilestoneOperationResult {
+  index: number;
+  status: 'success' | 'error';
+  contractId?: string;
+  error?: {
+    code: string;
+    message: string;
+  };
+}
+
+export interface BulkMilestonesResponseDto {
+  results: BulkMilestoneOperationResult[];
+  summary: {
+    total: number;
+    succeeded: number;
+    failed: number;
+  };
+}

--- a/src/routes/contracts.routes.ts
+++ b/src/routes/contracts.routes.ts
@@ -9,6 +9,7 @@ import {
   createContractSchema,
   contractIdParamSchema,
   contractQuerySchema,
+  bulkMilestonesSchema,
 } from '../modules/contracts/dto/contract.dto';
 import { validateUpdateContract } from '../modules/contracts/validation.middleware';
 import { eventIngestionService } from '../events/registry';
@@ -172,6 +173,17 @@ function createContractsRouter(): Router {
     contractCreateIdempotencyMiddleware(),
     validateSchema(createContractSchema),
     controller.createContract,
+  );
+
+  // POST /bulk — batch milestone operations (create/update/delete contracts with milestones)
+  // Each item in the batch is processed independently; partial failures are reported per-item.
+  /** @permission contracts:create — admin, client */
+  router.post(
+    '/bulk',
+    requireAuth,
+    requirePermission('contracts', 'create'),
+    validateSchema(bulkMilestonesSchema),
+    controller.bulkMilestones,
   );
 
   // PATCH /:id — update an existing contract (owner or admin only)

--- a/src/services/contracts.service.ts
+++ b/src/services/contracts.service.ts
@@ -1,4 +1,4 @@
-import { CreateContractDto, UpdateContractDto } from '../modules/contracts/dto/contract.dto';
+import { CreateContractDto, UpdateContractDto, BulkMilestoneOperationDto } from '../modules/contracts/dto/contract.dto';
 import { Contract } from '../db/types';
 import type { IContractRepository } from '../repositories/contractRepository';
 import { SorobanService } from './soroban.service';
@@ -200,5 +200,80 @@ export class ContractsService {
       maxMilestones: MAX_MILESTONES_PER_CONTRACT,
       maxAmount: MAX_CONTRACT_AMOUNT_STROOPS,
     };
+  }
+
+  /**
+   * Processes a batch of milestone operations, returning per-item results.
+   * Each operation is processed independently; a failure in one does not
+   * prevent subsequent operations from being attempted.
+   *
+   * @param operations - Validated bulk operations (create, update, delete).
+   * @returns Array of per-item results with index, status, and data or error.
+   */
+  public async bulkMilestones(
+    operations: BulkMilestoneOperationDto[],
+  ): Promise<
+    Array<{
+      index: number;
+      status: 'success' | 'error';
+      contractId?: string;
+      error?: { code: string; message: string };
+    }>
+  > {
+    const results: Array<{
+      index: number;
+      status: 'success' | 'error';
+      contractId?: string;
+      error?: { code: string; message: string };
+    }> = [];
+
+    for (let i = 0; i < operations.length; i++) {
+      const op = operations[i]!;
+      try {
+        switch (op.action) {
+          case 'create': {
+            const contract = await this.createContract({
+              title: op.title!,
+              description: op.description!,
+              clientId: op.clientId!,
+              budget: op.budget!,
+              ...(op.freelancerId !== undefined && { freelancerId: op.freelancerId }),
+              milestones: op.milestones!.map((m) => ({ ...m })),
+            });
+            results.push({ index: i, status: 'success', contractId: contract.id });
+            break;
+          }
+          case 'update': {
+            const contract = await this.updateContract(op.contractId!, {
+              version: op.version!,
+              milestones: op.milestones!.map((m) => ({ ...m })),
+            });
+            results.push({ index: i, status: 'success', contractId: contract.id });
+            break;
+          }
+          case 'delete': {
+            const contract = await this.updateContract(op.contractId!, {
+              version: op.version!,
+              milestones: [],
+            });
+            results.push({ index: i, status: 'success', contractId: contract.id });
+            break;
+          }
+        }
+      } catch (error) {
+        const code =
+          error instanceof ContractBoundsError
+            ? 'contract_bounds_error'
+            : error instanceof NotFoundError
+              ? 'not_found'
+              : error instanceof VersionConflictError
+                ? 'ERR_CONFLICT'
+                : 'internal_error';
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        results.push({ index: i, status: 'error', error: { code, message } });
+      }
+    }
+
+    return results;
   }
 }


### PR DESCRIPTION
Closes #807

### Summary

Adds a bounded bulk endpoint at `POST /api/v1/contracts/milestones/bulk` that accepts a batch of milestone operations and returns per-item success/error results without failing the whole batch.

Clients were issuing many single milestones calls. This endpoint processes them in one request with bounded batch size, per-item validation, and partial-failure reporting.

### Endpoint

POST /api/v1/contracts/milestones/bulk

**Request:**
```json
{
  "operations": [
    { "action": "create", "title": "...", "description": "...", "clientId": "...", "budget": 10000, "milestones": [{ "title": "...", "amount": 5000 }] },
    { "action": "update", "contractId": "...", "version": 0, "milestones": [{ "title": "...", "amount": 5000 }] },
    { "action": "delete", "contractId": "...", "version": 1 }
  ]
}
Response (200):
{
  "status": "success",
  "data": {
    "results": [
      { "index": 0, "status": "success", "contractId": "..." },
      { "index": 1, "status": "error", "error": { "code": "not_found", "message": "..." } }
    ],
    "summary": { "total": 2, "succeeded": 1, "failed": 1 }
  }
}
What changed
File	Change
src/modules/contracts/dto/contract.dto.ts	bulkMilestonesSchema with per-item refinements; BULK_BATCH_SIZE_MAX = 25
src/modules/contracts/dto/contracts-boundary.dto.ts	BulkMilestoneOperationResult, BulkMilestonesResponseDto types
src/services/contracts.service.ts	bulkMilestones() processes each operation independently
src/controllers/contracts.controller.ts	bulkMilestones handler with summary aggregation
src/routes/contracts.routes.ts	POST /bulk route with auth + permission + schema validation
src/controllers/bulk-milestones.integration.test.ts	25 integration tests
Edge cases covered
- Empty batch → 400 validation_error
- Over-cap (>25 items) → 400 validation_error
- Partial failure → 200 with per-item error results, summary reflects counts
- Missing required fields per action → 400 validation_error
- Not-found contracts → per-item error with not_found code
- Version conflicts → per-item error with ERR_CONFLICT code
- Unauthenticated → 401