### PR TITLE
refactor(disputes): extract shared event-envelope validation helper

### DIFF
--- a/src/contracts/validation.ts
+++ b/src/contracts/validation.ts
@@ -1,4 +1,8 @@
 import { ContractEvent } from './types';
+import {
+  EnvelopeValidationOptions,
+  validateEventEnvelopePreamble,
+} from '../shared/eventEnvelopeValidation';
 
 type ValidationResult =
   | { ok: true; event: ContractEvent }
@@ -12,53 +16,54 @@ const EVENT_TYPES = new Set<ContractEvent['type']>([
   'CONTRACT_CANCELLED',
 ]);
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
+/**
+ * Preamble options for the contract-event validator.
+ * Mirrors the inline behaviour that used to live here:
+ * - short-circuit on first failure (`abortEarly: true`)
+ * - ISO-string timestamps only (`timestampRule: 'iso'`)
+ * - no trailing-period punctuation on messages
+ */
+const CONTRACT_PREAMBLE_OPTIONS = {
+  rootErrorMessage: 'Payload must be a JSON object',
+  messageSuffix: '',
+  timestampRule: 'iso',
+  abortEarly: true,
+} satisfies EnvelopeValidationOptions;
 
 /**
  * @notice Validates and normalizes unknown payloads into a strict contract event.
+ * @dev    The per-field preamble is delegated to the shared envelope validator
+ *         so the dispute-event ingestion path can reuse the exact same checks.
+ *         The `type` whitelist and event-payload shape remain specific to
+ *         contract ingestion.
  */
 export function validateContractEventPayload(payload: unknown): ValidationResult {
-  if (!isRecord(payload)) {
-    return { ok: false, reason: 'Payload must be a JSON object' };
+  const errors = validateEventEnvelopePreamble(payload, CONTRACT_PREAMBLE_OPTIONS);
+  if (errors.length > 0) {
+    return { ok: false, reason: errors[0].message };
   }
 
-  const { contractId, eventId, sequence, timestamp, type, payload: eventPayload } = payload;
+  // `validateEventEnvelopePreamble` already enforces isRecord + per-field
+  // types. The casts below are safe because the helper has just validated
+  // each destructured field against its expected predicate.
+  const checked = payload as Record<string, unknown>;
 
-  if (typeof contractId !== 'string' || contractId.trim().length === 0) {
-    return { ok: false, reason: 'contractId is required' };
-  }
-
-  if (typeof eventId !== 'string' || eventId.trim().length === 0) {
-    return { ok: false, reason: 'eventId is required' };
-  }
-
-  if (typeof sequence !== 'number' || !Number.isInteger(sequence) || sequence < 0) {
-    return { ok: false, reason: 'sequence must be a non-negative integer' };
-  }
-
-  if (typeof timestamp !== 'string' || Number.isNaN(Date.parse(timestamp))) {
-    return { ok: false, reason: 'timestamp must be a valid ISO string' };
-  }
-
-  if (typeof type !== 'string' || !EVENT_TYPES.has(type as ContractEvent['type'])) {
+  if (
+    typeof checked.type !== 'string' ||
+    !EVENT_TYPES.has(checked.type as ContractEvent['type'])
+  ) {
     return { ok: false, reason: 'type is invalid' };
-  }
-
-  if (!isRecord(eventPayload)) {
-    return { ok: false, reason: 'payload must be an object' };
   }
 
   return {
     ok: true,
     event: {
-      contractId: contractId.trim(),
-      eventId: eventId.trim(),
-      sequence,
-      timestamp,
-      type: type as ContractEvent['type'],
-      payload: eventPayload,
+      contractId: (checked.contractId as string).trim(),
+      eventId: (checked.eventId as string).trim(),
+      sequence: checked.sequence as number,
+      timestamp: checked.timestamp as string,
+      type: checked.type as ContractEvent['type'],
+      payload: checked.payload as Record<string, unknown>,
     },
   };
 }

--- a/src/events/eventIngestionService.ts
+++ b/src/events/eventIngestionService.ts
@@ -1,5 +1,10 @@
 import { EventAuditService } from '../repository/eventAuditRepository';
 import { ContractEvent } from './types';
+import {
+  EnvelopeValidationOptions,
+  isRecord,
+  validateEventEnvelopePreamble,
+} from '../shared/eventEnvelopeValidation';
 
 export interface EventIngestionConfig {
   enableStrictValidation: boolean;
@@ -26,10 +31,6 @@ export interface EventIngestionResult {
   code?: string;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
 function toTimestampNumber(value: unknown): number | null {
   if (typeof value === 'number' && Number.isFinite(value)) {
     return value;
@@ -42,6 +43,20 @@ function toTimestampNumber(value: unknown): number | null {
 
   return null;
 }
+
+/**
+ * Preamble options for the event-ingestion-service validator.
+ * Mirrors the inline behaviour that used to live here:
+ * - collect every failing field (`abortEarly: false`)
+ * - accept numeric or numeric-string timestamps (`timestampRule: 'numeric'`)
+ * - messages suffixed with a trailing `.`
+ */
+const INGESTION_PREAMBLE_OPTIONS = {
+  rootErrorMessage: 'Event must be a JSON object.',
+  messageSuffix: '.',
+  timestampRule: 'numeric',
+  abortEarly: false,
+} satisfies EnvelopeValidationOptions;
 
 export class EventIngestionService {
   constructor(
@@ -113,40 +128,30 @@ export class EventIngestionService {
   public validateEvent(event: unknown, contractType: string): EventValidationResult {
     const errors: EventValidationError[] = [];
 
-    if (!isRecord(event)) {
-      return {
-        isValid: false,
-        errors: [{ field: 'event', message: 'Event must be a JSON object.' }],
-      };
+    // Delegate the shared preamble to the helper. This produces the same
+    // set of field errors as the previous inline implementation, with the
+    // same messages and field names.
+    const preambleErrors = validateEventEnvelopePreamble(event, INGESTION_PREAMBLE_OPTIONS);
+    for (const err of preambleErrors) {
+      errors.push({ field: err.field, message: err.message });
     }
 
-    const { contractId, eventId, sequence, timestamp, payload } = event;
+    // Caller-specific follow-up: age check (numeric timestamp only) and
+    // contract-type-specific payload shape. Both early-exit when `event`
+    // is not a record, which the helper has already established.
+    if (isRecord(event)) {
+      const timestampNumber = toTimestampNumber(event.timestamp);
+      if (
+        timestampNumber !== null &&
+        !preambleErrors.some((e) => e.field === 'timestamp') &&
+        Date.now() - timestampNumber > this.config.maxEventAgeMs
+      ) {
+        errors.push({ field: 'timestamp', message: 'Event too old.' });
+      }
 
-    if (typeof contractId !== 'string' || contractId.trim().length === 0) {
-      errors.push({ field: 'contractId', message: 'contractId is required.' });
-    }
-
-    if (typeof eventId !== 'string' || eventId.trim().length === 0) {
-      errors.push({ field: 'eventId', message: 'eventId is required.' });
-    }
-
-    if (typeof sequence !== 'number' || !Number.isInteger(sequence) || sequence < 0) {
-      errors.push({ field: 'sequence', message: 'sequence must be a non-negative integer.' });
-    }
-
-    const timestampNumber = toTimestampNumber(timestamp);
-    if (timestampNumber === null) {
-      errors.push({ field: 'timestamp', message: 'timestamp must be a valid epoch number or numeric string.' });
-    } else if (Date.now() - timestampNumber > this.config.maxEventAgeMs) {
-      errors.push({ field: 'timestamp', message: 'Event too old.' });
-    }
-
-    if (!isRecord(payload)) {
-      errors.push({ field: 'payload', message: 'payload must be an object.' });
-    }
-
-    if (this.config.enableStrictValidation) {
-      errors.push(...this.validateContractSpecificPayload(contractType, payload));
+      if (this.config.enableStrictValidation) {
+        errors.push(...this.validateContractSpecificPayload(contractType, event.payload));
+      }
     }
 
     return {

--- a/src/shared/eventEnvelopeValidation.test.ts
+++ b/src/shared/eventEnvelopeValidation.test.ts
@@ -1,0 +1,377 @@
+import {
+  isRecord,
+  validateEventEnvelopePreamble,
+  EnvelopeValidationOptions,
+  FieldError,
+} from './eventEnvelopeValidation';
+
+/**
+ * Build a fully valid envelope. Tests then mutate one field at a time to
+ * exercise the per-field branches of `validateEventEnvelopePreamble`.
+ */
+function makeEnvelope(overrides: Record<string, unknown> = {}) {
+  return {
+    contractId: 'contract-1',
+    eventId: 'event-1',
+    sequence: 1,
+    timestamp: 1_700_000_000_000, // numeric epoch (ms) — covers `toFiniteNumber`
+    payload: { foo: 'bar' },
+    ...overrides,
+  };
+}
+
+/** Shared options used by most tests in this file. */
+const NUMERIC_NO_ABORT: EnvelopeValidationOptions = {
+  rootErrorMessage: 'Event must be a JSON object.',
+  messageSuffix: '.',
+  timestampRule: 'numeric',
+  abortEarly: false,
+};
+
+const ISO_NO_ABORT: EnvelopeValidationOptions = {
+  rootErrorMessage: 'Payload must be a JSON object',
+  messageSuffix: '',
+  timestampRule: 'iso',
+  abortEarly: false,
+};
+
+const ISO_ABORT: EnvelopeValidationOptions = {
+  rootErrorMessage: 'Payload must be a JSON object',
+  messageSuffix: '',
+  timestampRule: 'iso',
+  abortEarly: true,
+};
+
+describe('isRecord', () => {
+  it('returns true for plain objects', () => {
+    expect(isRecord({})).toBe(true);
+    expect(isRecord({ a: 1 })).toBe(true);
+  });
+
+  it('returns false for null and undefined', () => {
+    expect(isRecord(null)).toBe(false);
+    expect(isRecord(undefined)).toBe(false);
+  });
+
+  it('returns false for primitives', () => {
+    expect(isRecord('x')).toBe(false);
+    expect(isRecord(1)).toBe(false);
+    expect(isRecord(true)).toBe(false);
+  });
+
+  it('returns false for arrays (even empty arrays)', () => {
+    expect(isRecord([])).toBe(false);
+    expect(isRecord([1, 2, 3])).toBe(false);
+  });
+});
+
+describe('validateEventEnvelopePreamble — happy path', () => {
+  it('returns no errors for a fully valid envelope (numeric timestamp)', () => {
+    const errors = validateEventEnvelopePreamble(makeEnvelope(), NUMERIC_NO_ABORT);
+    expect(errors).toEqual([]);
+  });
+
+  it('returns no errors for a fully valid envelope (ISO timestamp)', () => {
+    const envelope = { ...makeEnvelope(), timestamp: '2024-01-01T00:00:00.000Z' };
+    const errors = validateEventEnvelopePreamble(envelope, ISO_NO_ABORT);
+    expect(errors).toEqual([]);
+  });
+
+  it('accepts numeric-string timestamps under the numeric rule', () => {
+    const envelope = { ...makeEnvelope(), timestamp: '1700000000000' };
+    expect(validateEventEnvelopePreamble(envelope, NUMERIC_NO_ABORT)).toEqual([]);
+  });
+
+  it('rejects a numeric epoch when the rule is ISO (no Date.parse of a number)', () => {
+    const envelope = { ...makeEnvelope(), timestamp: 1_700_000_000_000 };
+    const errors = validateEventEnvelopePreamble(envelope, ISO_NO_ABORT);
+    expect(errors).toEqual([
+      { field: 'timestamp', message: 'timestamp must be a valid ISO string' },
+    ]);
+  });
+
+  it('accepts an ISO string when the rule is ISO', () => {
+    const envelope = { ...makeEnvelope(), timestamp: '2024-13-01T00:00:00.000Z' };
+    // First assert parse failure, then accept valid ISO.
+    expect(validateEventEnvelopePreamble({ ...envelope }, ISO_NO_ABORT)).toHaveLength(1);
+    const ok = { ...envelope, timestamp: '2024-01-01T00:00:00.000Z' };
+    expect(validateEventEnvelopePreamble(ok, ISO_NO_ABORT)).toEqual([]);
+  });
+});
+
+describe('validateEventEnvelopePreamble — root shape', () => {
+  it('emits the root error when the input is not an object', () => {
+    const cases: unknown[] = [null, undefined, 'x', 1, true, []];
+    for (const value of cases) {
+      const errors = validateEventEnvelopePreamble(value, NUMERIC_NO_ABORT);
+      expect(errors).toEqual([
+        { field: 'event', message: 'Event must be a JSON object.' },
+      ]);
+    }
+  });
+
+  it('uses the configured root error message verbatim (no suffix variant)', () => {
+    const errors = validateEventEnvelopePreamble('not-an-object', ISO_NO_ABORT);
+    expect(errors).toEqual([
+      { field: 'event', message: 'Payload must be a JSON object' },
+    ]);
+  });
+
+  it('short-circuits on root shape failure even when abortEarly=true', () => {
+    const errors = validateEventEnvelopePreamble(null, ISO_ABORT);
+    expect(errors).toEqual([
+      { field: 'event', message: 'Payload must be a JSON object' },
+    ]);
+  });
+});
+
+describe('validateEventEnvelopePreamble — contractId branch', () => {
+  it.each([
+    ['missing', undefined],
+    ['empty string', ''],
+    ['whitespace-only', '   '],
+    ['number', 123],
+    ['null', null],
+    ['array', ['x']],
+  ])('rejects contractId when value is %s', (_label, value) => {
+    const errors = validateEventEnvelopePreamble(
+      makeEnvelope({ contractId: value }),
+      NUMERIC_NO_ABORT,
+    );
+    expect(errors).toEqual([
+      { field: 'contractId', message: 'contractId is required.' },
+    ]);
+  });
+
+  it('respects messageSuffix (no suffix when caller passes "")', () => {
+    // The default makeEnvelope() timestamp is numeric, which fails the ISO rule.
+    // Override to a valid ISO string so this test isolates the contractId rejection.
+    const errors = validateEventEnvelopePreamble(
+      makeEnvelope({ contractId: '', timestamp: '2024-01-01T00:00:00.000Z' }),
+      ISO_NO_ABORT,
+    );
+    expect(errors).toEqual([
+      { field: 'contractId', message: 'contractId is required' },
+    ]);
+  });
+
+  it('short-circuits on contractId failure with abortEarly=true', () => {
+    const errors = validateEventEnvelopePreamble(
+      { ...makeEnvelope(), contractId: '', eventId: '', sequence: -1 },
+      ISO_ABORT,
+    );
+    // Only the first failing field is reported.
+    expect(errors).toEqual([
+      { field: 'contractId', message: 'contractId is required' },
+    ]);
+  });
+});
+
+describe('validateEventEnvelopePreamble — eventId branch', () => {
+  it('rejects missing/empty/non-string eventId', () => {
+    for (const value of [undefined, '', '   ', 0, false, null] as unknown[]) {
+      const errors = validateEventEnvelopePreamble(
+        makeEnvelope({ eventId: value }),
+        NUMERIC_NO_ABORT,
+      );
+      expect(errors).toContainEqual({
+        field: 'eventId',
+        message: 'eventId is required.',
+      });
+    }
+  });
+
+  it('produces both contractId and eventId errors when abortEarly=false', () => {
+    const errors = validateEventEnvelopePreamble(
+      makeEnvelope({ contractId: '', eventId: '' }),
+      NUMERIC_NO_ABORT,
+    );
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        { field: 'contractId', message: 'contractId is required.' },
+        { field: 'eventId', message: 'eventId is required.' },
+      ]),
+    );
+  });
+});
+
+describe('validateEventEnvelopePreamble — sequence branch', () => {
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['float', 1.5],
+    ['negative integer', -1],
+    ['NaN', NaN],
+    ['string', '1'],
+  ])('rejects sequence when value is %s', (_label, value) => {
+    const errors = validateEventEnvelopePreamble(
+      makeEnvelope({ sequence: value }),
+      NUMERIC_NO_ABORT,
+    );
+    expect(errors).toEqual([
+      { field: 'sequence', message: 'sequence must be a non-negative integer.' },
+    ]);
+  });
+
+  it('accepts sequence=0', () => {
+    expect(
+      validateEventEnvelopePreamble(makeEnvelope({ sequence: 0 }), NUMERIC_NO_ABORT),
+    ).toEqual([]);
+  });
+});
+
+describe('validateEventEnvelopePreamble — timestamp branches', () => {
+  it('rejects a non-string when ISO rule is active', () => {
+    const errors = validateEventEnvelopePreamble(
+      makeEnvelope({ timestamp: 1_700_000_000_000 }),
+      ISO_NO_ABORT,
+    );
+    expect(errors).toEqual([
+      { field: 'timestamp', message: 'timestamp must be a valid ISO string' },
+    ]);
+  });
+
+  it('rejects a string Date.parse cannot parse when ISO rule is active', () => {
+    const errors = validateEventEnvelopePreamble(
+      makeEnvelope({ timestamp: 'not-a-date' }),
+      ISO_NO_ABORT,
+    );
+    expect(errors).toEqual([
+      { field: 'timestamp', message: 'timestamp must be a valid ISO string' },
+    ]);
+  });
+
+  it('rejects a non-finite number when numeric rule is active', () => {
+    const errors = validateEventEnvelopePreamble(
+      makeEnvelope({ timestamp: NaN }),
+      NUMERIC_NO_ABORT,
+    );
+    expect(errors).toEqual([
+      { field: 'timestamp', message: 'timestamp must be a valid epoch number or numeric string.' },
+    ]);
+  });
+
+  it('rejects a non-numeric string when numeric rule is active', () => {
+    const errors = validateEventEnvelopePreamble(
+      makeEnvelope({ timestamp: 'not-a-number' }),
+      NUMERIC_NO_ABORT,
+    );
+    expect(errors).toEqual([
+      { field: 'timestamp', message: 'timestamp must be a valid epoch number or numeric string.' },
+    ]);
+  });
+
+  it('rejects an empty string when numeric rule is active', () => {
+    const errors = validateEventEnvelopePreamble(
+      makeEnvelope({ timestamp: '' }),
+      NUMERIC_NO_ABORT,
+    );
+    expect(errors).toEqual([
+      { field: 'timestamp', message: 'timestamp must be a valid epoch number or numeric string.' },
+    ]);
+  });
+
+  it('rejects a whitespace-only string when numeric rule is active', () => {
+    const errors = validateEventEnvelopePreamble(
+      makeEnvelope({ timestamp: '   ' }),
+      NUMERIC_NO_ABORT,
+    );
+    expect(errors).toEqual([
+      { field: 'timestamp', message: 'timestamp must be a valid epoch number or numeric string.' },
+    ]);
+  });
+
+  it('accepts an infinite number under numeric rule', () => {
+    const errors = validateEventEnvelopePreamble(
+      makeEnvelope({ timestamp: Number.POSITIVE_INFINITY }),
+      NUMERIC_NO_ABORT,
+    );
+    expect(errors).toContainEqual({
+      field: 'timestamp',
+      message: 'timestamp must be a valid epoch number or numeric string.',
+    });
+  });
+});
+
+describe('validateEventEnvelopePreamble — payload branch', () => {
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['string', 'x'],
+    ['number', 1],
+    ['array', []],
+  ])('rejects payload when value is %s', (_label, value) => {
+    const errors = validateEventEnvelopePreamble(
+      makeEnvelope({ payload: value }),
+      NUMERIC_NO_ABORT,
+    );
+    expect(errors).toEqual([
+      { field: 'payload', message: 'payload must be an object.' },
+    ]);
+  });
+
+  it('accepts an empty object as payload', () => {
+    expect(
+      validateEventEnvelopePreamble(makeEnvelope({ payload: {} }), NUMERIC_NO_ABORT),
+    ).toEqual([]);
+  });
+});
+
+describe('validateEventEnvelopePreamble — abortEarly behaviour', () => {
+  it('returns only the first failing field when abortEarly=true', () => {
+    const errors = validateEventEnvelopePreamble(
+      makeEnvelope({ contractId: '', eventId: '', sequence: -1 }),
+      ISO_ABORT,
+    );
+    expect(errors).toEqual([
+      { field: 'contractId', message: 'contractId is required' },
+    ]);
+  });
+
+  it('returns every failing field when abortEarly=false', () => {
+    const errors = validateEventEnvelopePreamble(
+      makeEnvelope({ contractId: '', eventId: '', sequence: -1, payload: 'bad' }),
+      ISO_NO_ABORT,
+    );
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        { field: 'contractId', message: 'contractId is required' },
+        { field: 'eventId', message: 'eventId is required' },
+        { field: 'sequence', message: 'sequence must be a non-negative integer' },
+        { field: 'payload', message: 'payload must be an object' },
+      ]),
+    );
+  });
+});
+
+describe('validateEventEnvelopePreamble — message shaping', () => {
+  it('appends messageSuffix to every per-field message', () => {
+    const opts: EnvelopeValidationOptions = {
+      rootErrorMessage: 'X',
+      messageSuffix: '!!!',
+      timestampRule: 'numeric',
+      abortEarly: false,
+    };
+    const errors: FieldError[] = validateEventEnvelopePreamble(
+      makeEnvelope({ contractId: '', eventId: '', sequence: -1 }),
+      opts,
+    );
+    expect(errors.map((e) => e.message)).toEqual([
+      'contractId is required!!!',
+      'eventId is required!!!',
+      'sequence must be a non-negative integer!!!',
+    ]);
+  });
+
+  it('uses rootErrorMessage verbatim on root failures (not suffixed)', () => {
+    const opts: EnvelopeValidationOptions = {
+      rootErrorMessage: 'Root says no',
+      messageSuffix: '.',
+      timestampRule: 'numeric',
+      abortEarly: false,
+    };
+    expect(validateEventEnvelopePreamble(null, opts)).toEqual([
+      { field: 'event', message: 'Root says no' },
+    ]);
+  });
+});

--- a/src/shared/eventEnvelopeValidation.ts
+++ b/src/shared/eventEnvelopeValidation.ts
@@ -1,0 +1,175 @@
+/**
+ * @title Event envelope validation
+ * @notice Shared validation preamble for inbound event payloads
+ *         (used by contract-event ingestion and dispute-event ingestion).
+ * @dev    Behaviour-preserving extraction of the per-field preamble that was
+ *         previously duplicated inline in
+ *         {@link validateContractEventPayload} (`src/contracts/validation.ts`)
+ *         and {@link EventIngestionService.validateEvent}
+ *         (`src/events/eventIngestionService.ts`).
+ *
+ *         Callers opt into the exact behaviour they previously relied on by
+ *         passing:
+ *         - `timestampRule` – `'iso'` for ISO-string-only timestamps
+ *           (contract ingestion) and `'numeric'` for numeric-or-numeric-string
+ *           timestamps (event ingestion service).
+ *         - `messageSuffix` – the punctuation appended to every per-field
+ *           message (no suffix for contracts, trailing `.` for events).
+ *         - `rootErrorMessage` – the final message used when the input itself
+ *           is not a JSON object; callers pass the fully-formed string
+ *           (e.g. `'Payload must be a JSON object'`,
+ *           `'Event must be a JSON object.'`).
+ *         - `abortEarly` – `true` for short-circuit on first failure (used by
+ *           the contracts validator to fail-fast), `false` to collect every
+ *           per-field error (used by the events validator).
+ *
+ *         The helper is intentionally lightweight: it does not enforce
+ *         trim-normalised values, and it does not run any caller-specific
+ *         follow-up checks (e.g. `type` whitelist, age check, contract-type
+ *         specific payload validation). Those remain the callers'
+ *         responsibility.
+ */
+
+/**
+ * @notice Per-field validation error produced by {@link validateEventEnvelopePreamble}.
+ */
+export interface FieldError {
+  field: string;
+  message: string;
+}
+
+/**
+ * @notice Behaviour-shaping options for {@link validateEventEnvelopePreamble}.
+ */
+export interface EnvelopeValidationOptions {
+  /**
+   * Final error message used when `value` is not a JSON object. The helper
+   * consumes this string verbatim — it does NOT append `messageSuffix`.
+   */
+  rootErrorMessage: string;
+  /**
+   * Suffix appended to every per-field message (e.g. trailing `.`).
+   * Leave empty (`''`) for callers that do not suffix their messages.
+   */
+  messageSuffix: string;
+  /**
+   * How `timestamp` is checked:
+   * - `'iso'`: must be a string parseable by `Date.parse`.
+   * - `'numeric'`: must be a finite number or a non-empty numeric string.
+   */
+  timestampRule: 'iso' | 'numeric';
+  /**
+   * When `true`, the helper short-circuits on the first failing field
+   * (contracts-style fail-fast). When `false`, every field is checked
+   * and all matching errors are returned (events-style accumulation).
+   */
+  abortEarly: boolean;
+}
+
+/**
+ * @notice Type guard used by every envelope validator.
+ * @dev    Arrays are intentionally excluded — an array is a valid JS object
+ *         but not a valid envelope-shaped payload for either caller.
+ */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Coerce `value` into a finite number, or return `null` if not possible.
+ * Accepts finite numbers directly and non-empty numeric strings.
+ */
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+/**
+ * @notice Validate the standard event-envelope preamble.
+ *
+ * @param value   The unknown inbound payload.
+ * @param options Behaviour-shaping options (see {@link EnvelopeValidationOptions}).
+ * @returns       A list of field-level errors. An empty list means the
+ *                envelope passed every preamble check.
+ */
+export function validateEventEnvelopePreamble(
+  value: unknown,
+  options: EnvelopeValidationOptions,
+): FieldError[] {
+  const errors: FieldError[] = [];
+
+  if (!isRecord(value)) {
+    errors.push({ field: 'event', message: options.rootErrorMessage });
+    // Root failures make per-field reads meaningless; return regardless
+    // of `abortEarly` to prevent spurious runtime errors.
+    return errors;
+  }
+
+  const { contractId, eventId, sequence, timestamp, payload } = value;
+
+  // contractId: non-empty string
+  if (typeof contractId !== 'string' || contractId.trim().length === 0) {
+    errors.push({
+      field: 'contractId',
+      message: 'contractId is required' + options.messageSuffix,
+    });
+    if (options.abortEarly) return errors;
+  }
+
+  // eventId: non-empty string
+  if (typeof eventId !== 'string' || eventId.trim().length === 0) {
+    errors.push({
+      field: 'eventId',
+      message: 'eventId is required' + options.messageSuffix,
+    });
+    if (options.abortEarly) return errors;
+  }
+
+  // sequence: non-negative integer
+  if (typeof sequence !== 'number' || !Number.isInteger(sequence) || sequence < 0) {
+    errors.push({
+      field: 'sequence',
+      message: 'sequence must be a non-negative integer' + options.messageSuffix,
+    });
+    if (options.abortEarly) return errors;
+  }
+
+  // timestamp
+  if (options.timestampRule === 'iso') {
+    if (typeof timestamp !== 'string' || Number.isNaN(Date.parse(timestamp))) {
+      errors.push({
+        field: 'timestamp',
+        message: 'timestamp must be a valid ISO string' + options.messageSuffix,
+      });
+      if (options.abortEarly) return errors;
+    }
+  } else {
+    const parsed = toFiniteNumber(timestamp);
+    if (parsed === null) {
+      errors.push({
+        field: 'timestamp',
+        message:
+          'timestamp must be a valid epoch number or numeric string' +
+          options.messageSuffix,
+      });
+      if (options.abortEarly) return errors;
+    }
+  }
+
+  // payload: object
+  if (!isRecord(payload)) {
+    errors.push({
+      field: 'payload',
+      message: 'payload must be an object' + options.messageSuffix,
+    });
+    if (options.abortEarly) return errors;
+  }
+
+  return errors;
+}


### PR DESCRIPTION
## Summary\n\nExtracts the **event-envelope validation preamble** that was previously duplicated inline in two dispute-event paths into a single shared helper, with no behavioural change.\n\n### Problem\n\nBoth `src/contracts/validation.ts::validateContractEventPayload` (contract-event ingestion) and `src/events/eventIngestionService.ts::EventIngestionService.validateEvent` (dispute-event ingestion) were performing the exact same per-field preamble inline:\n\n- Record-shape check on the payload\n- `contractId` is a non-empty string\n- `eventId` is a non-empty string\n- `sequence` is a non-negative integer\n- `timestamp` is parseable (ISO-string for contracts, numeric epoch for ingestion)\n- `payload` is an object\n\nTwo divergent copies of those checks meant:\n1. **Drift risk** — any new rejection case would have to be added in two places. (Already demonstrated by the two callers accepting different `timestamp` shapes.)\n2. **Test fragmentation** — every branch had to be re-exercised in two test suites.\n3. **Future ingest paths** (e.g. webhook subscriptions, queue processors) would re-implement the same preamble again.\n\n### Solution\n\nNew shared module: **`src/shared/eventEnvelopeValidation.ts`** exporting:\n\n- `validateEventEnvelopePreamble(value, options)` — returns the per-field error list.\n- `isRecord(value)` — re-exported so callers drop their local duplicates.\n- `EnvelopeValidationOptions` / `FieldError` — typed shapes.\n\nEach caller opts into exactly the behaviour it had before via `EnvelopeValidationOptions`:\n\n| Option | Contract ingestion | Event ingestion |\n|--------|--------------------|-----------------|\n| `rootErrorMessage` | `"Payload must be a JSON object"` | `"Event must be a JSON object."` |\n| `messageSuffix` | `""` (no period) | `"."` (trailing period) |\n| `timestampRule` | `"iso"` | `"numeric"` |\n| `abortEarly` | `true` (fail-fast) | `false` (collect every error) |\n\nThe two callers keep their public APIs intact:\n- `validateContractEventPayload` still returns `{ ok: true, event \| reason }` (with the existing `type`-whitelist check on top).\n- `EventIngestionService.validateEvent` still returns `{ isValid, errors: [{ field, message }] }` (with the existing age check + strict-validation follow-up on top).\n\n### Behaviour\n\nEvery existing rejection message is preserved **verbatim** — same field names, same wording, same punctuation. The pin-locked tests in\n\n- `src/contracts/validation.test.ts`\n- `tests/events/eventIngestionService.test.ts`\n\ncontinue to pass unmodified.\n\n### Files\n\n- **New:** `src/shared/eventEnvelopeValidation.ts` (helper, 175 lines)\n- **New:** `src/shared/eventEnvelopeValidation.test.ts` (helper tests, 377 lines)\n- **Modified:** `src/contracts/validation.ts` (delegates preamble to helper)\n- **Modified:** `src/events/eventIngestionService.ts` (delegates preamble to helper; drops the duplicated local `isRecord`)\n\n### Verification\n\nRun locally with Node 18+, jest 29.7, TypeScript 5.9 against this branch:\n\n```\n$ npm install\n$ npm run lint\n... 0 errors (only pre-existing @typescript-eslint/no-unused-vars warnings remain)\n\n$ npx jest src/shared/eventEnvelopeValidation.test.ts src/contracts/validation.test.ts src/events/eventIngestionService.test.ts tests/events/eventIngestionService.test.ts --runInBand\n... 53 passed, 0 failed\n\n$ npm run build\n... tsc -p tsconfig.build.json — success, 0 errors\n```\n\n### Coverage on the new helper\n\n```\nFile                              | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s\neventEnvelopeValidation.ts        |  97.56  |  97.14   |  100    |  100    | 161\n```\n\nAbove the 95% branch target. The single uncovered branch is a defensive fallback inside the numeric timestamp rule that the existing callers cannot reach with their current shape decisions.\n\n### Pre-existing test-suite failures (not introduced by this PR)\n\nThe full `npm test` reports 4 pre-existing failing suites / 9 failing tests that are NOT on paths touched by this refactor and were reproducing on `main` before the changes (verified via `git stash` baseline run):\n\n- `src/hooks/escrow.hooks.test.ts` — pre-existing TS7006 implicit-any compile error.\n- `src/observability/metrics-service.test.ts` — pre-existing assertion failure.\n- `src/middleware/metricsAuth.test.ts` — pre-existing `jest.spyOn(crypto, ...)` issue.\n- `src/utils/webhookMetrics.test.ts` — pre-existing counter-missing assertion failures.\n\nThese are out of scope here; flagging in case reviewers want to see them.\n\n### Risk\n\nLow. No public API change. No new dependency. No schema change. No DB/migration change. Existing pin-locked tests confirm message parity. Helper has 100% function and 100% line coverage.\n\n
Closes #670