### PR TITLE
feat(reputation): add mutation audit log

### DIFF
--- a/src/services/reputation.audit.test.ts
+++ b/src/services/reputation.audit.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Reputation Service — Audit Trail Tests
+ *
+ * Issue #863: reputation mutations must leave an audit trail (actor, action,
+ * before/after summary, timestamp) with a read view, bounded storage, and
+ * secret redaction.
+ *
+ * Most of this already existed generically before this change: TalentTrust
+ * has a mature, hash-chained, append-only audit subsystem (src/audit/*)
+ * mounted at `/audit` (`GET /audit`, `GET /audit/:id`, cursor pagination
+ * bounded to 1-100 entries/page — see sqliteRepository.ts / store.ts), and
+ * `ReputationService.createRating` already called into it. What was missing:
+ *   1. An explicit before/after summary in the audit metadata (this PR adds
+ *      `metadata.before.totalRatings` / `metadata.after.totalRatings`, see
+ *      reputation.service.ts).
+ *   2. Test coverage proving the reputation audit trail actually works
+ *      end-to-end: entry shape, read-view retrieval, redaction, hash-chain
+ *      integrity, and that rejected (guard-failed) attempts do NOT produce
+ *      an entry — this suite.
+ *
+ * SCOPE NOTE on "cover create/update/delete audit entries": reputation
+ * ratings are immutable by design — `ReputationRepository` has no update or
+ * delete method for entries (append-only + a DB `UNIQUE(reviewer_id,
+ * target_id, context_id)` constraint is exactly what prevents a reviewer
+ * from overwriting or removing a past rating, which is the anti-abuse
+ * property `createRating`'s guards exist to protect). There is no
+ * update/delete reputation mutation anywhere in this codebase, so there is
+ * nothing to audit there. Inventing one to satisfy a generic issue template
+ * would weaken, not strengthen, the reputation system's integrity. This
+ * suite instead covers every mutation that actually exists: successful
+ * create, and rejected create attempts (which correctly produce no entry).
+ *
+ * This test does NOT mock `../audit/service` — unlike reputation.service.test.ts
+ * — because the whole point is to exercise the real audit store.
+ */
+
+import { ReputationService } from './reputation.service';
+import { auditService } from '../audit/service';
+import { auditStore } from '../audit/store';
+import { getDb } from '../db/database';
+import Database from '../db/betterSqlite3';
+import { createHash } from 'crypto';
+
+function insertUser(db: ReturnType<typeof Database>, id: string): void {
+  db.prepare(
+    `INSERT OR IGNORE INTO users (id, username, email, role, created_at)
+     VALUES (?, ?, ?, 'client', datetime('now'))`,
+  ).run(id, id, `${id}@test.com`);
+}
+
+function insertContract(
+  db: ReturnType<typeof Database>,
+  id: string,
+  clientId: string,
+  freelancerId: string,
+): void {
+  db.prepare(
+    `INSERT OR IGNORE INTO contracts
+       (id, title, client_id, freelancer_id, amount, status, version, created_at)
+     VALUES (?, ?, ?, ?, 1000, 'completed', 0, datetime('now'))`,
+  ).run(id, `Contract ${id}`, clientId, freelancerId);
+}
+
+describe('ReputationService.createRating — audit trail', () => {
+  let db: ReturnType<typeof Database>;
+  let scenarioCounter = 0;
+
+  beforeAll(() => {
+    db = getDb(':memory:');
+    ReputationService.initialize(db);
+  });
+
+  beforeEach(() => {
+    auditStore._reset();
+  });
+
+  /**
+   * Builds a fully isolated target/reviewer/contract set for a single test,
+   * so tests never interfere with each other's rating counts or duplicate
+   * guards regardless of execution order.
+   */
+  function freshScenario() {
+    const n = ++scenarioCounter;
+    const targetId = `audit-target-${n}`;
+    const reviewerA = `audit-reviewer-a-${n}`;
+    const reviewerB = `audit-reviewer-b-${n}`;
+    const contextA = `audit-contract-a-${n}`;
+    const contextB = `audit-contract-b-${n}`;
+
+    insertUser(db, targetId);
+    insertUser(db, reviewerA);
+    insertUser(db, reviewerB);
+    insertContract(db, contextA, reviewerA, targetId);
+    insertContract(db, contextB, reviewerB, targetId);
+
+    return { targetId, reviewerA, reviewerB, contextA, contextB };
+  }
+
+  it('creates exactly one audit entry with actor, action, resource, resourceId, and timestamp', () => {
+    const { targetId, reviewerA, contextA } = freshScenario();
+
+    const beforeTs = new Date().toISOString();
+    ReputationService.createRating(reviewerA, targetId, 5, contextA, 'Great work');
+    const afterTs = new Date().toISOString();
+
+    const entries = auditService.query({ resource: 'reputation', resourceId: targetId });
+    expect(entries).toHaveLength(1);
+
+    const entry = entries[0];
+    expect(entry.action).toBe('REPUTATION_UPDATED');
+    expect(entry.actor).toBe(reviewerA);
+    expect(entry.resource).toBe('reputation');
+    expect(entry.resourceId).toBe(targetId);
+    expect(entry.timestamp >= beforeTs && entry.timestamp <= afterTs).toBe(true);
+  });
+
+  it('records a before/after summary of the target rating count for each mutation', () => {
+    const { targetId, reviewerA, reviewerB, contextA, contextB } = freshScenario();
+
+    ReputationService.createRating(reviewerA, targetId, 4, contextA);
+    ReputationService.createRating(reviewerB, targetId, 2, contextB);
+
+    const entries = auditService.query({ resource: 'reputation', resourceId: targetId });
+    expect(entries).toHaveLength(2);
+
+    expect(entries[0].metadata.before).toEqual({ totalRatings: 0 });
+    expect(entries[0].metadata.after).toMatchObject({ totalRatings: 1, rating: 4 });
+
+    expect(entries[1].metadata.before).toEqual({ totalRatings: 1 });
+    expect(entries[1].metadata.after).toMatchObject({ totalRatings: 2, rating: 2 });
+  });
+
+  it('is retrievable through the audit read view by resource+resourceId, and by id', () => {
+    const { targetId, reviewerA, contextA } = freshScenario();
+    const created = ReputationService.createRating(reviewerA, targetId, 3, contextA);
+
+    const viaQuery = auditService.query({ resource: 'reputation', resourceId: targetId });
+    expect(viaQuery).toHaveLength(1);
+    const entryId = viaQuery[0].id;
+
+    const viaGetById = auditService.getById(entryId);
+    expect(viaGetById).toBeDefined();
+    expect(viaGetById?.resourceId).toBe(targetId);
+
+    const viaCursor = auditService.queryWithCursor({ resource: 'reputation', resourceId: targetId });
+    expect(viaCursor.entries).toHaveLength(1);
+    expect(viaCursor.entries[0].id).toBe(entryId);
+
+    // entryId round-trips through the audit metadata too, linking the
+    // reputation row back to its audit entry for incident review.
+    expect((viaGetById?.metadata as { entryId: string }).entryId).toBe(created.id);
+  });
+
+  it('never stores the raw comment text in the audit log — only its SHA-256 hash', () => {
+    const { targetId, reviewerA, contextA } = freshScenario();
+    const secretLookingComment = 'Contact me at attacker@example.com, password: hunter2';
+    ReputationService.createRating(reviewerA, targetId, 5, contextA, secretLookingComment);
+
+    const [entry] = auditService.query({ resource: 'reputation', resourceId: targetId });
+    const serialized = JSON.stringify(entry);
+
+    expect(serialized).not.toContain(secretLookingComment);
+    expect(serialized).not.toContain('attacker@example.com');
+    expect(serialized).not.toContain('hunter2');
+
+    const storedHash = (entry.metadata.after as { comment?: string }).comment;
+    expect(storedHash).toBe(createHash('sha256').update(secretLookingComment).digest('hex'));
+  });
+
+  it('does not create an audit entry when a guard rejects the mutation', () => {
+    const { targetId, contextA } = freshScenario();
+    // Self-rating is rejected by Guard 1 before any DB write happens.
+    expect(() => ReputationService.createRating(targetId, targetId, 5, contextA)).toThrow();
+
+    const entries = auditService.query({ resource: 'reputation', resourceId: targetId });
+    expect(entries).toHaveLength(0);
+  });
+
+  it('keeps the hash chain valid across multiple reputation writes', () => {
+    const { targetId, reviewerA, reviewerB, contextA, contextB } = freshScenario();
+    ReputationService.createRating(reviewerA, targetId, 4, contextA);
+    ReputationService.createRating(reviewerB, targetId, 5, contextB);
+
+    const report = auditService.verifyIntegrity();
+    expect(report.valid).toBe(true);
+    expect(report.totalEntries).toBe(2);
+  });
+
+  it('bounds a single query page to at most 100 entries via cursor pagination', () => {
+    const result = auditService.queryWithCursor({ resource: 'reputation', limit: 500 });
+    expect(result.limit).toBeLessThanOrEqual(100);
+  });
+});

--- a/src/services/reputation.service.ts
+++ b/src/services/reputation.service.ts
@@ -164,6 +164,12 @@ export class ReputationService {
     }
 
     /**
+     * Snapshot the target's rating count immediately before the write so the
+     * audit entry can carry a before/after summary for incident review.
+     */
+    const totalRatingsBefore = this.repository.findByTargetId(targetId).length;
+
+    /**
      * Guard 5 — Persist the reputation entry.
      * Runs only after all guards have passed.
      */
@@ -177,7 +183,9 @@ export class ReputationService {
 
     /**
      * Guard 6 — Mandatory audit log.
-     * Every successful write MUST produce an immutable audit entry.
+     * Every successful write MUST produce an immutable audit entry, carrying
+     * a before/after summary of the target's rating count so reviewers can
+     * see the effect of the mutation without re-deriving it from raw rows.
      * The comment is stored as a SHA-256 hash to avoid leaking PII into the
      * audit store; the plaintext is never logged.
      *
@@ -197,9 +205,16 @@ export class ReputationService {
         resource: 'reputation',
         resourceId: targetId,
         metadata: {
-          rating,
-          comment: comment ? this.hashComment(comment) : undefined,
+          entryId: entry.id,
           contextId,
+          before: {
+            totalRatings: totalRatingsBefore,
+          },
+          after: {
+            totalRatings: totalRatingsBefore + 1,
+            rating,
+            comment: comment ? this.hashComment(comment) : undefined,
+          },
         },
       });
     } catch (auditError) {


### PR DESCRIPTION
Closes #863.

## What already existed
TalentTrust already has a mature, hash-chained, append-only audit subsystem (`src/audit/*`): immutable entries with SHA-256 hash-chain integrity verification, a bounded/paginated read view mounted at `/audit` (`GET /audit`, `GET /audit/:id`, `GET /audit/export`, `GET /audit/integrity`, cursor pagination capped at 100 entries/page — `sqliteRepository.ts`/`store.ts`), and deterministic redaction rules (`audit/redact.ts`). `ReputationService.createRating` already called into it on every successful write (`REPUTATION_UPDATED`, actor = reviewer, resource = `reputation`, resourceId = target, comment stored as a SHA-256 hash rather than plaintext).

## What was actually missing
1. An explicit **before/after summary** in the metadata, as the issue asks for.
2. **Test coverage** proving the reputation audit trail works end-to-end — it had never been exercised by a test that doesn't mock `../audit/service`.

## What this PR adds
- `reputation.service.ts`: the audit entry written by `createRating` now includes `metadata.before.totalRatings` and `metadata.after.{totalRatings, rating, comment}`, captured via a `findByTargetId` snapshot immediately before the write.
- `reputation.audit.test.ts` (new, does **not** mock the audit service — exercises the real store):
  - Entry shape: actor, action (`REPUTATION_UPDATED`), resource, resourceId, timestamp.
  - Before/after summary is correct across two successive writes to the same target.
  - Retrieval through the read view three ways: `query()`, `getById()`, `queryWithCursor()`.
  - Comments are never stored in plaintext — only their SHA-256 hash (asserts the raw comment string is absent from the serialized entry).
  - A guard-rejected mutation (self-rating) produces **no** audit entry.
  - Hash-chain integrity (`verifyIntegrity()`) holds after multiple reputation writes.
  - Cursor pagination is bounded to ≤100 entries/page (existing repository behavior, asserted here for the reputation resource specifically).

## On "cover create/update/delete audit entries"
Reputation ratings are immutable by design: `ReputationRepository` has no update or delete method for entries anywhere in this codebase — the DB `UNIQUE(reviewer_id, target_id, context_id)` constraint plus `createRating`'s duplicate-rating guard are exactly what make the anti-abuse model work (a reviewer can't revise or retract a rating after the fact). There is no update/delete reputation mutation to audit, so I didn't invent one to satisfy a generic template line — doing so would weaken the anti-abuse property this system exists to protect. This is called out in the test file's header comment. The suite instead covers every mutation that actually exists: successful create, and rejected create attempts (which correctly produce no entry).

## Testing
- `npx jest reputation` — **10 suites / 177 tests passed**, including both new/changed files.
- `npm run lint` — no new warnings/errors from either touched file (pre-existing warnings in `reputation.service.test.ts` are unrelated and untouched).
- `npm test` (full suite) — **14 suites / 62 tests failing, all pre-existing and unrelated** (rate limiting, contracts DTO validation, secrets redaction, webhook metrics, `app.test.ts` body parsing). One of those (`audit/router.rateLimit.test.ts`) only fails under full-suite CPU contention — it passes 10/10 in isolation (`npx jest src/audit/router.rateLimit.test.ts`), consistent with that suite's known timing sensitivity; not related to this change. Every reputation suite passes.
- `npm run build` — fails on `src/routes/health.ts:95` (`error TS1005: '}' expected`), confirmed pre-existing on `main` (`git diff main -- src/routes/health.ts` is empty) and unrelated to this change — same as noted in #864's PR (#957).