### PR TITLE
test(reputation): add concurrency smoke tests

### DIFF
--- a/src/services/reputation.concurrency.test.ts
+++ b/src/services/reputation.concurrency.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Reputation Service — Concurrency Smoke Tests
+ *
+ * Issue #864: the reputation write path was never exercised under
+ * concurrent dispatch, which could hide a lost-update or duplicate-write
+ * bug in ReputationService.createRating's check-then-act duplicate guard
+ * (find existing entry, then insert).
+ *
+ * IMPORTANT SCOPE NOTE: the HTTP endpoint wired to `PUT /api/v1/reputation/:id`
+ * (ReputationController.createRating) does not actually call
+ * `ReputationService.createRating` — it calls the non-existent
+ * `(ReputationService as any).updateProfile`, which is always undefined, so it
+ * silently falls through to `ReputationService.getProfile` and never persists
+ * anything (see reputation.controller.ts:73-75, and reputation.controller.test.ts
+ * which asserts exactly this behaviour). That is a pre-existing functional bug,
+ * not a concurrency bug, and is out of scope for this issue — fixing it would
+ * change response contracts covered by other tests. These tests instead target
+ * `ReputationService.createRating` / `ReputationRepository` directly: the real,
+ * fully-implemented write path (already unit-tested for anti-abuse guards in
+ * reputation.service.test.ts, but never under concurrent dispatch).
+ *
+ * All calls here go through a real in-memory SQLite database (no mocked
+ * repository), are bounded to a fixed, small N, and touch no network or
+ * timers, so the suite is deterministic.
+ */
+
+import { ReputationService } from './reputation.service';
+import { getDb } from '../db/database';
+import Database from '../db/betterSqlite3';
+import { ConflictError } from '../errors/appError';
+
+jest.mock('../audit/service', () => ({
+  auditService: {
+    log: jest.fn(),
+  },
+}));
+
+const TARGET_ID = 'concurrency-target';
+const CONCURRENCY_N = 20;
+
+function insertContract(
+  db: ReturnType<typeof Database>,
+  id: string,
+  clientId: string,
+  freelancerId: string,
+): void {
+  db.prepare(
+    `INSERT OR IGNORE INTO contracts
+       (id, title, client_id, freelancer_id, amount, status, version, created_at)
+     VALUES (?, ?, ?, ?, 1000, 'completed', 0, datetime('now'))`,
+  ).run(id, `Contract ${id}`, clientId, freelancerId);
+}
+
+function insertUser(db: ReturnType<typeof Database>, id: string): void {
+  db.prepare(
+    `INSERT OR IGNORE INTO users (id, username, email, role, created_at)
+     VALUES (?, ?, ?, 'client', datetime('now'))`,
+  ).run(id, id, `${id}@test.com`);
+}
+
+function reputationRowCount(db: ReturnType<typeof Database>, targetId: string): number {
+  const row = db
+    .prepare<[string], { c: number }>(
+      'SELECT COUNT(*) AS c FROM reputation_entries WHERE target_id = ?',
+    )
+    .get(targetId);
+  return row?.c ?? 0;
+}
+
+/**
+ * Dispatches `fn` on a fresh microtask so concurrent calls are queued
+ * together via Promise.all rather than run one at a time by the caller —
+ * the closest approximation of "concurrent requests" available for a
+ * synchronous (better-sqlite3) write path in a single Node process.
+ */
+function deferred<T>(fn: () => T): Promise<T> {
+  return Promise.resolve().then(fn);
+}
+
+describe('ReputationService.createRating — concurrency smoke tests', () => {
+  let db: ReturnType<typeof Database>;
+
+  beforeAll(() => {
+    db = getDb(':memory:');
+    ReputationService.initialize(db);
+    insertUser(db, TARGET_ID);
+  });
+
+  it('accepts N concurrent ratings from distinct reviewers with no lost updates', async () => {
+    const reviewerIds = Array.from({ length: CONCURRENCY_N }, (_, i) => `reviewer-${i}`);
+    reviewerIds.forEach((reviewerId, i) => {
+      insertUser(db, reviewerId);
+      insertContract(db, `contract-distinct-${i}`, reviewerId, TARGET_ID);
+    });
+
+    const results = await Promise.all(
+      reviewerIds.map((reviewerId, i) =>
+        deferred(() =>
+          ReputationService.createRating(reviewerId, TARGET_ID, (i % 5) + 1, `contract-distinct-${i}`),
+        ),
+      ),
+    );
+
+    // No lost updates: every one of the N concurrent writes actually persisted.
+    expect(results).toHaveLength(CONCURRENCY_N);
+    expect(reputationRowCount(db, TARGET_ID)).toBe(CONCURRENCY_N);
+
+    // Read-after-write consistency: the profile reflects the full batch
+    // immediately, with no dropped or duplicated entries.
+    const profile = ReputationService.getProfile(TARGET_ID);
+    expect(profile.totalRatings).toBe(CONCURRENCY_N);
+    expect(profile.reviews).toHaveLength(CONCURRENCY_N);
+    const uniqueReviewers = new Set(profile.reviews.map((r) => r.reviewerId));
+    expect(uniqueReviewers.size).toBe(CONCURRENCY_N);
+  });
+
+  it('resolves concurrent duplicate ratings (same reviewer/target/context) to exactly one persisted entry', async () => {
+    const reviewerId = 'dup-reviewer';
+    const contextId = 'contract-duplicate';
+    insertUser(db, reviewerId);
+    insertContract(db, contextId, reviewerId, TARGET_ID);
+
+    const attempts = 10;
+    const outcomes = await Promise.allSettled(
+      Array.from({ length: attempts }, () =>
+        deferred(() => ReputationService.createRating(reviewerId, TARGET_ID, 5, contextId)),
+      ),
+    );
+
+    const fulfilled = outcomes.filter((o) => o.status === 'fulfilled');
+    const rejected = outcomes.filter(
+      (o): o is PromiseRejectedResult => o.status === 'rejected',
+    );
+
+    // Exactly one writer wins; every other concurrent attempt is rejected —
+    // never silently dropped, never double-written.
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(attempts - 1);
+    for (const r of rejected) {
+      expect(r.reason).toBeInstanceOf(ConflictError);
+    }
+
+    // The DB agrees: no duplicate row was ever created for this composite key.
+    const row = db
+      .prepare<[string, string, string], { c: number }>(
+        'SELECT COUNT(*) AS c FROM reputation_entries WHERE reviewer_id = ? AND target_id = ? AND context_id = ?',
+      )
+      .get(reviewerId, TARGET_ID, contextId);
+    expect(row?.c).toBe(1);
+  });
+
+  it('is bounded and deterministic: fixed N, no timers, no network, same result on repeat', async () => {
+    const isolatedTarget = 'concurrency-target-repeat';
+    insertUser(db, isolatedTarget);
+
+    async function runBatch(contractPrefix: string): Promise<number> {
+      const reviewerIds = Array.from({ length: 5 }, (_, i) => `${contractPrefix}-reviewer-${i}`);
+      reviewerIds.forEach((reviewerId, i) => {
+        insertUser(db, reviewerId);
+        insertContract(db, `${contractPrefix}-contract-${i}`, reviewerId, isolatedTarget);
+      });
+      await Promise.all(
+        reviewerIds.map((reviewerId, i) =>
+          deferred(() =>
+            ReputationService.createRating(
+              reviewerId,
+              isolatedTarget,
+              3,
+              `${contractPrefix}-contract-${i}`,
+            ),
+          ),
+        ),
+      );
+      return reputationRowCount(db, isolatedTarget);
+    }
+
+    const first = await runBatch('batch-a');
+    expect(first).toBe(5);
+
+    const second = await runBatch('batch-b');
+    expect(second).toBe(10);
+  });
+});


### PR DESCRIPTION
Closes #864.

## Important scope note — read first
The HTTP endpoint actually wired to `PUT /api/v1/reputation/:id` (`ReputationController.createRating`) does **not** call `ReputationService.createRating`. It calls `(ReputationService as any).updateProfile`, which does not exist anywhere in the codebase (`grep -rn updateProfile src` only matches the controller itself), so the ternary always falls through to `ReputationService.getProfile(id)` and the endpoint never persists a rating — it just echoes back the current profile. `reputation.controller.test.ts` currently locks this behavior in by mocking `getProfile` and asserting the controller returns whatever it returns.

That's a real, pre-existing functional bug, but it's a wiring/business-logic bug, not a concurrency bug, and fixing it would change response contracts other tests depend on — out of scope here per the issue's "Repository scope" note. I'd suggest filing it separately. Given the wired HTTP endpoint doesn't write anything, I scoped these concurrency tests to the actual, fully-implemented write path it *should* be calling: `ReputationService.createRating` → `ReputationRepository` (real in-memory SQLite, no mocks), which already has its own guard-coverage unit tests (`reputation.service.test.ts`) but had never been exercised under concurrent dispatch.

## What's added
`src/services/reputation.concurrency.test.ts` — three deterministic, bounded tests (fixed N, no timers, no network):
1. N concurrent ratings from distinct reviewers → no lost updates, all N persist, read-after-write profile aggregation is exact.
2. Concurrent duplicate ratings (same reviewer/target/context) → exactly one write wins, every other concurrent attempt rejects with `ConflictError`, DB confirms no duplicate row.
3. Bounded/repeatable batch check for determinism.

## On "fix any race surfaced"
No race was found, and the test file's header explains why: `better-sqlite3` is fully synchronous and `createRating` has no `await` points, so under Node's single-threaded event loop, calls dispatched concurrently via `Promise.all` still fully serialize at the microtask queue — whichever call starts first runs to completion before the next begins. In this topology, the application-level check-then-insert duplicate guard is what actually prevents duplicates; the DB's `UNIQUE(reviewer_id, target_id, context_id)` constraint is defense-in-depth for a future async/pooled driver or multi-process deployment, and isn't reachable from these tests. I'm noting this rather than inventing a fix for a race that doesn't reproduce here.

## Testing
- `npx jest src/services/reputation.concurrency.test.ts` — **3/3 passed**.
- `npm test` (full suite) — **13 suites / 61 tests failing, all pre-existing and unrelated** (rate limiting, contracts DTO validation, secrets redaction, webhook metrics, `app.test.ts` body parsing). Every reputation-related suite passes, including the new one. None of the 13 failing suites touch reputation.
- `npm run lint` — pre-existing errors in `src/routes/health.ts` and `src/utils/webhookMetrics.test.ts` (parsing errors, unrelated files I didn't touch); no new warnings/errors from my file (`grep`-confirmed).
- `npm run build` — **fails** on `src/routes/health.ts:95` (`error TS1005: '}' expected`). Confirmed pre-existing on `main` (`git diff main -- src/routes/health.ts` is empty; the file has a syntax error already, breaking the whole-program `tsc` build for anyone on `main` right now). Not something I touched or can respons8ibly fix as part of a concurrency-tests PR — flagging clearly rather than silently working around it.

Full output for all four commands available on request; trimmed here since the interesting parts are excerpted above and the rest is unrelated pre-existing noise.