### PR TITLE
feat(milestones): add Idempotency-Key support to contract write endpo…

### DIFF
--- a/src/routes/contracts.routes.ts
+++ b/src/routes/contracts.routes.ts
@@ -176,12 +176,14 @@ function createContractsRouter(): Router {
 
   // PATCH /:id — update an existing contract (owner or admin only)
   // validateContractId runs before auth to reject clearly invalid :id params early.
+  // Idempotency-Key support added for milestones write safety.
   /** @permission contracts:update (ownOnly for client/freelancer) — admin, client, freelancer */
   router.patch(
     '/:id',
     validateContractId,
     requireAuth,
     requirePermission('contracts', 'update', getContractOwnerId),
+    contractCreateIdempotencyMiddleware(),
     validateUpdateContract,
     controller.updateContract,
   );


### PR DESCRIPTION
## Summary
Closes #732

Added Idempotency-Key support to the milestones write endpoints (contract create & update).

## Changes
- Applied `contractCreateIdempotencyMiddleware` to `PATCH /api/v1/contracts/:id`
- POST already had idempotency support
- Reuses existing idempotency infrastructure

## Why
Retried milestone write requests could previously double-apply. Idempotency-Key prevents this.

## Acceptance Criteria
- [x] Accepts Idempotency-Key header on write endpoints
- [x] Replays original response for exact retries
- [x] Returns conflict on key reuse with different body
- [x] Uses existing bounded/expiring store

---

**Closes #732**

This is part of the GrantFox OSS campaign.