### PR TITLE
feat(disputes): add read caching with invalidation

### DIFF
--- a/src/config/env.schema.ts
+++ b/src/config/env.schema.ts
@@ -155,6 +155,22 @@ export const envSchema = z.object({
     .transform((val) => val === undefined ? undefined : parseInt(val, 10))
     .pipe(z.number().int().positive().optional()),
 
+  // Disputes Cache Configuration
+  DISPUTES_CACHE_TTL_MS: z.string()
+    .default('5000')
+    .transform((val) => parseInt(val, 10))
+    .pipe(z.number().int().positive('DISPUTES_CACHE_TTL_MS must be a positive integer').max(300_000)),
+
+  DISPUTES_CACHE_SWR_MS: z.string()
+    .default('30000')
+    .transform((val) => parseInt(val, 10))
+    .pipe(z.number().int().nonnegative('DISPUTES_CACHE_SWR_MS must be >= 0').max(600_000)),
+
+  DISPUTES_CACHE_MAX_ENTRIES: z.string()
+    .default('100')
+    .transform((val) => parseInt(val, 10))
+    .pipe(z.number().int().positive('DISPUTES_CACHE_MAX_ENTRIES must be a positive integer').max(10000)),
+
   RATE_LIMIT_STORE_TYPE: z.enum(['memory', 'redis'])
     .default('memory'),
   REDIS_URL: z.string().optional(),

--- a/src/routes/disputes.routes.test.ts
+++ b/src/routes/disputes.routes.test.ts
@@ -476,4 +476,86 @@ describe('Disputes endpoints — rate limiting', () => {
       expect(over.status).toBe(429);
     });
   });
+
+  // ── Read caching ────────────────────────────────────────────────────────
+
+  describe('read caching', () => {
+    it('GET / returns valid response contract with caching', async () => {
+      const app = buildApp();
+      const res = await request(app)
+        .get('/api/v1/disputes')
+        .set('X-Forwarded-For', '90.0.0.1');
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('disputes');
+      expect(Array.isArray(res.body.disputes)).toBe(true);
+    });
+
+    it('GET /:id returns the dispute with the correct id', async () => {
+      const app = buildApp();
+      const res = await request(app)
+        .get('/api/v1/disputes/dispute-42')
+        .set('X-Forwarded-For', '90.0.0.2');
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('dispute');
+      expect(res.body.dispute.id).toBe('dispute-42');
+      expect(res.body.dispute).toHaveProperty('status');
+      expect(res.body.dispute).toHaveProperty('createdAt');
+    });
+  });
+
+  // ── Write invalidation ──────────────────────────────────────────────────
+
+  describe('write invalidation', () => {
+    it('POST / returns 201 and invalidates list cache for subsequent GET', async () => {
+      const app = buildApp();
+      const ip = '91.0.0.1';
+
+      // Warm the list cache with a GET
+      const getBefore = await request(app)
+        .get('/api/v1/disputes')
+        .set('X-Forwarded-For', ip);
+      expect(getBefore.status).toBe(200);
+
+      // POST creates a new dispute
+      const postRes = await request(app)
+        .post('/api/v1/disputes')
+        .set('X-Forwarded-For', ip)
+        .send({ reason: 'test-invalidation' });
+      expect(postRes.status).toBe(201);
+      expect(postRes.body).toHaveProperty('dispute');
+      expect(postRes.body.dispute.status).toBe('open');
+
+      // Subsequent GET still works
+      const getAfter = await request(app)
+        .get('/api/v1/disputes')
+        .set('X-Forwarded-For', ip);
+      expect(getAfter.status).toBe(200);
+    });
+
+    it('PATCH /:id returns 200 and invalidates caches', async () => {
+      const app = buildApp();
+      const ip = '91.0.0.2';
+
+      const patchRes = await request(app)
+        .patch('/api/v1/disputes/dispute-99')
+        .set('X-Forwarded-For', ip)
+        .send({ status: 'resolved' });
+      expect(patchRes.status).toBe(200);
+      expect(patchRes.body).toHaveProperty('dispute');
+      expect(patchRes.body.dispute.id).toBe('dispute-99');
+      expect(patchRes.body.dispute).toHaveProperty('updatedAt');
+    });
+
+    it('DELETE /:id returns 200 and invalidates caches', async () => {
+      const app = buildApp();
+      const ip = '91.0.0.3';
+
+      const delRes = await request(app)
+        .delete('/api/v1/disputes/dispute-77')
+        .set('X-Forwarded-For', ip);
+      expect(delRes.status).toBe(200);
+      expect(delRes.body).toHaveProperty('message');
+      expect(delRes.body.message).toContain('dispute-77');
+    });
+  });
 });

--- a/src/routes/disputes.routes.ts
+++ b/src/routes/disputes.routes.ts
@@ -1,13 +1,19 @@
 /**
  * @module routes/disputes
- * @description Disputes API routes with per-client rate limiting.
+ * @description Disputes API routes with per-client rate limiting and
+ * read-response caching.
  *
  * All disputes endpoints are protected by authentication and role-based
  * authorization. A sliding-window rate limiter (sensitive-tier) is applied
  * to every route to prevent abuse and accidental overload.
  *
- * @route GET    /api/v1/disputes       - List disputes
- * @route GET    /api/v1/disputes/:id   - Get a single dispute
+ * GET / and GET /:id responses are cached with a config-driven TTL
+ * (default 5 s) and LRU max-entries bound (default 100).  POST, PATCH,
+ * and DELETE invalidate the affected cache keys so subsequent reads
+ * reflect the new state.
+ *
+ * @route GET    /api/v1/disputes       - List disputes (cached)
+ * @route GET    /api/v1/disputes/:id   - Get a single dispute (cached)
  * @route POST   /api/v1/disputes       - Create a new dispute
  * @route PATCH  /api/v1/disputes/:id   - Update a dispute
  * @route DELETE /api/v1/disputes/:id   - Delete a dispute
@@ -22,6 +28,7 @@ import { Router, Request, Response } from 'express';
 import { createRateLimiter } from '../middleware/rateLimiter';
 import { rateLimitConfig } from '../config/rateLimit';
 import { requireAuth, requirePermission } from '../middleware/authorization';
+import { DisputesCache, DisputesCacheConfig } from '../utils/disputesCache';
 
 const router = Router();
 
@@ -34,29 +41,44 @@ router.use(disputesLimiter);
 // ── Authentication — all disputes routes require a valid JWT ──────────────────
 router.use(requireAuth);
 
-// ── GET / — list disputes ─────────────────────────────────────────────────────
+// ── Cache initialisation (config-driven) ──────────────────────────────────────
+const cacheConfig: Partial<DisputesCacheConfig> = {
+  ttlMs: parseInt(process.env.DISPUTES_CACHE_TTL_MS ?? '5000', 10),
+  swrMs: parseInt(process.env.DISPUTES_CACHE_SWR_MS ?? '30000', 10),
+  maxEntries: parseInt(process.env.DISPUTES_CACHE_MAX_ENTRIES ?? '100', 10),
+};
+
+const disputesCache = new DisputesCache(cacheConfig);
+
+// ── GET / — list disputes (cached) ────────────────────────────────────────────
 /** @permission disputes:list — admin, auditor, client (ownOnly), freelancer (ownOnly) */
 router.get(
   '/',
   requirePermission('disputes', 'list'),
-  (_req: Request, res: Response) => {
-    res.status(200).json({ disputes: [], total: 0 });
+  async (_req: Request, res: Response) => {
+    const result = await disputesCache.getOrFetchList(async () => ({
+      disputes: [],
+      total: 0,
+    }));
+    res.status(200).json(result.data);
   },
 );
 
-// ── GET /:id — get a single dispute ───────────────────────────────────────────
+// ── GET /:id — get a single dispute (cached) ──────────────────────────────────
 /** @permission disputes:read — admin, auditor, client (ownOnly), freelancer (ownOnly) */
 router.get(
   '/:id',
   requirePermission('disputes', 'read'),
-  (req: Request, res: Response) => {
-    res.status(200).json({
+  async (req: Request, res: Response) => {
+    const id = req.params.id;
+    const result = await disputesCache.getOrFetchDispute(id, async () => ({
       dispute: {
-        id: req.params.id,
+        id,
         status: 'open',
         createdAt: new Date().toISOString(),
       },
-    });
+    }));
+    res.status(200).json(result.data);
   },
 );
 
@@ -67,14 +89,16 @@ router.post(
   requirePermission('disputes', 'create'),
   (req: Request, res: Response) => {
     const body = req.body ?? {};
-    res.status(201).json({
+    const newDispute = {
       dispute: {
         id: `dispute-${Date.now()}`,
         ...body,
         status: 'open',
         createdAt: new Date().toISOString(),
       },
-    });
+    };
+    disputesCache.invalidateList();
+    res.status(201).json(newDispute);
   },
 );
 
@@ -85,13 +109,16 @@ router.patch(
   requirePermission('disputes', 'update'),
   (req: Request, res: Response) => {
     const body = req.body ?? {};
-    res.status(200).json({
+    const updated = {
       dispute: {
         id: req.params.id,
         ...body,
         updatedAt: new Date().toISOString(),
       },
-    });
+    };
+    disputesCache.invalidateList();
+    disputesCache.invalidateDispute(req.params.id);
+    res.status(200).json(updated);
   },
 );
 
@@ -101,6 +128,8 @@ router.delete(
   '/:id',
   requirePermission('disputes', 'delete'),
   (req: Request, res: Response) => {
+    disputesCache.invalidateList();
+    disputesCache.invalidateDispute(req.params.id);
     res.status(200).json({
       message: `Dispute ${req.params.id} deleted successfully`,
     });

--- a/src/utils/disputesCache.test.ts
+++ b/src/utils/disputesCache.test.ts
@@ -1,0 +1,197 @@
+import { DisputesCache, disputesCacheHitsTotal, disputesCacheMissesTotal } from './disputesCache';
+
+beforeEach(() => {
+  disputesCacheHitsTotal.reset();
+  disputesCacheMissesTotal.reset();
+});
+
+describe('DisputesCache', () => {
+  let cache: DisputesCache;
+
+  beforeEach(() => {
+    cache = new DisputesCache({ ttlMs: 5000, swrMs: 30000, maxEntries: 100 });
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  describe('cold cache (miss)', () => {
+    it('calls the fetcher on first list request', async () => {
+      const fetcher = jest.fn().mockResolvedValue({ disputes: [], total: 0 });
+      const result = await cache.getOrFetchList(fetcher);
+      expect(result.data).toEqual({ disputes: [], total: 0 });
+      expect(result.source).toBe('upstream');
+      expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls the fetcher on first dispute request', async () => {
+      const fetcher = jest.fn().mockResolvedValue({ dispute: { id: 'd1', status: 'open' } });
+      const result = await cache.getOrFetchDispute('d1', fetcher);
+      expect(result.data).toEqual({ dispute: { id: 'd1', status: 'open' } });
+      expect(result.source).toBe('upstream');
+      expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+
+    it('increments miss counter on cold cache', async () => {
+      const before = Number((await disputesCacheMissesTotal.get()).values[0]?.value ?? 0);
+      await cache.getOrFetchList(() => Promise.resolve({ disputes: [] }));
+      const after = Number((await disputesCacheMissesTotal.get()).values[0]?.value ?? 0);
+      expect(after).toBe(before + 1);
+    });
+  });
+
+  describe('cache hit', () => {
+    it('returns cached list without calling fetcher within TTL', async () => {
+      const fetcher = jest.fn().mockResolvedValue({ disputes: [], total: 0 });
+      await cache.getOrFetchList(fetcher);
+      const result = await cache.getOrFetchList(fetcher);
+      expect(result.source).toBe('cache_fresh');
+      expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns cached dispute without calling fetcher within TTL', async () => {
+      const fetcher = jest.fn().mockResolvedValue({ dispute: { id: 'd1', status: 'open' } });
+      await cache.getOrFetchDispute('d1', fetcher);
+      const result = await cache.getOrFetchDispute('d1', fetcher);
+      expect(result.source).toBe('cache_fresh');
+      expect(result.data).toEqual({ dispute: { id: 'd1', status: 'open' } });
+      expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+
+    it('increments hit counter on cache hit', async () => {
+      await cache.getOrFetchList(() => Promise.resolve({ disputes: [] }));
+      const before = Number((await disputesCacheHitsTotal.get()).values[0]?.value ?? 0);
+      await cache.getOrFetchList(() => Promise.resolve({ disputes: [] }));
+      const after = Number((await disputesCacheHitsTotal.get()).values[0]?.value ?? 0);
+      expect(after).toBe(before + 1);
+    });
+
+    it('returns stale data within SWR window and revalidates in background', async () => {
+      const seed = jest.fn().mockResolvedValue({ disputes: ['v1'] });
+      await cache.getOrFetchList(seed);
+      jest.advanceTimersByTime(6000);
+      const reval = jest.fn().mockResolvedValue({ disputes: ['v2'] });
+      const result = await cache.getOrFetchList(reval);
+      expect(result.source).toBe('cache_stale');
+      expect(result.data).toEqual({ disputes: ['v1'] });
+      await Promise.resolve();
+      expect(reval).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('write invalidation', () => {
+    it('invalidates list cache on POST', async () => {
+      const fetcher = jest.fn().mockResolvedValue({ disputes: ['original'] });
+      await cache.getOrFetchList(fetcher);
+      expect(fetcher).toHaveBeenCalledTimes(1);
+      cache.invalidateList();
+      const result = await cache.getOrFetchList(fetcher);
+      expect(result.source).toBe('upstream');
+      expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+
+    it('invalidates dispute cache on PATCH', async () => {
+      const fetcher = jest.fn().mockResolvedValue({ dispute: { id: 'd1', status: 'open' } });
+      await cache.getOrFetchDispute('d1', fetcher);
+      expect(fetcher).toHaveBeenCalledTimes(1);
+      cache.invalidateDispute('d1');
+      const result = await cache.getOrFetchDispute('d1', fetcher);
+      expect(result.source).toBe('upstream');
+      expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+
+    it('invalidates dispute for a different id independently', async () => {
+      const fetcherD1 = jest.fn().mockResolvedValue({ dispute: { id: 'd1' } });
+      const fetcherD2 = jest.fn().mockResolvedValue({ dispute: { id: 'd2' } });
+      await cache.getOrFetchDispute('d1', fetcherD1);
+      await cache.getOrFetchDispute('d2', fetcherD2);
+      cache.invalidateDispute('d1');
+      const r1 = await cache.getOrFetchDispute('d1', fetcherD1);
+      const r2 = await cache.getOrFetchDispute('d2', fetcherD2);
+      expect(r1.source).toBe('upstream');
+      expect(r2.source).toBe('cache_fresh');
+      expect(fetcherD1).toHaveBeenCalledTimes(2);
+      expect(fetcherD2).toHaveBeenCalledTimes(1);
+    });
+
+    it('list and dispute caches are independent', async () => {
+      const listFetcher = jest.fn().mockResolvedValue({ disputes: [] });
+      const disputeFetcher = jest.fn().mockResolvedValue({ dispute: { id: 'd1' } });
+      await cache.getOrFetchList(listFetcher);
+      await cache.getOrFetchDispute('d1', disputeFetcher);
+      cache.invalidateList();
+      const listResult = await cache.getOrFetchList(listFetcher);
+      const disputeResult = await cache.getOrFetchDispute('d1', disputeFetcher);
+      expect(listResult.source).toBe('upstream');
+      expect(disputeResult.source).toBe('cache_fresh');
+    });
+
+    it('invalidates both list and dispute on PATCH', async () => {
+      const listFetcher = jest.fn().mockResolvedValue({ disputes: [] });
+      const disputeFetcher = jest.fn().mockResolvedValue({ dispute: { id: 'd1' } });
+      await cache.getOrFetchList(listFetcher);
+      await cache.getOrFetchDispute('d1', disputeFetcher);
+      cache.invalidateList();
+      cache.invalidateDispute('d1');
+      const listResult = await cache.getOrFetchList(listFetcher);
+      const disputeResult = await cache.getOrFetchDispute('d1', disputeFetcher);
+      expect(listResult.source).toBe('upstream');
+      expect(disputeResult.source).toBe('upstream');
+    });
+  });
+
+  describe('TTL expiration', () => {
+    it('refetches after TTL expires', async () => {
+      const fetcher = jest.fn().mockResolvedValue({ disputes: ['old'] });
+      await cache.getOrFetchList(fetcher);
+      jest.advanceTimersByTime(5001);
+      const result = await cache.getOrFetchList(fetcher);
+      expect(result.data).toEqual({ disputes: ['old'] });
+      expect(result.source).toBe('cache_stale');
+      await Promise.resolve();
+      const freshResult = await cache.getOrFetchList(fetcher);
+      expect(freshResult.source).toBe('cache_fresh');
+    });
+
+    it('fully refetches after SWR window expires', async () => {
+      const fetcher = jest.fn()
+        .mockResolvedValueOnce({ disputes: ['old'] })
+        .mockResolvedValueOnce({ disputes: ['new'] });
+      await cache.getOrFetchList(fetcher);
+      jest.advanceTimersByTime(40000);
+      const result = await cache.getOrFetchList(fetcher);
+      expect(result.source).toBe('upstream');
+      expect(result.data).toEqual({ disputes: ['new'] });
+    });
+  });
+
+  describe('LRU eviction', () => {
+    it('enforces maxEntries bound', async () => {
+      const smallCache = new DisputesCache({ maxEntries: 3, ttlMs: 60000, swrMs: 0 });
+      for (let i = 0; i < 3; i++) {
+        await smallCache.getOrFetchDispute(`d${i}`, () => Promise.resolve({ dispute: { id: `d${i}` } }));
+      }
+      expect(smallCache.size).toBe(3);
+      await smallCache.getOrFetchDispute('d4', () => Promise.resolve({ dispute: { id: 'd4' } }));
+      expect(smallCache.size).toBe(3);
+      const result = await smallCache.getOrFetchDispute('d0', () => Promise.resolve({ dispute: { id: 'd0-evicted' } }));
+      expect(result.source).toBe('upstream');
+      expect(result.data).toEqual({ dispute: { id: 'd0-evicted' } });
+    });
+
+    it('defaults maxEntries to 100', () => {
+      const defaultCache = new DisputesCache();
+      expect(defaultCache.maxEntries).toBe(100);
+    });
+  });
+
+  describe('config', () => {
+    it('accepts custom TTL and maxEntries', () => {
+      const custom = new DisputesCache({ ttlMs: 1000, maxEntries: 10 });
+      expect(custom.maxEntries).toBe(10);
+    });
+  });
+});

--- a/src/utils/disputesCache.ts
+++ b/src/utils/disputesCache.ts
@@ -1,0 +1,77 @@
+import { Counter, register as promRegister } from 'prom-client';
+import { SWRCache } from './swrCache';
+
+export interface DisputesCacheConfig {
+  ttlMs: number;
+  swrMs: number;
+  maxEntries: number;
+}
+
+const DEFAULT_TTL_MS = 5_000;
+const DEFAULT_SWR_MS = 30_000;
+const DEFAULT_MAX_ENTRIES = 100;
+
+export const disputesCacheHitsTotal = new Counter({
+  name: 'disputes_cache_hits_total',
+  help: 'Total number of disputes cache hits',
+  labelNames: ['type'] as const,
+  registers: [promRegister],
+});
+
+export const disputesCacheMissesTotal = new Counter({
+  name: 'disputes_cache_misses_total',
+  help: 'Total number of disputes cache misses',
+  labelNames: ['type'] as const,
+  registers: [promRegister],
+});
+
+export class DisputesCache {
+  private cache: SWRCache;
+  private options: { ttlMs: number; swrMs: number };
+
+  constructor(config?: Partial<DisputesCacheConfig>) {
+    this.cache = new SWRCache({
+      maxEntries: config?.maxEntries ?? DEFAULT_MAX_ENTRIES,
+    });
+    this.options = {
+      ttlMs: config?.ttlMs ?? DEFAULT_TTL_MS,
+      swrMs: config?.swrMs ?? DEFAULT_SWR_MS,
+    };
+  }
+
+  async getOrFetchList<T>(fetcher: () => Promise<T>): Promise<{ data: T; source: 'cache_fresh' | 'cache_stale' | 'upstream' }> {
+    const result = await this.cache.get('disputes:list', fetcher, this.options);
+    if (result.source === 'cache_fresh' || result.source === 'cache_stale') {
+      disputesCacheHitsTotal.inc({ type: 'list' });
+    } else {
+      disputesCacheMissesTotal.inc({ type: 'list' });
+    }
+    return { data: result.data as T, source: result.source };
+  }
+
+  async getOrFetchDispute<T>(id: string, fetcher: () => Promise<T>): Promise<{ data: T; source: 'cache_fresh' | 'cache_stale' | 'upstream' }> {
+    const result = await this.cache.get(`disputes:${id}`, fetcher, this.options);
+    if (result.source === 'cache_fresh' || result.source === 'cache_stale') {
+      disputesCacheHitsTotal.inc({ type: 'dispute' });
+    } else {
+      disputesCacheMissesTotal.inc({ type: 'dispute' });
+    }
+    return { data: result.data as T, source: result.source };
+  }
+
+  invalidateList(): void {
+    this.cache.delete('disputes:list');
+  }
+
+  invalidateDispute(id: string): void {
+    this.cache.delete(`disputes:${id}`);
+  }
+
+  get size(): number {
+    return this.cache.size;
+  }
+
+  get maxEntries(): number {
+    return this.cache.maxEntries;
+  }
+}

--- a/src/utils/swrCache.ts
+++ b/src/utils/swrCache.ts
@@ -153,6 +153,19 @@ export class SWRCache {
   }
 
   /**
+   * Remove a single entry from the cache by key.
+   * Active fetches for this key are NOT cancelled — they still complete and
+   * the result is stored back via `setEntry` unless eviction pressure removes
+   * it before resolution.
+   *
+   * @param key - The cache key to remove.
+   * @returns `true` if the entry existed and was removed, `false` otherwise.
+   */
+  public delete(key: string): boolean {
+    return this.cache.delete(key);
+  }
+
+  /**
    * Retrieve data from cache or upstream fetcher using SWR strategy.
    *
    * The SWR strategy follows these rules:


### PR DESCRIPTION
closed #811

Description
Hot disputes read endpoints recompute on every request. This issue adds a bounded cache with explicit invalidation on writes.

Requirements and context
Repository scope: Talenttrust/Talenttrust-Backend only.
Cache disputes read responses with a short TTL and a max-entry bound; invalidate affected keys on writes.
Expose cache hit/miss metrics; make TTL config-driven.
Cover hit, miss, and invalidation in tests.