### PR TITLE
feat(audit): add bulk operations endpoint

### DIFF
--- a/src/audit/router.bulk.test.ts
+++ b/src/audit/router.bulk.test.ts
@@ -1,0 +1,491 @@
+/**
+ * @file router.bulk.test.ts
+ * @description Integration tests for `POST /api/v1/audit/bulk` — issue audit-22.
+ *
+ * Coverage goals:
+ * 1. Success — all items valid, per-item results, sequential hash chain intact.
+ * 2. Partial failure — some items fail validation or persistence; the batch
+ *    still completes and reports per-item success/error (207).
+ * 3. Envelope validation — empty batch, over-cap batch, non-array `entries`,
+ *    missing `entries` (all rejected with 400 before any item is processed).
+ * 4. Idempotency — whole-batch replay and payload-conflict semantics, shared
+ *    with `POST /` via the same `idempotencyMiddleware`.
+ * 5. Access-middleware gating — 401/403 paths, matching `POST /`'s pattern.
+ *
+ * Uses isolated in-memory stores (DB-free, deterministic), matching the
+ * conventions in `router.integration.test.ts`.
+ */
+
+process.env['JWT_SECRET'] = 'router-bulk-test-secret-2026';
+
+import express, { type RequestHandler } from 'express';
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import { AuditStore } from './store';
+import { AuditService } from './service';
+import { createAuditRouter, MAX_BULK_AUDIT_ITEMS } from './router';
+import { requireAuth, requireRole } from '../middleware/authorization';
+import { clearIdempotencyStore } from '../middleware/idempotency';
+import type { AuditEntry, AuditLogRepository, AuditQuery, AuditQueryResult, CreateAuditEntryInput, IntegrityReport } from './types';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Minimal valid bulk item with optional overrides. */
+function makeItem(overrides: Partial<CreateAuditEntryInput> = {}): CreateAuditEntryInput {
+  return {
+    action: 'CONTRACT_CREATED',
+    severity: 'INFO',
+    actor: 'user-abc',
+    resource: 'contract',
+    resourceId: 'contract-1',
+    metadata: { note: 'test' },
+    ...overrides,
+  };
+}
+
+/** JWT signed with the test secret. */
+function makeToken(role: 'admin' | 'auditor' | 'client', sub = `${role}-1`): string {
+  return jwt.sign(
+    { sub, email: `${role}@test.example`, role },
+    process.env['JWT_SECRET'] as string,
+    { expiresIn: '1h' },
+  );
+}
+
+/**
+ * Builds an isolated Express app wired to createAuditRouter().
+ * Pass `accessMiddleware` to test the auth-gated variant.
+ */
+function buildApp(
+  store: AuditStore,
+  opts: { accessMiddleware?: RequestHandler[] } = {},
+) {
+  const service = new AuditService(store);
+  const app = express();
+  app.use(express.json());
+  app.use((_req, res, next) => {
+    res.locals['requestId'] = 'test-request-id';
+    next();
+  });
+  app.use(
+    '/api/v1/audit',
+    createAuditRouter({ service, accessMiddleware: opts.accessMiddleware ?? [] }),
+  );
+  return { app, service, store };
+}
+
+/**
+ * Wraps a real AuditStore, forwarding every call except `append`, which
+ * throws `error` on calls whose 1-based index is in `failOnCalls`. Used to
+ * simulate a persistence-layer failure for a specific item in a batch
+ * without needing a full mock of AuditLogRepository.
+ */
+class FlakyRepository implements AuditLogRepository {
+  private callCount = 0;
+
+  constructor(
+    private readonly inner: AuditStore,
+    private readonly failOnCalls: Set<number>,
+    private readonly error: Error,
+  ) {}
+
+  append(input: CreateAuditEntryInput): AuditEntry {
+    this.callCount += 1;
+    if (this.failOnCalls.has(this.callCount)) {
+      throw this.error;
+    }
+    return this.inner.append(input);
+  }
+
+  getById(id: string): AuditEntry | undefined {
+    return this.inner.getById(id);
+  }
+
+  query(query?: AuditQuery): AuditEntry[] {
+    return this.inner.query(query);
+  }
+
+  queryWithCursor(query?: AuditQuery): AuditQueryResult {
+    return this.inner.queryWithCursor(query);
+  }
+
+  stream(query?: AuditQuery): IterableIterator<AuditEntry> {
+    return this.inner.stream(query);
+  }
+
+  count(): number {
+    return this.inner.count();
+  }
+
+  verifyIntegrity(): IntegrityReport {
+    return this.inner.verifyIntegrity();
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 1. Success paths
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('POST /api/v1/audit/bulk — success paths', () => {
+  let store: AuditStore;
+
+  beforeEach(() => {
+    store = new AuditStore();
+    clearIdempotencyStore();
+  });
+
+  it('creates every entry and returns 201 when all items are valid', async () => {
+    const { app } = buildApp(store);
+    const entries = [
+      makeItem({ actor: 'alice' }),
+      makeItem({ actor: 'bob' }),
+      makeItem({ actor: 'carol' }),
+    ];
+
+    const res = await request(app)
+      .post('/api/v1/audit/bulk')
+      .send({ entries })
+      .expect(201);
+
+    expect(res.body.succeeded).toBe(3);
+    expect(res.body.failed).toBe(0);
+    expect(res.body.results).toHaveLength(3);
+    res.body.results.forEach((result: { index: number; success: boolean; entry?: AuditEntry }, i: number) => {
+      expect(result.index).toBe(i);
+      expect(result.success).toBe(true);
+      expect(result.entry?.id).toBeDefined();
+    });
+    expect(store.count()).toBe(3);
+  });
+
+  it('appends entries sequentially, preserving the tamper-evident hash chain', async () => {
+    const { app } = buildApp(store);
+    const entries = [makeItem({ actor: 'alice' }), makeItem({ actor: 'bob' })];
+
+    await request(app).post('/api/v1/audit/bulk').send({ entries }).expect(201);
+
+    const report = store.verifyIntegrity();
+    expect(report.valid).toBe(true);
+    expect(report.totalEntries).toBe(2);
+    const [first, second] = store.getAll();
+    expect(second.previousHash).toBe(first.hash);
+  });
+
+  it('accepts a batch of exactly MAX_BULK_AUDIT_ITEMS items', async () => {
+    const { app } = buildApp(store);
+    const entries = Array.from({ length: MAX_BULK_AUDIT_ITEMS }, (_, i) => makeItem({ actor: `user-${i}` }));
+
+    const res = await request(app)
+      .post('/api/v1/audit/bulk')
+      .send({ entries })
+      .expect(201);
+
+    expect(res.body.succeeded).toBe(MAX_BULK_AUDIT_ITEMS);
+    expect(store.count()).toBe(MAX_BULK_AUDIT_ITEMS);
+  });
+
+  it('accepts a single-item batch', async () => {
+    const { app } = buildApp(store);
+    const res = await request(app)
+      .post('/api/v1/audit/bulk')
+      .send({ entries: [makeItem()] })
+      .expect(201);
+
+    expect(res.body.succeeded).toBe(1);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2. Partial failure
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('POST /api/v1/audit/bulk — partial failure', () => {
+  let store: AuditStore;
+
+  beforeEach(() => {
+    store = new AuditStore();
+    clearIdempotencyStore();
+  });
+
+  it('returns 207 and reports per-item errors for items missing required fields, without failing the batch', async () => {
+    const { app } = buildApp(store);
+    const entries = [
+      makeItem({ actor: 'alice' }),
+      { action: 'CONTRACT_CREATED' }, // missing severity/actor/resource/resourceId
+      makeItem({ actor: 'carol' }),
+    ];
+
+    const res = await request(app)
+      .post('/api/v1/audit/bulk')
+      .send({ entries })
+      .expect(207);
+
+    expect(res.body.succeeded).toBe(2);
+    expect(res.body.failed).toBe(1);
+    expect(res.body.results).toHaveLength(3);
+    expect(res.body.results[0].success).toBe(true);
+    expect(res.body.results[1].success).toBe(false);
+    expect(res.body.results[1].error).toContain('Missing required fields');
+    expect(res.body.results[1].entry).toBeUndefined();
+    expect(res.body.results[2].success).toBe(true);
+
+    // Only the two valid items were actually persisted.
+    expect(store.count()).toBe(2);
+  });
+
+  it('rejects an item with an invalid action while accepting the rest', async () => {
+    const { app } = buildApp(store);
+    const entries = [makeItem(), makeItem({ action: 'NOT_A_REAL_ACTION' as never })];
+
+    const res = await request(app)
+      .post('/api/v1/audit/bulk')
+      .send({ entries })
+      .expect(207);
+
+    expect(res.body.results[0].success).toBe(true);
+    expect(res.body.results[1].success).toBe(false);
+    expect(res.body.results[1].error).toContain('Invalid action');
+  });
+
+  it('rejects an item with an invalid severity while accepting the rest', async () => {
+    const { app } = buildApp(store);
+    const entries = [makeItem({ severity: 'CATASTROPHIC' as never }), makeItem()];
+
+    const res = await request(app)
+      .post('/api/v1/audit/bulk')
+      .send({ entries })
+      .expect(207);
+
+    expect(res.body.results[0].success).toBe(false);
+    expect(res.body.results[0].error).toContain('Invalid severity');
+    expect(res.body.results[1].success).toBe(true);
+  });
+
+  it('rejects a non-object item (e.g. a string) while accepting the rest', async () => {
+    const { app } = buildApp(store);
+    const entries = [makeItem(), 'not-an-object'];
+
+    const res = await request(app)
+      .post('/api/v1/audit/bulk')
+      .send({ entries })
+      .expect(207);
+
+    expect(res.body.results[0].success).toBe(true);
+    expect(res.body.results[1].success).toBe(false);
+    expect(res.body.results[1].error).toBe('Item must be an object');
+  });
+
+  it('reports a persistence-layer failure for a single item without discarding sibling items', async () => {
+    const repo = new FlakyRepository(store, new Set([2]), new Error('simulated write failure'));
+    const service = new AuditService(repo);
+    const app = express();
+    app.use(express.json());
+    app.use('/api/v1/audit', createAuditRouter({ service }));
+
+    const entries = [makeItem({ actor: 'alice' }), makeItem({ actor: 'bob' }), makeItem({ actor: 'carol' })];
+
+    const res = await request(app)
+      .post('/api/v1/audit/bulk')
+      .send({ entries })
+      .expect(207);
+
+    expect(res.body.succeeded).toBe(2);
+    expect(res.body.failed).toBe(1);
+    expect(res.body.results[0].success).toBe(true);
+    expect(res.body.results[1].success).toBe(false);
+    expect(res.body.results[1].error).toBe('simulated write failure');
+    expect(res.body.results[2].success).toBe(true);
+
+    // The failed item never reached the store; the chain among the two
+    // successful appends is still intact.
+    expect(store.count()).toBe(2);
+    expect(store.verifyIntegrity().valid).toBe(true);
+  });
+
+  it('returns 207 when every item fails', async () => {
+    const { app } = buildApp(store);
+    const entries = [{ action: 'CONTRACT_CREATED' }, { action: 'CONTRACT_CREATED' }];
+
+    const res = await request(app)
+      .post('/api/v1/audit/bulk')
+      .send({ entries })
+      .expect(207);
+
+    expect(res.body.succeeded).toBe(0);
+    expect(res.body.failed).toBe(2);
+    expect(store.count()).toBe(0);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 3. Envelope validation — empty batch, over-cap, malformed body
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('POST /api/v1/audit/bulk — envelope validation', () => {
+  let store: AuditStore;
+
+  beforeEach(() => {
+    store = new AuditStore();
+    clearIdempotencyStore();
+  });
+
+  it('rejects an empty batch with 400', async () => {
+    const { app } = buildApp(store);
+    const res = await request(app)
+      .post('/api/v1/audit/bulk')
+      .send({ entries: [] })
+      .expect(400);
+
+    expect(res.body.error.code).toBe('validation_error');
+    expect(store.count()).toBe(0);
+  });
+
+  it('rejects a batch over MAX_BULK_AUDIT_ITEMS with 400 and processes nothing', async () => {
+    const { app } = buildApp(store);
+    const entries = Array.from({ length: MAX_BULK_AUDIT_ITEMS + 1 }, () => makeItem());
+
+    const res = await request(app)
+      .post('/api/v1/audit/bulk')
+      .send({ entries })
+      .expect(400);
+
+    expect(res.body.error.code).toBe('validation_error');
+    expect(store.count()).toBe(0);
+  });
+
+  it('rejects a request with no entries field', async () => {
+    const { app } = buildApp(store);
+    const res = await request(app)
+      .post('/api/v1/audit/bulk')
+      .send({})
+      .expect(400);
+
+    expect(res.body.error.code).toBe('validation_error');
+  });
+
+  it('rejects a request where entries is not an array', async () => {
+    const { app } = buildApp(store);
+    const res = await request(app)
+      .post('/api/v1/audit/bulk')
+      .send({ entries: 'not-an-array' })
+      .expect(400);
+
+    expect(res.body.error.code).toBe('validation_error');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 4. Idempotency — shared idempotencyMiddleware, whole-batch semantics
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('POST /api/v1/audit/bulk — idempotency', () => {
+  let store: AuditStore;
+
+  beforeEach(() => {
+    store = new AuditStore();
+    clearIdempotencyStore();
+  });
+
+  it('returns 200 + replay response on identical retry with the same Idempotency-Key', async () => {
+    const { app } = buildApp(store);
+    const entries = [makeItem({ actor: 'alice' }), makeItem({ actor: 'bob' })];
+
+    const first = await request(app)
+      .post('/api/v1/audit/bulk')
+      .set('Idempotency-Key', 'bulk-key-replay')
+      .send({ entries })
+      .expect(201);
+
+    const replay = await request(app)
+      .post('/api/v1/audit/bulk')
+      .set('Idempotency-Key', 'bulk-key-replay')
+      .send({ entries })
+      .expect(200);
+
+    expect(replay.body.succeeded).toBe(first.body.succeeded);
+    expect(replay.body.idempotencyHeader).toBe('replay-detected');
+    // The retried request did not append a second time.
+    expect(store.count()).toBe(2);
+  });
+
+  it('rejects a reused Idempotency-Key with a different batch payload via 409', async () => {
+    const { app } = buildApp(store);
+
+    await request(app)
+      .post('/api/v1/audit/bulk')
+      .set('Idempotency-Key', 'bulk-key-conflict')
+      .send({ entries: [makeItem({ actor: 'alice' })] })
+      .expect(201);
+
+    const conflict = await request(app)
+      .post('/api/v1/audit/bulk')
+      .set('Idempotency-Key', 'bulk-key-conflict')
+      .send({ entries: [makeItem({ actor: 'bob' })] })
+      .expect(409);
+
+    expect(conflict.body.error.code).toBe('idempotency_payload_conflict');
+  });
+
+  it('allows different Idempotency-Keys for independent batches', async () => {
+    const { app } = buildApp(store);
+
+    await request(app)
+      .post('/api/v1/audit/bulk')
+      .set('Idempotency-Key', 'bulk-key-a')
+      .send({ entries: [makeItem({ actor: 'alice' })] })
+      .expect(201);
+
+    await request(app)
+      .post('/api/v1/audit/bulk')
+      .set('Idempotency-Key', 'bulk-key-b')
+      .send({ entries: [makeItem({ actor: 'bob' })] })
+      .expect(201);
+
+    expect(store.count()).toBe(2);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 5. Access-middleware gating — 401/403 paths
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('POST /api/v1/audit/bulk — auth gating', () => {
+  let store: AuditStore;
+
+  beforeEach(() => {
+    store = new AuditStore();
+    clearIdempotencyStore();
+  });
+
+  function buildAuthApp() {
+    return buildApp(store, {
+      accessMiddleware: [requireAuth, requireRole('admin', 'auditor')],
+    });
+  }
+
+  it('returns 401 when no token is provided', async () => {
+    const { app } = buildAuthApp();
+    await request(app)
+      .post('/api/v1/audit/bulk')
+      .send({ entries: [makeItem()] })
+      .expect(401);
+  });
+
+  it('returns 403 for a role without access', async () => {
+    const { app } = buildAuthApp();
+    await request(app)
+      .post('/api/v1/audit/bulk')
+      .set('Authorization', `Bearer ${makeToken('client')}`)
+      .send({ entries: [makeItem()] })
+      .expect(403);
+  });
+
+  it('returns 201 for admin role', async () => {
+    const { app } = buildAuthApp();
+    await request(app)
+      .post('/api/v1/audit/bulk')
+      .set('Authorization', `Bearer ${makeToken('admin')}`)
+      .send({ entries: [makeItem()] })
+      .expect(201);
+  });
+});

--- a/src/audit/router.rateLimit.test.ts
+++ b/src/audit/router.rateLimit.test.ts
@@ -61,8 +61,10 @@ describe('audit router rate limiting', () => {
     accessLimiterConfig?: Parameters<typeof createRateLimiter>[0];
     integrityLimiterConfig?: Parameters<typeof createRateLimiter>[0];
     exportLimiterConfig?: Parameters<typeof createRateLimiter>[0];
+    bulkLimiterConfig?: Parameters<typeof createRateLimiter>[0];
   } = {}) {
     const app = express();
+    app.use(express.json());
     app.use((_req, res, next) => {
       res.locals['requestId'] = 'req-audit-ratelimit';
       next();
@@ -101,6 +103,17 @@ describe('audit router rate limiting', () => {
       ...overrides.exportLimiterConfig,
     });
 
+    const bulkLimiter = createRateLimiter({
+      maxRequests: 1,
+      windowMs: 60_000,
+      abuseThreshold: 10,
+      blockWindowMs: 60_000,
+      blockDurationMs: 60_000,
+      maxBlockDurationMs: 60_000,
+      keyFn: actorKeyFn('bulk'),
+      ...overrides.bulkLimiterConfig,
+    });
+
     app.use(
       '/api/v1/audit',
       createAuditRouter({
@@ -109,6 +122,7 @@ describe('audit router rate limiting', () => {
         accessMiddleware: [requireAuth, requireRole('admin', 'auditor'), accessLimiter],
         exportMiddleware: [exportLimiter],
         integrityMiddleware: [integrityLimiter],
+        bulkMiddleware: [bulkLimiter],
       }),
     );
 
@@ -244,6 +258,58 @@ describe('audit router rate limiting', () => {
         .expect(429);
 
       expect(response.body.error.code).toBe('rate_limited');
+    });
+  });
+
+  describe('bulk tier (POST /bulk)', () => {
+    it('is rate limited independently and stacks with the general access tier', async () => {
+      const app = buildApp({ accessLimiterConfig: { maxRequests: 100 } });
+      const token = makeToken('admin', 'admin-bulk');
+      const entries = [{
+        action: 'CONTRACT_CREATED',
+        severity: 'INFO',
+        actor: 'user-1',
+        resource: 'contract',
+        resourceId: 'contract-1',
+      }];
+
+      await request(app)
+        .post('/api/v1/audit/bulk')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ entries })
+        .expect(201);
+
+      const response = await request(app)
+        .post('/api/v1/audit/bulk')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ entries })
+        .expect(429);
+
+      expect(response.body.error.code).toBe('rate_limited');
+      expect(response.headers['retry-after']).toBeDefined();
+    });
+
+    it('does not consume the general-access bucket for a different route', async () => {
+      const app = buildApp();
+      const token = makeToken('admin', 'admin-bulk-isolation');
+      const entries = [{
+        action: 'CONTRACT_CREATED',
+        severity: 'INFO',
+        actor: 'user-1',
+        resource: 'contract',
+        resourceId: 'contract-1',
+      }];
+
+      // Bulk is capped at 1 by default in this test app, and also consumes
+      // one unit of the shared access bucket (cap 2).
+      await request(app)
+        .post('/api/v1/audit/bulk')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ entries })
+        .expect(201);
+
+      // One access-bucket slot remains; a query should still succeed.
+      await request(app).get('/api/v1/audit').set('Authorization', `Bearer ${token}`).expect(200);
     });
   });
 

--- a/src/audit/router.ts
+++ b/src/audit/router.ts
@@ -1,11 +1,13 @@
 /**
  * @module audit/router
- * @description REST endpoints for querying the audit log.
+ * @description REST endpoints for querying and writing the audit log.
  *
  * Routes:
  *   GET  /api/v1/audit          - Query audit entries with optional filters
  *   GET  /api/v1/audit/:id      - Retrieve a single entry by ID
  *   GET  /api/v1/audit/integrity - Verify the hash chain integrity
+ *   POST /api/v1/audit          - Write a single audit entry
+ *   POST /api/v1/audit/bulk     - Write a bounded batch of audit entries
  *
  * Security notes:
  * - In production these routes MUST be protected by authentication and
@@ -13,18 +15,21 @@
  * - Query parameters are validated and clamped to prevent abuse.
  * - All routes are rate-limited per client (issue #746): `accessMiddleware`
  *   carries the general `audit` tier, `/export` additionally gets the
- *   `auditExport` tier via `exportMiddleware`, and `/integrity` additionally
- *   gets the stricter `auditIntegrity` tier via `integrityMiddleware` — see
- *   `rateLimitConfig` in `src/config/rateLimit.ts`.
+ *   `auditExport` tier via `exportMiddleware`, `/integrity` additionally
+ *   gets the stricter `auditIntegrity` tier via `integrityMiddleware`, and
+ *   `/bulk` additionally gets the `auditBulk` tier via `bulkMiddleware` —
+ *   see `rateLimitConfig` in `src/config/rateLimit.ts`.
  */
 
 import { Router, Request, Response, type RequestHandler } from 'express';
 import { pipeline } from 'stream/promises';
+import { z } from 'zod';
 import { auditService, AuditService } from './service';
 import { auditExportService, AuditExportService, type AuditExportFilters } from './exportService';
-import type { AuditAction, AuditQuery, AuditSeverity, CreateAuditEntryInput } from './types';
+import type { AuditAction, AuditQuery, AuditSeverity, BulkAuditItemResult, CreateAuditEntryInput } from './types';
 import { decodeCursor } from './types';
 import { idempotencyMiddleware } from '../middleware/idempotency';
+import { validateRequest } from '../middleware/validate.middleware';
 
 export interface AuditRouterOptions {
   service?: AuditService;
@@ -38,9 +43,16 @@ export interface AuditRouterOptions {
    * `rateLimitConfig.auditIntegrity` in `src/config/rateLimit.ts`.
    */
   integrityMiddleware?: RequestHandler[];
+  /**
+   * Middleware applied only to `POST /bulk`, in addition to
+   * `accessMiddleware`. Bulk writes can append up to `MAX_BULK_AUDIT_ITEMS`
+   * entries per request, so this endpoint gets its own rate limiter — see
+   * `rateLimitConfig.auditBulk` in `src/config/rateLimit.ts`.
+   */
+  bulkMiddleware?: RequestHandler[];
 }
 
-const VALID_ACTIONS = new Set<AuditAction>([
+const AUDIT_ACTIONS = [
   'CONTRACT_CREATED', 'CONTRACT_UPDATED', 'CONTRACT_CANCELLED', 'CONTRACT_COMPLETED',
   'PAYMENT_INITIATED', 'PAYMENT_RELEASED', 'PAYMENT_DISPUTED',
   'REPUTATION_UPDATED',
@@ -48,9 +60,57 @@ const VALID_ACTIONS = new Set<AuditAction>([
   'AUTH_LOGIN', 'AUTH_LOGOUT', 'AUTH_FAILED',
   'ADMIN_ACTION',
   'ENDPOINT_ACCESS', 'ENDPOINT_MUTATION',
-]);
+] as const satisfies readonly AuditAction[];
 
-const VALID_SEVERITIES = new Set<AuditSeverity>(['INFO', 'WARNING', 'CRITICAL']);
+const AUDIT_SEVERITIES = ['INFO', 'WARNING', 'CRITICAL'] as const satisfies readonly AuditSeverity[];
+
+const VALID_ACTIONS = new Set<AuditAction>(AUDIT_ACTIONS);
+const VALID_SEVERITIES = new Set<AuditSeverity>(AUDIT_SEVERITIES);
+
+/** Hard cap on the number of items accepted by a single `POST /bulk` request. */
+export const MAX_BULK_AUDIT_ITEMS = 100;
+
+/**
+ * Validates only the envelope shape of a bulk request: `entries` must be a
+ * bounded, non-empty array. Individual item field validation intentionally
+ * happens per-item in the route handler (see `validateBulkAuditItem`) rather
+ * than here, so that one malformed item fails only itself instead of
+ * rejecting the whole batch with a 400.
+ */
+const bulkAuditRequestSchema = z.object({
+  entries: z
+    .array(z.unknown())
+    .min(1, 'entries must contain at least 1 item')
+    .max(MAX_BULK_AUDIT_ITEMS, `entries must not exceed ${MAX_BULK_AUDIT_ITEMS} items`),
+});
+
+/**
+ * Validates a single bulk-batch item, mirroring the hand-rolled checks used
+ * by `POST /` (required fields) plus the action/severity enum checks already
+ * applied to query filters. Returns an error message, or `undefined` if the
+ * item is valid.
+ */
+function validateBulkAuditItem(raw: unknown): string | undefined {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    return 'Item must be an object';
+  }
+
+  const input = raw as Partial<CreateAuditEntryInput>;
+
+  if (!input.action || !input.severity || !input.actor || !input.resource || !input.resourceId) {
+    return 'Missing required fields: action, severity, actor, resource, resourceId';
+  }
+
+  if (!VALID_ACTIONS.has(input.action as AuditAction)) {
+    return `Invalid action: ${String(input.action)}`;
+  }
+
+  if (!VALID_SEVERITIES.has(input.severity as AuditSeverity)) {
+    return `Invalid severity: ${String(input.severity)}`;
+  }
+
+  return undefined;
+}
 
 function parseOptionalIsoDate(
   value: string | undefined,
@@ -169,6 +229,7 @@ export function createAuditRouter(options: AuditRouterOptions = {}): Router {
   const accessMiddleware = options.accessMiddleware ?? [];
   const exportMiddleware = options.exportMiddleware ?? [];
   const integrityMiddleware = options.integrityMiddleware ?? [];
+  const bulkMiddleware = options.bulkMiddleware ?? [];
 
   /**
    * POST /api/v1/audit
@@ -194,6 +255,57 @@ export function createAuditRouter(options: AuditRouterOptions = {}): Router {
       } catch (error) {
         res.status(500).json({ error: (error as Error).message });
       }
+    },
+  );
+
+  /**
+   * POST /api/v1/audit/bulk
+   *
+   * Write a bounded batch of audit entries in one request. Each item is
+   * validated and appended independently — a malformed or failing item is
+   * reported in its own `results[]` slot without discarding the rest of the
+   * batch. The whole request is rejected with 400 only when the envelope
+   * itself is invalid (not an array, empty, or over `MAX_BULK_AUDIT_ITEMS`).
+   *
+   * Entries are appended sequentially (not in parallel) to preserve the
+   * tamper-evident hash chain, so a large batch is O(n) requests to the
+   * underlying store — bounded by `MAX_BULK_AUDIT_ITEMS`.
+   *
+   * The whole batch shares one Idempotency-Key, matching `POST /`: a retried
+   * request with an identical body replays the cached aggregate response.
+   *
+   * Responds 201 when every item succeeded, or 207 (Multi-Status) when at
+   * least one item failed, so callers can distinguish "fully applied" from
+   * "needs per-item inspection" without parsing the body first.
+   */
+  router.post(
+    '/bulk',
+    idempotencyMiddleware,
+    ...accessMiddleware,
+    ...bulkMiddleware,
+    validateRequest(bulkAuditRequestSchema),
+    (req: Request, res: Response): void => {
+      const { entries } = req.body as { entries: unknown[] };
+
+      const results: BulkAuditItemResult[] = entries.map((raw, index) => {
+        const validationError = validateBulkAuditItem(raw);
+        if (validationError) {
+          return { index, success: false, error: validationError };
+        }
+
+        try {
+          const entry = service.log(raw as CreateAuditEntryInput);
+          return { index, success: true, entry };
+        } catch (error) {
+          return { index, success: false, error: (error as Error).message };
+        }
+      });
+
+      const failed = results.filter((result) => !result.success).length;
+      const succeeded = results.length - failed;
+      const status = failed === 0 ? 201 : 207;
+
+      res.status(status).json({ results, succeeded, failed });
     },
   );
 

--- a/src/audit/types.ts
+++ b/src/audit/types.ts
@@ -74,6 +74,25 @@ export interface AuditEntry {
 /** Input required to create a new audit entry (hash fields are computed internally). */
 export type CreateAuditEntryInput = Omit<AuditEntry, 'id' | 'timestamp' | 'hash' | 'previousHash'>;
 
+/**
+ * Outcome of a single item within a `POST /api/v1/audit/bulk` request.
+ * Exactly one of `entry` / `error` is populated, matching `success`.
+ */
+export interface BulkAuditItemResult {
+  /** Position of this item within the submitted `entries` array. */
+  index: number;
+  success: boolean;
+  entry?: AuditEntry;
+  error?: string;
+}
+
+/** Aggregate response body for `POST /api/v1/audit/bulk`. */
+export interface BulkAuditResult {
+  results: BulkAuditItemResult[];
+  succeeded: number;
+  failed: number;
+}
+
 /** Opaque cursor for pagination. Encodes position and filters. */
 export type AuditCursor = string;
 

--- a/src/config/rateLimit.ts
+++ b/src/config/rateLimit.ts
@@ -24,6 +24,9 @@
  * | RL_AUDIT_ABUSE_THRESHOLD   | 5          | Violations before hard block (audit)     |
  * | RL_AUDIT_INTEGRITY_MAX     | 10         | Max requests per window (audit integrity)|
  * | RL_AUDIT_INTEGRITY_WINDOW_MS | 60000    | Window duration in ms (audit integrity)  |
+ * | RL_AUDIT_BULK_MAX          | 30         | Max requests per window (audit bulk)     |
+ * | RL_AUDIT_BULK_WINDOW_MS    | 60000      | Window duration in ms (audit bulk)       |
+ * | RL_AUDIT_BULK_ABUSE_THRESHOLD | 5       | Violations before hard block (audit bulk)|
  *
  * ## Tier Descriptions
  *
@@ -176,6 +179,24 @@ export const rateLimitConfig = {
     blockWindowMs: toMs(process.env.RL_AUDIT_EXPORT_BLOCK_WINDOW_MS, 21_600_000),
     blockDurationMs: toMs(process.env.RL_AUDIT_EXPORT_BLOCK_DURATION_MS, 3_600_000),
     maxBlockDurationMs: toMs(process.env.RL_AUDIT_EXPORT_MAX_BLOCK_MS, 86_400_000),
+    sendHeaders: true,
+    ...sharedStore,
+  } satisfies RateLimiterConfig,
+
+  /**
+   * Audit bulk tier: `POST /api/v1/audit/bulk` batch writes.
+   * Kept tighter than the general `audit`/write-request limit because each
+   * request can append up to `MAX_BULK_AUDIT_ITEMS` entries to the hash
+   * chain (sequential appends), not just one — similar rationale to
+   * `auditExport` being its own tier rather than reusing `audit`.
+   */
+  auditBulk: {
+    maxRequests: toCount(process.env.RL_AUDIT_BULK_MAX, 30),
+    windowMs: toMs(process.env.RL_AUDIT_BULK_WINDOW_MS, 60_000),
+    abuseThreshold: toCount(process.env.RL_AUDIT_BULK_ABUSE_THRESHOLD, 5),
+    blockWindowMs: toMs(process.env.RL_AUDIT_BULK_BLOCK_WINDOW_MS, 300_000),
+    blockDurationMs: toMs(process.env.RL_AUDIT_BULK_BLOCK_DURATION_MS, 600_000),
+    maxBlockDurationMs: toMs(process.env.RL_AUDIT_BULK_MAX_BLOCK_MS, 86_400_000),
     sendHeaders: true,
     ...sharedStore,
   } satisfies RateLimiterConfig,

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,12 +46,18 @@ const auditIntegrityLimiter = createRateLimiter({
   keyFn: auditActorKeyFn('audit-integrity'),
 });
 
+const auditBulkLimiter = createRateLimiter({
+  ...rateLimitConfig.auditBulk,
+  keyFn: auditActorKeyFn('audit-bulk'),
+});
+
 app.use(
   '/api/v1/audit',
   createAuditRouter({
     accessMiddleware: [requireAuth, requireRole('admin', 'auditor'), auditQueryLimiter],
     exportMiddleware: [auditExportLimiter],
     integrityMiddleware: [auditIntegrityLimiter],
+    bulkMiddleware: [auditBulkLimiter],
   }),
 );
 

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -85,10 +85,4 @@ healthRouter.post('/', validateRequest(HealthWriteBodySchema), (_req: Request, r
     timestamp: new Date().toISOString(),
     version: process.env.npm_package_version ?? '0.1.0',
   });
-healthRouter.get('/', (_req: Request, res: Response) => {
-  res.status(200).json({ status: 'ok', service: 'talenttrust-backend' });
-});
-
-healthRouter.post("/", (_req: Request, res: Response) => {
-  sendHealthResponse(res);
 });


### PR DESCRIPTION
Closes #829

---

#829

$ npx jest src/audit --silent

PASS src/audit/exportService.test.ts
PASS src/audit/audit.test.ts
PASS src/audit/router.bulk.test.ts
PASS src/audit/router.integration.test.ts
PASS src/audit/router.rateLimit.test.ts
PASS src/audit/router.validation.test.ts
PASS src/audit/protectedEndpointMiddleware.test.ts
PASS src/audit/router.secure.test.ts
PASS src/audit/middleware.test.ts
PASS src/audit/sqliteRepository.test.ts
PASS src/audit/service.test.ts

Test Suites: 11 passed, 11 total
Tests:       438 passed, 438 total
Snapshots:   0 total
Time:        22.401 s

$ npx jest src/audit --coverage --collectCoverageFrom='src/audit/router.ts' --collectCoverageFrom='src/audit/types.ts'

-----------|---------|----------|---------|---------|-------------------
File       | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
-----------|---------|----------|---------|---------|-------------------
All files  |    97.9 |    95.83 |     100 |   97.88 |
 router.ts |   97.77 |    95.83 |     100 |   97.76 | 256,322-323
 types.ts  |     100 |      100 |     100 |     100 |
-----------|---------|----------|---------|---------|-------------------

Test Suites: 11 passed, 11 total
Tests:       438 passed, 438 total