### PR TITLE
feat(observability): add metrics service and instrumentation for API keys

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -92,6 +92,7 @@ export function createApp(options?: AppFactoryOptions): express.Application {
   app.use('/api/config', configRouter);
   app.use('/api/v1', eventsRouter);
   app.use('/api/v1/auth', authRouter);
+  app.use('/api/v1/api-keys', metricsService.trackApiKeysRequest.bind(metricsService));
   app.use('/api/v1', apiKeysRouter);
   app.use('/api/v1/contracts', contractsModuleRouter);
   app.use('/api/v1/disputes', disputesRouter);

--- a/src/observability/api-keys-observability.test.ts
+++ b/src/observability/api-keys-observability.test.ts
@@ -1,0 +1,164 @@
+import { EventEmitter } from "events";
+import { NextFunction, Request, Response } from "express";
+import { Registry } from "prom-client";
+
+import { MetricsService } from "./metrics-service";
+
+function record(
+  service: MetricsService,
+  method: string,
+  routePath: string,
+  statusCode: number,
+) {
+  const response = new EventEmitter() as Response & EventEmitter;
+  response.statusCode = statusCode;
+  response.locals = {
+    log: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+  };
+  const request = {
+    method,
+    route: { path: routePath },
+  } as unknown as Request;
+  const next = jest.fn() as NextFunction;
+
+  service.trackApiKeysRequest(request, response, next);
+  expect(next).toHaveBeenCalledTimes(1);
+  response.emit("finish");
+
+  return response.locals["log"] as {
+    info: jest.Mock;
+    warn: jest.Mock;
+    error: jest.Mock;
+  };
+}
+
+describe("API keys observability", () => {
+  it("records success duration and status and emits a structured info log", async () => {
+    const registry = new Registry();
+    const service = new MetricsService("test", registry);
+    const log = record(service, "POST", "/api-keys", 201);
+    const metrics = await registry.getMetricsAsJSON();
+
+    expect(
+      metrics.find((metric) => metric.name === "api_keys_requests_total")
+        ?.values,
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          labels: { operation: "create", status_code: "201" },
+          value: 1,
+        }),
+      ]),
+    );
+    expect(
+      metrics.find(
+        (metric) => metric.name === "api_keys_request_duration_seconds",
+      )?.values,
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          labels: expect.objectContaining({
+            operation: "create",
+            status_code: "201",
+          }),
+        }),
+      ]),
+    );
+    expect(
+      metrics.find((metric) => metric.name === "api_keys_errors_total")?.values,
+    ).toHaveLength(0);
+    expect(log.info).toHaveBeenCalledWith(
+      "api_keys_request",
+      expect.objectContaining({
+        method: "POST",
+        route: "/api/v1/api-keys",
+        operation: "create",
+        statusCode: 201,
+        outcome: "success",
+        durationMs: expect.any(Number),
+      }),
+    );
+    expect(log.warn).not.toHaveBeenCalled();
+    expect(log.error).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [400, "validation_error"],
+    [401, "authentication_error"],
+    [403, "authorization_error"],
+    [404, "not_found"],
+    [429, "client_error"],
+  ])(
+    "records client status %i with bounded cause %s",
+    async (statusCode, cause) => {
+      const registry = new Registry();
+      const service = new MetricsService("test", registry);
+      const log = record(service, "GET", "/api-keys/:id", statusCode);
+      const metrics = await registry.getMetricsAsJSON();
+
+      expect(
+        metrics.find((metric) => metric.name === "api_keys_errors_total")
+          ?.values,
+      ).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            labels: { operation: "get", cause },
+            value: 1,
+          }),
+        ]),
+      );
+      expect(log.warn).toHaveBeenCalledWith(
+        "api_keys_request",
+        expect.objectContaining({
+          route: "/api/v1/api-keys/:id",
+          statusCode,
+          errorCause: cause,
+          outcome: "error",
+        }),
+      );
+    },
+  );
+
+  it("records server errors on the existing registry and logs at error level", async () => {
+    const registry = new Registry();
+    const service = new MetricsService("test", registry);
+    const log = record(service, "POST", "/api-keys/:id/rotate", 500);
+
+    expect(await service.getMetrics()).toContain(
+      'api_keys_errors_total{operation="rotate",cause="server_error"} 1',
+    );
+    expect(log.error).toHaveBeenCalledWith(
+      "api_keys_request",
+      expect.objectContaining({
+        operation: "rotate",
+        statusCode: 500,
+        errorCause: "server_error",
+      }),
+    );
+  });
+
+  it.each([
+    ["GET", "/api-keys", "list"],
+    ["DELETE", "/api-keys/:id", "deactivate"],
+    ["PATCH", "/api-keys/:id", "unknown"],
+  ])(
+    "uses a static operation label for %s %s",
+    async (method, routePath, operation) => {
+      const registry = new Registry();
+      const service = new MetricsService("test", registry);
+      record(service, method, routePath, 200);
+      const metrics = await registry.getMetricsAsJSON();
+
+      expect(
+        metrics.find((metric) => metric.name === "api_keys_requests_total")
+          ?.values,
+      ).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            labels: { operation, status_code: "200" },
+          }),
+        ]),
+      );
+    },
+  );
+});

--- a/src/observability/metrics-service.ts
+++ b/src/observability/metrics-service.ts
@@ -15,6 +15,7 @@ import {
   WebhookOutcome as ValidatedWebhookOutcome,
 } from './metrics-validation';
 import { DEFAULT_HISTOGRAM_BUCKETS, validateHistogramBuckets } from './observability-config';
+import { Logger, logger as rootLogger } from '../logger';
 
 /**
  * Re-exported from metrics-validation to preserve existing import paths.
@@ -31,6 +32,9 @@ export type WebhookOutcome = ValidatedWebhookOutcome;
 export const CATALOG_METRIC_NAMES: readonly string[] = [
   'http_requests_total',
   'http_request_duration_seconds',
+  'api_keys_requests_total',
+  'api_keys_request_duration_seconds',
+  'api_keys_errors_total',
   'service_health_status',
   'webhook_deliveries_total',
   'webhook_dlq_depth',
@@ -41,6 +45,7 @@ export const CATALOG_METRIC_NAMES: readonly string[] = [
 export interface MetricsServiceLike {
   contentType: string;
   trackHttpRequest: (req: Request, res: Response, next: NextFunction) => void;
+  trackApiKeysRequest: (req: Request, res: Response, next: NextFunction) => void;
   getMetrics: () => Promise<string>;
   recordHealthStatus: (status: ServiceStatus) => void;
   recordWebhookDelivery: (outcome: WebhookOutcome) => void;
@@ -81,6 +86,12 @@ export class MetricsService implements MetricsServiceLike {
   private readonly httpRequestsTotal: Counter;
 
   private readonly httpRequestDurationSeconds: Histogram;
+
+  private readonly apiKeysRequestsTotal: Counter;
+
+  private readonly apiKeysRequestDurationSeconds: Histogram;
+
+  private readonly apiKeysErrorsTotal: Counter;
 
   private readonly serviceHealthStatus: Gauge;
 
@@ -127,6 +138,28 @@ export class MetricsService implements MetricsServiceLike {
       help: 'Duration of HTTP requests in seconds.',
       labelNames: ['method', 'route', 'status_code'],
       buckets: resolvedBuckets,
+      registers: [this.register],
+    });
+
+    this.apiKeysRequestsTotal = new Counter({
+      name: 'api_keys_requests_total',
+      help: 'Total number of API key management requests.',
+      labelNames: ['operation', 'status_code'],
+      registers: [this.register],
+    });
+
+    this.apiKeysRequestDurationSeconds = new Histogram({
+      name: 'api_keys_request_duration_seconds',
+      help: 'Duration of API key management requests in seconds.',
+      labelNames: ['operation', 'status_code'],
+      buckets: resolvedBuckets,
+      registers: [this.register],
+    });
+
+    this.apiKeysErrorsTotal = new Counter({
+      name: 'api_keys_errors_total',
+      help: 'Total number of API key management request errors by cause.',
+      labelNames: ['operation', 'cause'],
       registers: [this.register],
     });
 
@@ -182,6 +215,45 @@ export class MetricsService implements MetricsServiceLike {
 
       this.httpRequestsTotal.inc(labels);
       this.httpRequestDurationSeconds.observe(labels, duration);
+    });
+
+    next();
+  }
+
+  trackApiKeysRequest(req: Request, res: Response, next: NextFunction): void {
+    const start = process.hrtime.bigint();
+
+    res.on('finish', () => {
+      const durationSeconds = Number(process.hrtime.bigint() - start) / 1_000_000_000;
+      const statusCode = res.statusCode;
+      const operation = apiKeysOperation(req.method, req.route?.path);
+      const labels = { operation, status_code: String(statusCode) };
+      const errorCause = apiKeysErrorCause(statusCode);
+
+      this.apiKeysRequestsTotal.inc(labels);
+      this.apiKeysRequestDurationSeconds.observe(labels, durationSeconds);
+      if (errorCause !== null) {
+        this.apiKeysErrorsTotal.inc({ operation, cause: errorCause });
+      }
+
+      const log = (res.locals['log'] as Logger | undefined) ?? rootLogger;
+      const logFields = {
+        method: req.method,
+        route: apiKeysRouteTemplate(req.route?.path),
+        operation,
+        statusCode,
+        durationMs: Number((durationSeconds * 1000).toFixed(3)),
+        outcome: statusCode < 400 ? 'success' : 'error',
+        ...(errorCause !== null && { errorCause }),
+      };
+
+      if (statusCode >= 500) {
+        log.error('api_keys_request', logFields);
+      } else if (statusCode >= 400) {
+        log.warn('api_keys_request', logFields);
+      } else {
+        log.info('api_keys_request', logFields);
+      }
     });
 
     next();
@@ -252,6 +324,38 @@ export class MetricsService implements MetricsServiceLike {
 
     return OTHER_ROUTE_LABEL;
   }
+}
+
+type ApiKeysErrorCause =
+  | 'validation_error'
+  | 'authentication_error'
+  | 'authorization_error'
+  | 'not_found'
+  | 'client_error'
+  | 'server_error';
+
+function apiKeysErrorCause(statusCode: number): ApiKeysErrorCause | null {
+  if (statusCode < 400) return null;
+  if (statusCode === 400 || statusCode === 422) return 'validation_error';
+  if (statusCode === 401) return 'authentication_error';
+  if (statusCode === 403) return 'authorization_error';
+  if (statusCode === 404) return 'not_found';
+  if (statusCode < 500) return 'client_error';
+  return 'server_error';
+}
+
+function apiKeysOperation(method: string, routePath: unknown): string {
+  const route = typeof routePath === 'string' ? routePath : '';
+  if (method === 'POST' && route === '/api-keys') return 'create';
+  if (method === 'GET' && route === '/api-keys') return 'list';
+  if (method === 'GET' && route === '/api-keys/:id') return 'get';
+  if (method === 'POST' && route === '/api-keys/:id/rotate') return 'rotate';
+  if (method === 'DELETE' && route === '/api-keys/:id') return 'deactivate';
+  return 'unknown';
+}
+
+function apiKeysRouteTemplate(routePath: unknown): string {
+  return typeof routePath === 'string' ? `/api/v1${routePath}` : '/api/v1/api-keys';
 }
 
 /**

--- a/src/routes/metrics.routes.test.ts
+++ b/src/routes/metrics.routes.test.ts
@@ -40,6 +40,7 @@ function buildMockService(overrides?: Partial<MetricsServiceLike>): jest.Mocked<
   return {
     contentType: 'text/plain',
     trackHttpRequest: jest.fn(),
+    trackApiKeysRequest: jest.fn(),
     getMetrics: jest.fn().mockResolvedValue(''),
     recordHealthStatus: jest.fn(),
     recordWebhookDelivery: jest.fn(),


### PR DESCRIPTION
Closes #763

## Problem
API key operations had no observability — no metrics tracking usage, 
errors, or performance for this part of the system.

## Changes
- src/observability/metrics-service.ts — new metrics service for 
  API-key observability.
- src/app.ts — wired the metrics service into the app.
- Tests: api-keys-observability.test.ts, metrics.routes.test.ts.

## Tests
- Focused suite: 4/4 test suites passed, 196/196 tests passed.
- Coverage on metrics-service.ts: 100% statements, 95.58% branches, 
  100% functions, 100% lines.
- Full repo suite: 161/174 suites passed, 3706/3767 tests passed. The 
  13 failing suites (61 tests) are pre-existing and unrelated — 
  malformed webhookMetrics.test.ts and stale contracts-controller 
  tests, confirmed unrelated to this change.
- Changed-file ESLint: passed.

## ⚠️ Known pre-existing blockers — not introduced by this PR
- **Repository build is currently broken on this branch's base**: 
  src/routes/health.ts(95,1): error TS1005: '}' expected. This is a 
  pre-existing syntax error unrelated to the observability work — it 
  blocks the full `build` step but is not something this PR touched or 
  caused. Recommend maintainer fix this separately; it will block CI 
  for every PR until resolved.
- Repository-wide lint has 7 pre-existing baseline errors and 63 
  warnings unrelated to this change.

## Files changed
- src/app.ts
- src/observability/metrics-service.ts
- src/observability/api-keys-observability.test.ts
- src/routes/metrics.routes.test.ts