### PR TITLE
test(milestones): snapshot error bodies

### DIFF
--- a/src/controllers/__tests__/__snapshots__/milestones-error-snapshots.test.ts.snap
+++ b/src/controllers/__tests__/__snapshots__/milestones-error-snapshots.test.ts.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`milestones error-response snapshots 400 validation error shape 1`] = `
+{
+  "error": {
+    "code": "validation_error",
+    "details": [
+      {
+        "code": "invalid_type",
+        "message": "Expected number, received string",
+        "path": [
+          "milestones",
+          "0",
+          "amount",
+        ],
+      },
+    ],
+    "message": "Request validation failed",
+    "requestId": "req-m-001",
+  },
+}
+`;
+
+exports[`milestones error-response snapshots 404 not-found error shape 1`] = `
+{
+  "error": {
+    "code": "not_found",
+    "message": "Milestone not found",
+    "requestId": "req-m-002",
+  },
+}
+`;
+
+exports[`milestones error-response snapshots 409 conflict error shape 1`] = `
+{
+  "error": {
+    "code": "conflict",
+    "message": "Milestone already approved and cannot be modified",
+    "requestId": "req-m-003",
+  },
+}
+`;
+
+exports[`milestones error-response snapshots 500 internal-server-error shape 1`] = `
+{
+  "error": {
+    "code": "internal_error",
+    "message": "An unexpected error occurred",
+    "requestId": "req-m-004",
+  },
+}
+`;

--- a/src/controllers/__tests__/milestones-error-snapshots.test.ts
+++ b/src/controllers/__tests__/milestones-error-snapshots.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  NotFoundError,
+  ValidationError,
+  ConflictError,
+  mapErrorToPayload,
+} from '../../errors/appError';
+import { ZodError } from 'zod';
+
+/**
+ * Snapshot tests for milestones error-response bodies (RFC 7807 / structured shape).
+ *
+ * These tests lock the shape of error payloads so that unintended drift
+ * is caught during code review.  Update the snapshots intentionally when
+ * the API contract changes.
+ */
+describe('milestones error-response snapshots', () => {
+  it('400 validation error shape', () => {
+    const zodError = new ZodError([
+      {
+        code: 'invalid_type',
+        expected: 'number',
+        received: 'string',
+        path: ['milestones', 0, 'amount'],
+        message: 'Expected number, received string',
+      },
+    ]);
+    const { payload } = mapErrorToPayload(zodError, 'req-m-001');
+    expect(payload).toMatchSnapshot();
+  });
+
+  it('404 not-found error shape', () => {
+    const err = new NotFoundError('Milestone not found');
+    const { payload } = mapErrorToPayload(err, 'req-m-002');
+    expect(payload).toMatchSnapshot();
+  });
+
+  it('409 conflict error shape', () => {
+    const err = new ConflictError('Milestone already approved and cannot be modified');
+    const { payload } = mapErrorToPayload(err, 'req-m-003');
+    expect(payload).toMatchSnapshot();
+  });
+
+  it('500 internal-server-error shape', () => {
+    const err = new Error('Unexpected database failure');
+    const { payload } = mapErrorToPayload(err, 'req-m-004');
+    expect(payload).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Overview\nThis PR adds snapshot tests for milestones error-response bodies to lock the RFC 7807 / structured shape so it cannot drift unintentionally.\n\n## Related Issue\nCloses #983\n\n## Changes\n[ADD] src/controllers/__tests__/milestones-error-snapshots.test.ts - Snapshot tests for 400/404/409/500 error shapes\n[ADD] src/controllers/__tests__/__snapshots__/milestones-error-snapshots.test.ts.snap - Auto-generated snapshots\n\n## Verification Results\n"""\nnpx jest src/controllers/__tests__/milestones-error-snapshots.test.ts --no-coverage\n✓ 4 passed, 4 total\nSnapshots: 4 written, 4 total\n"""\n\n## Acceptance Criteria\n| Requirement | Status |\n|---|---|\n| Snapshot tests for milestones error responses | ✅ |\n| Cover 400/404/409/500 shapes | ✅ |\n| RFC 7807 / structured shape locked | ✅ |