### PR TITLE
Add regression tests for known milestones edge cases (#923)

### DIFF
--- a/src/contracts/bounds.test.ts
+++ b/src/contracts/bounds.test.ts
@@ -137,4 +137,146 @@ describe('validateContractBounds', () => {
       if (!result.valid) expect(result.error).toMatch(/Budget exceeds/);
     });
   });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Regression tests — issue #923
+  //
+  // These lock in fixes for cases that were previously either uncaught
+  // exceptions (crashed instead of returning a validation result) or
+  // silently accepted malformed input as valid. validateContractBounds is
+  // the function whose entire job is defending against malformed input, so
+  // it must not depend on an upstream caller (e.g. the DTO/Zod layer) having
+  // already validated types first — a future internal caller that bypasses
+  // that layer (bulk import, admin override, migration script) must still
+  // get a graceful validation error, not a crash or a false "valid".
+  // ──────────────────────────────────────────────────────────────────────────
+  describe('regression: malformed budget (issue #923)', () => {
+    it('rejects NaN budget instead of silently passing (NaN > x is always false)', () => {
+      const result = validateContractBounds(NaN, []);
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.error).toMatch(/finite/i);
+    });
+
+    it('rejects Infinity budget', () => {
+      const result = validateContractBounds(Infinity, []);
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.error).toMatch(/finite/i);
+    });
+
+    it('rejects -Infinity budget', () => {
+      const result = validateContractBounds(-Infinity, []);
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects undefined budget at runtime (bypassing the TS type)', () => {
+      const result = validateContractBounds(undefined as unknown as number, []);
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects a string budget at runtime (bypassing the TS type)', () => {
+      const result = validateContractBounds('1000' as unknown as number, []);
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects null budget at runtime (bypassing the TS type)', () => {
+      const result = validateContractBounds(null as unknown as number, []);
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('regression: malformed milestones array (issue #923)', () => {
+    it('treats null milestones the same as undefined (valid, no milestones) instead of throwing', () => {
+      // Previously: TypeError: Cannot read properties of null (reading 'length')
+      const result = validateContractBounds(1000, null);
+      expect(result.valid).toBe(true);
+    });
+
+    it('rejects a non-array milestones value instead of throwing on .length', () => {
+      const result = validateContractBounds(1000, 'not-an-array' as unknown as Milestone[]);
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.error).toMatch(/array/i);
+    });
+
+    it('rejects a plain-object (non-array) milestones value', () => {
+      const result = validateContractBounds(1000, { title: 'x', amount: 1 } as unknown as Milestone[]);
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects an array containing a null entry instead of throwing on .amount', () => {
+      // Previously: TypeError: Cannot read properties of null (reading 'amount')
+      const milestones = [null, { title: 'ok', amount: 1 }] as unknown as Milestone[];
+      const result = validateContractBounds(1000, milestones);
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.error).toMatch(/finite numeric amount/i);
+    });
+
+    it('rejects an array containing an undefined entry', () => {
+      const milestones = [{ title: 'ok', amount: 1 }, undefined] as unknown as Milestone[];
+      const result = validateContractBounds(1000, milestones);
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects an array containing a primitive entry (e.g. a bare number)', () => {
+      const milestones = [42] as unknown as Milestone[];
+      const result = validateContractBounds(1000, milestones);
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects a milestone with a NaN amount instead of letting it corrupt the running total', () => {
+      const milestones = [{ title: 'x', amount: NaN }] as unknown as Milestone[];
+      const result = validateContractBounds(1000, milestones);
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.error).toMatch(/finite numeric amount/i);
+    });
+
+    it('rejects a milestone with an Infinity amount', () => {
+      const milestones = [{ title: 'x', amount: Infinity }];
+      const result = validateContractBounds(1000, milestones);
+      expect(result.valid).toBe(false);
+    });
+
+    it('rejects a milestone with a non-numeric amount at runtime (bypassing the TS type)', () => {
+      const milestones = [{ title: 'x', amount: '100' }] as unknown as Milestone[];
+      const result = validateContractBounds(1000, milestones);
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe('regression: empty-input edge cases (issue #923)', () => {
+    it('accepts an empty milestones array with a zero budget (fully empty contract)', () => {
+      expect(validateContractBounds(0, []).valid).toBe(true);
+    });
+
+    it('is valid when both budget is 0 and milestones is undefined', () => {
+      expect(validateContractBounds(0, undefined).valid).toBe(true);
+    });
+
+    it('is valid when both budget is 0 and milestones is null', () => {
+      expect(validateContractBounds(0, null).valid).toBe(true);
+    });
+  });
+
+  describe('regression: boundary edge cases (issue #923)', () => {
+    it('accepts a single milestone whose amount exactly equals the budget', () => {
+      const result = validateContractBounds(500, [{ title: 'x', amount: 500 }]);
+      expect(result.valid).toBe(true);
+    });
+
+    it('rejects the smallest possible over-cap total (cap + Number.EPSILON-scale unit)', () => {
+      const result = validateContractBounds(1000, [
+        { title: 'x', amount: MAX_CONTRACT_AMOUNT_STROOPS },
+        { title: 'y', amount: 1 },
+      ]);
+      expect(result.valid).toBe(false);
+    });
+
+    it('accepts MAX_MILESTONES_PER_CONTRACT milestones each with a tiny fractional amount summing under the cap', () => {
+      const milestones: Milestone[] = Array.from({ length: MAX_MILESTONES_PER_CONTRACT }, (_, i) => ({
+        title: `M${i}`,
+        amount: 0.1,
+      }));
+      const result = validateContractBounds(1000, milestones);
+      expect(result.valid).toBe(true);
+    });
+  });
 });

--- a/src/contracts/bounds.ts
+++ b/src/contracts/bounds.ts
@@ -50,8 +50,21 @@ export type Milestone = z.infer<typeof milestoneSchema>;
  */
 export function validateContractBounds(
   budget: number,
-  milestones?: Milestone[],
+  milestones?: Milestone[] | null,
 ): { valid: true } | { valid: false; error: string } {
+  // Defensive guard: this function's entire purpose is to protect against
+  // malformed/malicious input reaching the escrow contract, so it must not
+  // rely on an upstream caller (e.g. the DTO/Zod layer) having already
+  // validated types. A NaN/Infinity/non-numeric budget must never be
+  // reported as valid — `NaN > x` and `undefined > x` are always false in
+  // JS, which previously let these silently pass the cap check below.
+  if (typeof budget !== 'number' || !Number.isFinite(budget)) {
+    return {
+      valid: false,
+      error: 'Budget must be a finite number',
+    };
+  }
+
   if (budget > MAX_CONTRACT_AMOUNT_STROOPS) {
     return {
       valid: false,
@@ -59,7 +72,16 @@ export function validateContractBounds(
     };
   }
 
-  if (milestones !== undefined) {
+  // `null` is treated the same as `undefined` (no milestones to validate) —
+  // a common, reasonable shape for an explicit "no milestones" JSON payload.
+  if (milestones !== undefined && milestones !== null) {
+    if (!Array.isArray(milestones)) {
+      return {
+        valid: false,
+        error: 'Milestones must be an array',
+      };
+    }
+
     if (milestones.length > MAX_MILESTONES_PER_CONTRACT) {
       return {
         valid: false,
@@ -69,6 +91,16 @@ export function validateContractBounds(
 
     let total = 0;
     for (const m of milestones) {
+      // Regression guard: a null/undefined/non-object array entry (e.g.
+      // `[null, undefined, 42]`) previously threw `Cannot read properties
+      // of null (reading 'amount')` instead of returning a validation error.
+      if (m === null || typeof m !== 'object' || !Number.isFinite(m.amount)) {
+        return {
+          valid: false,
+          error: 'Each milestone must be an object with a finite numeric amount',
+        };
+      }
+
       total += m.amount;
       if (!Number.isFinite(total) || total > MAX_CONTRACT_AMOUNT_STROOPS) {
         return {

--- a/src/controllers/milestones.integration.test.ts
+++ b/src/controllers/milestones.integration.test.ts
@@ -343,6 +343,47 @@ describe('Milestone validation-failure paths', () => {
     expect(res.body.error).toHaveProperty('message');
     expect(res.body.error).toHaveProperty('requestId');
   });
+
+  // ── Regression: malformed milestones shape (issue #923) ───────────────
+  //
+  // These document that the DTO/Zod layer rejects malformed `milestones`
+  // shapes before the request ever reaches validateContractBounds — the
+  // same malformed shapes that, at the unit level (src/contracts/bounds.test.ts),
+  // previously threw an uncaught TypeError instead of a graceful result when
+  // passed directly to that function. Two independent layers now guard
+  // against the same class of malformed input.
+  it('returns 400 (not a 500 crash) when milestones is null', async () => {
+    const res = await request(app)
+      .post('/api/v1/contracts')
+      .set({ ...auth(adminToken()), 'Idempotency-Key': randomUUID() })
+      .send({ ...basePayload, milestones: null });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 (not a 500 crash) when milestones is a string, not an array', async () => {
+    const res = await request(app)
+      .post('/api/v1/contracts')
+      .set({ ...auth(adminToken()), 'Idempotency-Key': randomUUID() })
+      .send({ ...basePayload, milestones: 'not-an-array' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 (not a 500 crash) when the milestones array contains a null entry', async () => {
+    const res = await request(app)
+      .post('/api/v1/contracts')
+      .set({ ...auth(adminToken()), 'Idempotency-Key': randomUUID() })
+      .send({ ...basePayload, milestones: [null] });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 (not a 500 crash) when a milestone amount is NaN-producing (non-numeric string)', async () => {
+    const milestones = [{ title: 'Bad Amount', description: 'Non-numeric amount', amount: 'lots' }];
+    const res = await request(app)
+      .post('/api/v1/contracts')
+      .set({ ...auth(adminToken()), 'Idempotency-Key': randomUUID() })
+      .send({ ...basePayload, milestones });
+    expect(res.status).toBe(400);
+  });
 });
 
 // ─── Idempotent-repeat paths ──────────────────────────────────────────────────


### PR DESCRIPTION
Closes #923

## Still-broken case found and fixed (per issue instructions)

While writing regression tests I found `validateContractBounds()` in `src/contracts/bounds.ts` had real bugs, confirmed by direct probing (not speculation):

```
validateContractBounds(1000, null)                    → threw TypeError (Cannot read properties of null (reading 'length'))
validateContractBounds(1000, [null, undefined, 42])    → threw TypeError (Cannot read properties of null (reading 'amount'))
```

Not exploitable via the live API today — the Zod DTO layer already rejects these shapes before they reach this function. But `validateContractBounds` exists specifically to defend against malformed input reaching the escrow contract; it shouldn't depend on a caller having already validated. Hardened it to fail gracefully instead of crashing or silently accepting garbage. `null` milestones is treated the same as `undefined` (a reasonable, common "no milestones" JSON convention) rather than an error.

## Tests added

**`src/contracts/bounds.test.ts`** — 21 new tests across 4 new `describe` blocks, each scenario named in the test title:
- `regression: malformed budget (issue #923)` — NaN/Infinity/-Infinity/undefined/string/null budget
- `regression: malformed milestones array (issue #923)` — null, non-array, array with null/undefined/primitive entries, NaN/Infinity/non-numeric amounts
- `regression: empty-input edge cases (issue #923)` — zero budget + empty/undefined/null milestones
- `regression: boundary edge cases (issue #923)` — exact-cap amount, smallest over-cap breach, fractional-amount sum near the cap

**`src/controllers/milestones.integration.test.ts`** — 4 new HTTP-boundary tests confirming the DTO/Zod layer independently rejects the same malformed shapes with a clean 400, not a 500 crash. Two independent layers now guard the same class of malformed input.

Zero regressions — all 19 pre-existing `bounds.test.ts` tests and 26 pre-existing milestone integration tests pass unchanged.

## Full test output

```
bounds.test.ts:
  Test Suites: 1 passed, 1 total
  Tests:       40 passed, 40 total
  Coverage: 100% Stmts / 100% Branch / 100% Funcs / 100% Lines on bounds.ts

milestones.integration.test.ts:
  Test Suites: 1 passed, 1 total
  Tests:       30 passed, 30 total
```

## Lint

Clean on all 3 changed files (0 problems). Full `npm run lint`: 70 pre-existing problems — confirmed none are in files touched by this PR.

## Build

`npm run build` fails only on a pre-existing, unrelated syntax error in `src/routes/health.ts` (`error TS1005: '}' expected`, confirmed byte-identical to `HEAD` via `git stash`) — nothing to do with milestones or this PR.

## Acceptance criteria
- [x] Tests reproducing the tricky milestones edge cases (empty, boundary, malformed)
- [x] Scenarios referenced in test names
- [x] Still-broken case found, fixed, and noted (see above)