### PR TITLE
refactor(contracts): add validation schemas for contracts request/response payloads

### DIFF
--- a/src/controllers/contracts.controller.di.test.ts
+++ b/src/controllers/contracts.controller.di.test.ts
@@ -48,6 +48,20 @@ const mockService = {
   getContractStats: jest.fn(),
 };
 
+function makeContract(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'abc',
+    title: 'Test',
+    clientId: 'client-1',
+    freelancerId: 'freelancer-1',
+    amount: 1000,
+    status: 'active',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    version: 0,
+    ...overrides,
+  };
+}
+
 describe('ContractsController (DI)', () => {
   let controller: ReturnType<typeof createContractsController>;
 
@@ -58,11 +72,12 @@ describe('ContractsController (DI)', () => {
 
   describe('getContracts', () => {
     it('returns paginated contracts', async () => {
-      mockService.getAllContracts.mockResolvedValueOnce([{ id: '1' }, { id: '2' }]);
+      const contracts = [makeContract({ id: '1' }), makeContract({ id: '2' })];
+      mockService.getAllContracts.mockResolvedValueOnce(contracts);
       await controller.getContracts(makeMockReq(), makeMockRes(), next);
       expect(ok).toHaveBeenCalledWith(
         expect.anything(),
-        [{ id: '1' }, { id: '2' }],
+        contracts,
         expect.objectContaining({ page: 1, limit: 10, total: 2 }),
       );
     });
@@ -76,7 +91,7 @@ describe('ContractsController (DI)', () => {
 
   describe('getContractById', () => {
     it('returns contract when found', async () => {
-      const contract = { id: 'abc', title: 'Test' };
+      const contract = makeContract();
       mockService.getContractById.mockResolvedValueOnce(contract);
       await controller.getContractById(
         makeMockReq({ params: { id: 'abc' } }),
@@ -99,7 +114,7 @@ describe('ContractsController (DI)', () => {
 
   describe('createContract', () => {
     it('creates contract and returns 201', async () => {
-      const newContract = { id: 'new-1', title: 'New' };
+      const newContract = makeContract({ id: 'new-1', title: 'New', status: 'draft' });
       mockService.createContract.mockResolvedValueOnce(newContract);
       await controller.createContract(
         makeMockReq({ body: { title: 'New' } }),
@@ -125,7 +140,7 @@ describe('ContractsController (DI)', () => {
 
   describe('updateContract', () => {
     it('updates contract successfully', async () => {
-      const updated = { id: 'u-1', title: 'Updated' };
+      const updated = makeContract({ id: 'u-1', title: 'Updated', version: 1 });
       mockService.updateContract.mockResolvedValueOnce(updated);
       await controller.updateContract(
         makeMockReq({ params: { id: 'u-1' }, body: { title: 'Updated' } }),
@@ -180,7 +195,7 @@ describe('ContractsController (DI)', () => {
 
   describe('getContractStats', () => {
     it('returns stats', async () => {
-      const stats = { total: 5, active: 3 };
+      const stats = { total: 5, totalBudget: 5000, byStatus: { active: 3, draft: 2 } };
       mockService.getContractStats.mockResolvedValueOnce(stats);
       await controller.getContractStats(makeMockReq(), makeMockRes(), next);
       expect(ok).toHaveBeenCalledWith(expect.anything(), stats);

--- a/src/controllers/contracts.controller.test.ts
+++ b/src/controllers/contracts.controller.test.ts
@@ -293,10 +293,20 @@ describe('ContractsController', () => {
     });
 
     it('returns 200 with paginated legacy metadata when page+limit provided', async () => {
+      const makeContract = (id: string, title: string) => ({
+        id,
+        title,
+        clientId: 'client-1',
+        freelancerId: 'freelancer-1',
+        amount: 1000,
+        status: 'active',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        version: 0,
+      });
       const contracts = [
-        { id: '1', title: 'A' },
-        { id: '2', title: 'B' },
-        { id: '3', title: 'C' },
+        makeContract('1', 'A'),
+        makeContract('2', 'B'),
+        makeContract('3', 'C'),
       ];
       mockGetAllContracts.mockResolvedValue(contracts);
       mockRequest.query = { page: '1', limit: '2' };
@@ -441,7 +451,16 @@ describe('ContractsController', () => {
 
   describe('getContractById', () => {
     it('returns 200 with contract data', async () => {
-      const contract = { id: 'abc', title: 'Test' };
+      const contract = {
+        id: 'abc',
+        title: 'Test',
+        clientId: 'client-1',
+        freelancerId: 'freelancer-1',
+        amount: 1000,
+        status: 'active',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        version: 0,
+      };
       mockGetContractById.mockResolvedValue(contract);
       mockRequest.params = { id: 'abc' };
       await controller.getContractById(
@@ -475,7 +494,16 @@ describe('ContractsController', () => {
 
   describe('createContract', () => {
     it('returns 201 on success', async () => {
-      const contract = { id: 'abc', status: 'PENDING' };
+      const contract = {
+        id: 'abc',
+        title: 'Test',
+        clientId: 'client-1',
+        freelancerId: 'freelancer-1',
+        amount: 1000,
+        status: 'draft',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        version: 0,
+      };
       mockCreateContract.mockResolvedValue(contract);
       await controller.createContract(
         mockRequest as Request,
@@ -529,7 +557,16 @@ describe('ContractsController', () => {
 
   describe('updateContract', () => {
     it('returns 200 on success', async () => {
-      const updated = { id: 'abc', title: 'Updated' };
+      const updated = {
+        id: 'abc',
+        title: 'Updated',
+        clientId: 'client-1',
+        freelancerId: 'freelancer-1',
+        amount: 1000,
+        status: 'active',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        version: 1,
+      };
       mockUpdateContract.mockResolvedValue(updated);
       mockRequest.params = { id: 'abc' };
       await controller.updateContract(
@@ -758,7 +795,16 @@ describe('ContractsController', () => {
 
   describe('updateContract', () => {
     it('returns 200 on success', async () => {
-      const updatedContract = { id: 'abc', title: 'Updated', version: 1 };
+      const updatedContract = {
+        id: 'abc',
+        title: 'Updated',
+        clientId: 'client-1',
+        freelancerId: 'freelancer-1',
+        amount: 1000,
+        status: 'active',
+        createdAt: '2026-01-01T00:00:00.000Z',
+        version: 1,
+      };
       mockRequest.params = { id: 'abc' };
       mockRequest.body = { version: 0, title: 'Updated' };
       mockUpdateContract.mockResolvedValue(updatedContract);

--- a/src/controllers/contracts.controller.ts
+++ b/src/controllers/contracts.controller.ts
@@ -9,6 +9,15 @@ import {
   toCreateContractDto,
   toUpdateContractDto,
 } from '../modules/contracts/dto/contracts-boundary.dto';
+import {
+  assertResponseSchema,
+  contractBoundsResponseSchema,
+  contractStatsResponseSchema,
+  deleteContractResponseSchema,
+  ContractBoundsResponse,
+  ContractStatsResponse,
+  DeleteContractResponse,
+} from '../modules/contracts/dto/contract-response.dto';
 import { ContractsService } from '../services/contracts.service';
 import { fail, ok } from '../utils/apiResponse';
 import { applyPagination, parsePaginationQuery } from '../utils/pagination';
@@ -122,7 +131,14 @@ export class ContractsController {
   ): Promise<void> {
     try {
       await this.service.deleteContract(req.params.id!);
-      ok(res, { message: 'Contract deleted successfully' });
+      ok(
+        res,
+        assertResponseSchema<DeleteContractResponse>(
+          deleteContractResponseSchema,
+          { message: 'Contract deleted successfully' },
+          'DeleteContract',
+        ),
+      );
     } catch (error) {
       next(error);
     }
@@ -134,7 +150,15 @@ export class ContractsController {
     next: NextFunction,
   ): Promise<void> {
     try {
-      ok(res, await this.service.getContractStats());
+      const stats = await this.service.getContractStats();
+      ok(
+        res,
+        assertResponseSchema<ContractStatsResponse>(
+          contractStatsResponseSchema,
+          stats,
+          'ContractStats',
+        ),
+      );
     } catch (error) {
       if (error instanceof ContractBoundsError) {
         fail(res, 'contract_bounds_error', error.message, 422);
@@ -145,7 +169,14 @@ export class ContractsController {
   }
 
   public getBounds(_req: Request, res: Response): void {
-    ok(res, CONTRACT_BOUNDS);
+    ok(
+      res,
+      assertResponseSchema<ContractBoundsResponse>(
+        contractBoundsResponseSchema,
+        CONTRACT_BOUNDS,
+        'ContractBounds',
+      ),
+    );
   }
 }
 

--- a/src/controllers/contracts.integration.test.ts
+++ b/src/controllers/contracts.integration.test.ts
@@ -238,7 +238,12 @@ describe('GET /api/v1/contracts', () => {
     expect(res.body.data.hasNextPage).toBe(false);
   });
 
-  it('returns empty page for a cursor past the last item', async () => {
+  // The block below was previously mis-nested (an `it()` wrapping further
+  // `it()` calls, with an unrelated POST test spliced into the middle) as
+  // the result of a prior merge conflict — restored as a `describe()` with
+  // its two coherent cursor-pagination cases; see the milestone-bounds
+  // schema-validation test moved down to the POST describe block instead.
+  describe('cursor pagination — page boundary cases', () => {
     it('returns 200 with empty data array when no contracts exist', async () => {
       const res = await request(app)
         .get('/api/v1/contracts')
@@ -262,43 +267,9 @@ describe('GET /api/v1/contracts', () => {
       await createContractAsAdmin();
       await createContractAsAdmin();
 
-  it('returns 400 for total milestone amount exceeding bounds (schema validation)', async () => {
-    const excessiveAmountMilestones = [
-      {
-        title: 'Milestone 1',
-        description: 'Valid description',
-        amount: 999_000_000_000_000_000,
-      },
-    ];
-    const res = await request(app)
-      .post('/api/v1/contracts')
-      .set({ ...auth(adminToken()), 'Idempotency-Key': randomUUID() })
-      .send({ ...validPayload, milestones: excessiveAmountMilestones });
-    // The DTO schema now catches this at validation time (400) before the
-    // service can apply the 422 bounds check.
-    expect(res.status).toBe(400);
-    expect(res.body.error).toMatchObject({ code: 'validation_error' });
-  });
-});
-
-      if (first.body.data.nextCursor) {
-        const second = await request(app)
-          .get(`/api/v1/contracts?limit=2&cursor=${encodeURIComponent(first.body.data.nextCursor)}`)
-          .set(auth(adminToken()));
-        expect(second.status).toBe(200);
-        expect(second.body.data.data).toHaveLength(0);
-        expect(second.body.data.hasNextPage).toBe(false);
-      }
-
-      expect(first.body).toMatchObject({
-        status: 'success',
-        data: expect.objectContaining({
-          data: expect.any(Array),
-          nextCursor: expect.any(String),
-          hasNextPage: true,
-          limit: 2,
-        }),
-      });
+      const first = await request(app)
+        .get('/api/v1/contracts?limit=2')
+        .set(auth(adminToken()));
 
       const cursor = first.body.data.nextCursor;
 
@@ -508,7 +479,7 @@ describe('GET /api/v1/contracts', () => {
       expect(res.body.error).toMatchObject({ code: 'contract_bounds_error' });
     });
 
-    it('returns 422 for total milestone amount exceeding bounds', async () => {
+    it('returns 400 for total milestone amount exceeding bounds (schema validation)', async () => {
       const excessiveAmountMilestones = [
         {
           title: 'Milestone 1',
@@ -520,8 +491,10 @@ describe('GET /api/v1/contracts', () => {
         .post('/api/v1/contracts')
         .set({ ...auth(adminToken()), 'Idempotency-Key': randomUUID() })
         .send({ ...validPayload, milestones: excessiveAmountMilestones });
-      expect(res.status).toBe(422);
-      expect(res.body.error).toMatchObject({ code: 'contract_bounds_error' });
+      // The DTO schema's per-milestone amount cap catches this at validation
+      // time (400) before the service can apply the 422 bounds check.
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatchObject({ code: 'validation_error' });
     });
   });
 
@@ -534,6 +507,8 @@ describe('GET /api/v1/contracts', () => {
       expect(res.status).toBe(400);
       expect(res.body.error).toMatchObject({ code: 'bad_request' });
     });
+  });
+});
 
 afterAll(() => {
   closeDb();
@@ -568,8 +543,12 @@ describe('POST /api/v1/contracts — unknown field stripping', () => {
   });
 });
 
-describe('PATCH /api/v1/contracts/:id — unknown field stripping', () => {
-  it('strips unknown fields from update body and still succeeds', async () => {
+describe('PATCH /api/v1/contracts/:id — unknown field rejection', () => {
+  // Unlike POST (which strips unknown fields), PATCH rejects them outright:
+  // this is the write path used to initiate/resolve disputes via `status`,
+  // so a typo'd or unexpected field must surface as an error rather than be
+  // silently dropped. See the `.strict()` rationale on updateContractBodySchema.
+  it('rejects unknown fields in the update body with a structured 400', async () => {
     const contractId = await createContractAsAdmin();
     const fetched = await request(app)
       .get(`/api/v1/contracts/${contractId}`)
@@ -586,10 +565,8 @@ describe('PATCH /api/v1/contracts/:id — unknown field stripping', () => {
         __inject: 'payload',
         extraField: 'should-be-dropped',
       });
-    expect(res.status).toBe(200);
-    expect(res.body.data).not.toHaveProperty('__admin');
-    expect(res.body.data).not.toHaveProperty('__inject');
-    expect(res.body.data).not.toHaveProperty('extraField');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatchObject({ code: 'validation_error' });
   });
 });
 

--- a/src/errors/appError.ts
+++ b/src/errors/appError.ts
@@ -17,6 +17,7 @@ export const APP_ERROR_CODES = {
   CONFLICT: 'conflict',
   CONTRACT_METADATA_MISMATCH: 'contract_metadata_mismatch',
   VALIDATION_ERROR: 'validation_error',
+  RESPONSE_CONTRACT_ERROR: 'response_contract_error',
 } as const;
 
 export interface ErrorPayload {
@@ -119,6 +120,20 @@ export class ConflictError extends AppError {
 export class ContractMetadataMismatchError extends AppError {
   constructor(message = 'Contract metadata mismatch') {
     super(400, APP_ERROR_CODES.CONTRACT_METADATA_MISMATCH, message, false);
+  }
+}
+
+/**
+ * Thrown when an outgoing response payload fails its declared schema.
+ *
+ * @remarks Indicates a server-side bug (e.g. a persisted record drifting
+ * from the public contract) rather than a client mistake, so it maps to a
+ * 500 and `expose: false` keeps the raw Zod detail out of the client
+ * response — it is still logged server-side by the global error handler.
+ */
+export class ResponseContractError extends AppError {
+  constructor(message = 'Response failed schema validation') {
+    super(500, APP_ERROR_CODES.RESPONSE_CONTRACT_ERROR, message, false);
   }
 }
 

--- a/src/errors/safeErrors.ts
+++ b/src/errors/safeErrors.ts
@@ -35,6 +35,7 @@ export const SAFE_ERROR_MESSAGES: Readonly<Record<string, string>> = {
   payload_too_large: 'Payload Too Large',
   unsupported_media_type: 'Unsupported Media Type',
   invalid_webhook_signature: 'Webhook signature verification failed',
+  response_contract_error: 'An unexpected error occurred',
 };
 
 /**

--- a/src/modules/contracts/dto/contract-response.dto.test.ts
+++ b/src/modules/contracts/dto/contract-response.dto.test.ts
@@ -1,0 +1,180 @@
+import { ResponseContractError } from '../../../errors/appError';
+import {
+  assertResponseSchema,
+  contractBoundsResponseSchema,
+  contractListResponseSchema,
+  contractResponseSchema,
+  contractStatsResponseSchema,
+  deleteContractResponseSchema,
+} from './contract-response.dto';
+
+const VALID_CONTRACT = {
+  id: 'contract-1',
+  title: 'Build a typed boundary',
+  clientId: 'client-1',
+  freelancerId: 'freelancer-1',
+  amount: 2_000,
+  status: 'active',
+  createdAt: '2026-07-25T10:00:00.000Z',
+  version: 3,
+};
+
+describe('contractResponseSchema', () => {
+  it('accepts a fully-populated valid contract', () => {
+    expect(contractResponseSchema.safeParse(VALID_CONTRACT).success).toBe(true);
+  });
+
+  it.each(['id', 'title', 'clientId', 'freelancerId', 'amount', 'status', 'createdAt', 'version'])(
+    'rejects a contract missing %s',
+    (field) => {
+      const { [field]: _omitted, ...rest } = VALID_CONTRACT as Record<string, unknown>;
+      expect(contractResponseSchema.safeParse(rest).success).toBe(false);
+    },
+  );
+
+  it('rejects an invalid status enum value', () => {
+    const result = contractResponseSchema.safeParse({ ...VALID_CONTRACT, status: 'PENDING' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a non-numeric amount', () => {
+    const result = contractResponseSchema.safeParse({ ...VALID_CONTRACT, amount: '2000' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an unrecognized extra field', () => {
+    const result = contractResponseSchema.safeParse({ ...VALID_CONTRACT, extra: 'nope' });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((issue) => issue.code === 'unrecognized_keys')).toBe(true);
+    }
+  });
+});
+
+describe('contractListResponseSchema', () => {
+  it('accepts an empty list', () => {
+    expect(contractListResponseSchema.safeParse([]).success).toBe(true);
+  });
+
+  it('accepts a list of valid contracts', () => {
+    expect(
+      contractListResponseSchema.safeParse([VALID_CONTRACT, { ...VALID_CONTRACT, id: 'contract-2' }]).success,
+    ).toBe(true);
+  });
+
+  it('rejects a list containing one invalid contract', () => {
+    const result = contractListResponseSchema.safeParse([VALID_CONTRACT, { id: 'only-id' }]);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('contractStatsResponseSchema', () => {
+  const VALID_STATS = { total: 5, totalBudget: 12_000, byStatus: { active: 3, draft: 2 } };
+
+  it('accepts valid stats', () => {
+    expect(contractStatsResponseSchema.safeParse(VALID_STATS).success).toBe(true);
+  });
+
+  it('accepts an empty byStatus map', () => {
+    expect(
+      contractStatsResponseSchema.safeParse({ total: 0, totalBudget: 0, byStatus: {} }).success,
+    ).toBe(true);
+  });
+
+  it('rejects a negative total', () => {
+    expect(
+      contractStatsResponseSchema.safeParse({ ...VALID_STATS, total: -1 }).success,
+    ).toBe(false);
+  });
+
+  it('rejects a non-numeric byStatus count', () => {
+    const result = contractStatsResponseSchema.safeParse({
+      ...VALID_STATS,
+      byStatus: { active: 'three' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an unrecognized extra field', () => {
+    expect(
+      contractStatsResponseSchema.safeParse({ ...VALID_STATS, extra: 1 }).success,
+    ).toBe(false);
+  });
+});
+
+describe('contractBoundsResponseSchema', () => {
+  it('accepts valid bounds', () => {
+    expect(
+      contractBoundsResponseSchema.safeParse({
+        maxMilestonesPerContract: 20,
+        maxContractAmountStroops: 100_000_000_000_000,
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects a zero or negative bound', () => {
+    expect(
+      contractBoundsResponseSchema.safeParse({
+        maxMilestonesPerContract: 0,
+        maxContractAmountStroops: 100,
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects a missing field', () => {
+    expect(
+      contractBoundsResponseSchema.safeParse({ maxMilestonesPerContract: 20 }).success,
+    ).toBe(false);
+  });
+});
+
+describe('deleteContractResponseSchema', () => {
+  it('accepts a valid delete confirmation message', () => {
+    expect(
+      deleteContractResponseSchema.safeParse({ message: 'Contract deleted successfully' }).success,
+    ).toBe(true);
+  });
+
+  it('rejects a non-string message', () => {
+    expect(deleteContractResponseSchema.safeParse({ message: 123 }).success).toBe(false);
+  });
+
+  it('rejects a missing message', () => {
+    expect(deleteContractResponseSchema.safeParse({}).success).toBe(false);
+  });
+});
+
+describe('assertResponseSchema', () => {
+  it('returns the parsed data when it matches the schema', () => {
+    const result = assertResponseSchema(contractResponseSchema, VALID_CONTRACT, 'Contract');
+    expect(result).toEqual(VALID_CONTRACT);
+  });
+
+  it('throws a ResponseContractError when data fails the schema', () => {
+    expect(() =>
+      assertResponseSchema(contractResponseSchema, { id: 'only-id' }, 'Contract'),
+    ).toThrow(ResponseContractError);
+  });
+
+  it('includes the context label and field detail in the thrown error message', () => {
+    try {
+      assertResponseSchema(contractResponseSchema, { id: 'only-id' }, 'Contract');
+      throw new Error('expected assertResponseSchema to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(ResponseContractError);
+      expect((error as ResponseContractError).message).toContain('Contract response failed schema validation');
+    }
+  });
+
+  it('never exposes the raw validation detail to API clients (expose: false)', () => {
+    let caught: ResponseContractError | undefined;
+    try {
+      assertResponseSchema(contractResponseSchema, { id: 'only-id' }, 'Contract');
+    } catch (error) {
+      caught = error as ResponseContractError;
+    }
+    expect(caught?.expose).toBe(false);
+    expect(caught?.statusCode).toBe(500);
+    expect(caught?.code).toBe('response_contract_error');
+  });
+});

--- a/src/modules/contracts/dto/contract-response.dto.ts
+++ b/src/modules/contracts/dto/contract-response.dto.ts
@@ -1,0 +1,95 @@
+import { z, ZodTypeAny } from 'zod';
+import { registry } from '../../../docs/openapi-registry';
+import { ResponseContractError } from '../../../errors/appError';
+
+// ─── Response schemas ──────────────────────────────────────────────────────
+//
+// These mirror the transport DTOs in `contracts-boundary.dto.ts` and the
+// service-layer return shapes in `contracts.service.ts`. They are validated
+// at the boundary (see `assertResponseSchema` below) immediately before a
+// payload is handed to `ok()`, so a persistence or service bug that drifts
+// the outgoing shape away from the public contract fails loudly (500) rather
+// than silently changing the API's public surface.
+
+const contractStatusEnum = z.enum([
+  'draft',
+  'active',
+  'completed',
+  'cancelled',
+  'disputed',
+]);
+
+/** Response shape for a single contract, as returned by create/update/get. */
+export const contractResponseSchema = z
+  .object({
+    id: z.string().min(1),
+    title: z.string(),
+    clientId: z.string(),
+    freelancerId: z.string(),
+    amount: z.number(),
+    status: contractStatusEnum,
+    createdAt: z.string(),
+    version: z.number().int(),
+  })
+  .strict();
+
+/** Response shape for GET /api/v1/contracts (list of contracts). */
+export const contractListResponseSchema = z.array(contractResponseSchema);
+
+/** Response shape for GET /api/v1/contracts/stats. */
+export const contractStatsResponseSchema = z
+  .object({
+    total: z.number().int().nonnegative(),
+    totalBudget: z.number(),
+    byStatus: z.record(z.string(), z.number().int().nonnegative()),
+  })
+  .strict();
+
+/** Response shape for GET /api/v1/contracts/bounds. */
+export const contractBoundsResponseSchema = z
+  .object({
+    maxMilestonesPerContract: z.number().int().positive(),
+    maxContractAmountStroops: z.number().positive(),
+  })
+  .strict();
+
+/** Response shape for DELETE /api/v1/contracts/:id. */
+export const deleteContractResponseSchema = z
+  .object({
+    message: z.string(),
+  })
+  .strict();
+
+registry.register('ContractResponse', contractResponseSchema);
+
+export type ContractResponse = z.infer<typeof contractResponseSchema>;
+export type ContractStatsResponse = z.infer<typeof contractStatsResponseSchema>;
+export type ContractBoundsResponse = z.infer<typeof contractBoundsResponseSchema>;
+export type DeleteContractResponse = z.infer<typeof deleteContractResponseSchema>;
+
+// ─── Boundary assertion helper ─────────────────────────────────────────────
+
+/**
+ * Parses `data` against `schema`, returning the validated value.
+ *
+ * Throws a {@link ResponseContractError} (mapped to a 500 with no internal
+ * detail exposed to the client) when `data` does not match `schema`. Callers
+ * pass a short `context` label (e.g. `'Contract'`) used only in the
+ * server-side log message.
+ */
+export function assertResponseSchema<T>(
+  schema: ZodTypeAny,
+  data: unknown,
+  context: string,
+): T {
+  const result = schema.safeParse(data);
+  if (!result.success) {
+    const detail = result.error.issues
+      .map((issue) => `${issue.path.join('.') || '<root>'} ${issue.message}`)
+      .join('; ');
+    throw new ResponseContractError(
+      `${context} response failed schema validation: ${detail}`,
+    );
+  }
+  return result.data as T;
+}

--- a/src/modules/contracts/dto/contract.dto.ts
+++ b/src/modules/contracts/dto/contract.dto.ts
@@ -80,7 +80,8 @@ const createMilestoneSchema = z
 /**
  * Milestone sub-schema used inside updateContractSchema.
  * description is required (not optional) to keep create/update consistent.
- * .strip() drops unknown keys silently.
+ * `.strict()` rejects unknown keys rather than silently dropping them —
+ * consistent with the body-level `.strict()` on updateContractBodySchema.
  */
 const updateMilestoneSchema = z
   .object({
@@ -99,36 +100,7 @@ const updateMilestoneSchema = z
     deadline: datetimeField.optional(),
     completed: z.boolean().default(false),
   })
-  .strip();
-
-// Update contract schema with partial fields for PATCH and OCC version.
-// `.strict()` on both the body and each milestone rejects unrecognized
-// fields (400 validation_error) instead of silently dropping them — this is
-// the write path used to initiate/resolve disputes via `status`.
-// Milestone *count* is intentionally left unbounded here: it's enforced by
-// `validateContractBounds` in the service layer, which returns a 422
-// contract_bounds_error — an established, separately-tested contract this
-// schema must not shadow with an earlier 400.
-export const updateContractSchema = z.object({
-  body: z.object({
-    version: z.number().int().min(0),
-    title: z.string().min(5).max(100).optional(),
-    description: z.string().min(10).max(1000).optional(),
-    freelancerId: z.string().uuid().nullable().optional(),
-    clientId: z.string().uuid().optional(),
-    budget: z.number().positive().max(MAX_CONTRACT_AMOUNT_STROOPS).optional(),
-    deadline: z.string().datetime().nullable().optional(),
-    status: z.enum(['draft', 'active', 'completed', 'cancelled', 'disputed']).optional(),
-    terms: z.string().max(MAX_CONTRACT_TERMS_LENGTH).nullable().optional(),
-    milestones: z.array(z.object({
-      title: z.string().min(1).max(100),
-      description: z.string().min(1).max(500),
-      amount: z.number().positive().max(MAX_CONTRACT_AMOUNT_STROOPS),
-      deadline: z.string().datetime().optional(),
-      completed: z.boolean().default(false),
-    }).strict()).optional(),
-  }).strict(),
-});
+  .strict();
 
 /**
  * Schema for the body of POST /api/v1/contracts.
@@ -187,7 +159,15 @@ export const createContractSchema = z
  * Schema for the body of PATCH /api/v1/contracts/:id.
  *
  * All fields are optional except `version` (OCC requirement).
- * `.strip()` silently drops undeclared keys.
+ *
+ * `.strict()` on both this body and each milestone rejects unrecognized
+ * fields (400 validation_error) instead of silently dropping them — this is
+ * the write path used to initiate/resolve disputes via `status`, so a typo'd
+ * or unexpected field should surface as an error rather than be ignored.
+ * Milestone *count* is intentionally left unbounded here: it's enforced by
+ * `validateContractBounds` in the service layer, which returns a 422
+ * contract_bounds_error — an established, separately-tested contract this
+ * schema must not shadow with an earlier 400.
  */
 const updateContractBodySchema = z
   .object({
@@ -234,7 +214,7 @@ const updateContractBodySchema = z
       .optional(),
     milestones: z.array(updateMilestoneSchema).optional(),
   })
-  .strip();
+  .strict();
 
 export const updateContractSchema = z
   .object({

--- a/src/modules/contracts/dto/contracts-boundary.dto.test.ts
+++ b/src/modules/contracts/dto/contracts-boundary.dto.test.ts
@@ -1,4 +1,5 @@
 import type { Contract } from '../../../db/types';
+import { ResponseContractError } from '../../../errors/appError';
 import {
   CreateContractRequestDto,
   UpdateContractRequestDto,
@@ -106,5 +107,42 @@ describe('contracts boundary DTO mappings', () => {
 
   it('omits every missing optional update field', () => {
     expect(toUpdateContractDto({ version: 4 })).toEqual({ version: 4 });
+  });
+
+  it('throws a ResponseContractError when the domain record is missing a required field', () => {
+    // Simulates a corrupted/incomplete persistence record reaching the
+    // boundary mapper — this must fail loudly (500) rather than silently
+    // return a malformed public payload.
+    const malformedContract = {
+      id: 'contract-1',
+      title: 'Build a typed boundary',
+      clientId: 'client-1',
+      // freelancerId missing
+      amount: 2_000,
+      status: 'active',
+      createdAt: '2026-07-25T10:00:00.000Z',
+      version: 3,
+    } as unknown as Contract;
+
+    expect(() => toContractResponseDto(malformedContract)).toThrow(
+      ResponseContractError,
+    );
+  });
+
+  it('throws a ResponseContractError when the domain record has an invalid status', () => {
+    const malformedContract = {
+      id: 'contract-1',
+      title: 'Build a typed boundary',
+      clientId: 'client-1',
+      freelancerId: 'freelancer-1',
+      amount: 2_000,
+      status: 'PENDING',
+      createdAt: '2026-07-25T10:00:00.000Z',
+      version: 3,
+    } as unknown as Contract;
+
+    expect(() => toContractResponseDto(malformedContract)).toThrow(
+      ResponseContractError,
+    );
   });
 });

--- a/src/modules/contracts/dto/contracts-boundary.dto.ts
+++ b/src/modules/contracts/dto/contracts-boundary.dto.ts
@@ -3,6 +3,7 @@ import type {
   CreateContractDto,
   UpdateContractDto,
 } from './contract.dto';
+import { assertResponseSchema, contractResponseSchema } from './contract-response.dto';
 
 export interface ContractMilestoneDto {
   title: string;
@@ -99,18 +100,29 @@ export function toUpdateContractDto(
   };
 }
 
-/** Maps a persistence model into the stable public contract representation. */
+/**
+ * Maps a persistence model into the stable public contract representation.
+ *
+ * The mapped payload is validated against `contractResponseSchema` before
+ * being returned, so a persistence-layer bug that drifts the domain shape
+ * away from the public contract fails as a structured `response_contract_error`
+ * (500) instead of silently changing the API's outgoing shape.
+ */
 export function toContractResponseDto(contract: Contract): ContractResponseDto {
-  return {
-    id: contract.id,
-    title: contract.title,
-    clientId: contract.clientId,
-    freelancerId: contract.freelancerId,
-    amount: contract.amount,
-    status: contract.status,
-    createdAt: contract.createdAt,
-    version: contract.version,
-  };
+  return assertResponseSchema<ContractResponseDto>(
+    contractResponseSchema,
+    {
+      id: contract.id,
+      title: contract.title,
+      clientId: contract.clientId,
+      freelancerId: contract.freelancerId,
+      amount: contract.amount,
+      status: contract.status,
+      createdAt: contract.createdAt,
+      version: contract.version,
+    },
+    'Contract',
+  );
 }
 
 /**


### PR DESCRIPTION
Closes #919

## Summary

Contracts request payloads already had declarative Zod schemas (`createContractSchema`, `updateContractSchema`, `contractIdParamSchema`, `contractQuerySchema`) validated at the boundary via `validateSchema` middleware. What was missing was the **response** half of the issue: response payloads were plain TypeScript interfaces with no runtime check, so a persistence/service bug could silently drift the outgoing shape away from the public API contract.

This PR:

- Adds Zod **response** schemas for every contracts payload shape (`src/modules/contracts/dto/contract-response.dto.ts`): single contract, list, stats, bounds, and the delete-confirmation message.
- Validates every outgoing contracts response against its schema at the mapping boundary (`toContractResponseDto`, and directly in the controller for stats/bounds/delete), via a new `assertResponseSchema()` helper.
- On mismatch, throws a new `ResponseContractError` (500, `response_contract_error`, `expose: false`) — a structured error that never leaks the raw validation detail to clients, logged server-side for diagnosis. Behavior for valid payloads is unchanged.
- Fixes a real, pre-existing bug found in the process: `contract.dto.ts` declared `export const updateContractSchema` **twice**. Because TypeScript compiles `export const X` to a plain `exports.X = ...` assignment (not a block-scoped `const`), this wasn't a duplicate-identifier error — the second (`.strip()`-based) declaration silently won at runtime, permanently shadowing the first (`.strict()`-based) one. In production this meant `PATCH /api/v1/contracts/:id` was silently **stripping** unknown fields instead of **rejecting** them, contradicting both the code's own documented rationale and this issue's "reject invalid payloads with structured errors" requirement. Consolidated into one schema using `.strict()` (body + nested milestones), matching the documented intent.
- Fixes a pre-existing merge-conflict corruption in `contracts.integration.test.ts` that left mismatched braces (a wrongly-nested `it()`, an unrelated test spliced into another test's body, and an unclosed outer `describe`), which caused `npm run lint` / `tsc` to fail to parse the file at all. Restored valid structure and updated the two tests whose expectations no longer matched the corrected, documented behavior.

## Why the response side matters

`toContractResponseDto()` is the single mapping function every contracts response (`GET`, `POST`, `PATCH`, and the list endpoint) goes through. It now asserts its own output against `contractResponseSchema` before returning, so any drift between the domain model and the public contract fails loudly (500) instead of shipping a malformed payload.

## Test coverage added

- `contract-response.dto.test.ts` (new): valid/invalid cases for every response schema (missing fields, wrong types, invalid enum values, unrecognized extra fields via `.strict()`), plus dedicated coverage of `assertResponseSchema()` — returns parsed data on success, throws `ResponseContractError` on failure, never exposes raw detail (`expose: false`, `statusCode: 500`, `code: 'response_contract_error'`).
- `contracts-boundary.dto.test.ts`: two new cases proving `toContractResponseDto()` throws `ResponseContractError` when handed a domain record missing a required field or with an invalid `status` — simulating a corrupted persistence record reaching the boundary.
- `contracts.controller.test.ts` / `contracts.controller.di.test.ts`: updated fixtures from partial stubs (e.g. `{ id, title }`, `{ id, status: 'PENDING' }`) to fully-populated, schema-valid `Contract` shapes, since these tests now exercise real response validation rather than an unchecked passthrough.
- `contract.dto.test.ts`: the two "rejects an unrecognized field" cases (top-level and nested-in-milestone) now pass — they were failing before this PR due to the duplicate-schema bug above.

## Test output

`src/modules/contracts/` (all DTO + validation-middleware suites):
```
Test Suites: 4 passed, 4 total
Tests:       75 passed, 75 total
```

`contracts.controller.di.test.ts`:
```
Test Suites: 1 passed, 1 total
Tests:       13 passed, 13 total
```

Full repo suite, before vs. after this branch (verified via a clean `main` worktree):

| | main (baseline) | this branch |
|---|---|---|
| Test Suites | 13 failed, 160 passed, 173 total | 11 failed, 163 passed, 174 total |
| Tests | 61 failed, 3696 passed, 3757 total | 56 failed, 3734 passed, 3790 total |

No new failing suites were introduced — every suite that fails on this branch also failed on `main`. Two suites that were failing on `main` (`modules/contracts/dto/contract.dto.test.ts`, `modules/contracts/validation.middleware.test.ts`) are now fully green.

`npm run lint`: pre-existing on `main`, 7 parse errors block linting (`src/routes/health.ts`, `src/utils/webhookMetrics.test.ts`, and — until this PR — `src/controllers/contracts.integration.test.ts`, each from unrelated prior merges). This PR fixes the one in scope for contracts and reduces the count to 6; the remaining 2 are in unrelated modules (health check route, webhook metrics) and are out of scope here. All files touched by this PR lint clean (0 errors; 2 pre-existing warnings unrelated to these changes).

`npm run build`: also currently fails on `main` (`src/routes/health.ts(95,1): error TS1005: '}' expected`) — confirmed via `git stash` against the base commit, unrelated to and unaffected by this PR.

## Notes for reviewers

- Fixing the `contracts.integration.test.ts` parse error surfaced 5 pre-existing, unrelated failures for cursor-based pagination (`res.body.data.data`, `nextCursor`, `hasNextPage`) that were previously invisible because the whole file failed to compile. `ContractsController.getContracts` only implements page-based pagination — the cursor-based response shape these tests expect isn't implemented anywhere in the controller (same gap is visible as `getContractsCursor is not a function` in `contracts.controller.test.ts` on `main`, prior to this branch). That's a separate, larger feature gap and out of scope for this schema-validation PR.
- The `health.ts` and `webhookMetrics.test.ts` parse errors are unrelated modules and were left untouched to keep this PR's blast radius scoped to contracts.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
