### PR TITLE
feat(reputation): add metrics and structured logging

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -118,6 +118,9 @@ The `/metrics` endpoint exports the following metric families:
 |-------------|------|-------------|---------------|
 | `http_requests_total` | Counter | Total number of HTTP requests | `metrics-service.ts` |
 | `http_request_duration_seconds` | Histogram | Duration of HTTP requests in seconds | `metrics-service.ts` |
+| `reputation_requests_total` | Counter | Reputation requests by operation, status, HTTP status code, and bounded error cause | `metrics-service.ts` |
+| `reputation_request_duration_seconds` | Histogram | Reputation request duration by operation, status, HTTP status code, and bounded error cause | `metrics-service.ts` |
+| `reputation_errors_total` | Counter | Reputation errors by operation and bounded error cause | `metrics-service.ts` |
 | `service_health_status` | Gauge | Current service health status (2=up, 1=degraded, 0=down) | `metrics-service.ts` |
 | `webhook_deliveries_total` | Counter | Total webhook delivery attempts by outcome | `metrics-service.ts` |
 | `webhook_dlq_depth` | Gauge | Current number of entries in the webhook DLQ | `metrics-service.ts` |
@@ -130,6 +133,19 @@ The `/metrics` endpoint exports the following metric families:
 | `webhook_delivery_retries_total` | Counter | Total webhook delivery retries | `webhookMetrics.ts` |
 | `webhook_breaker_state` | Gauge | Circuit breaker state per provider (0=CLOSED, 1=OPEN, 2=HALF_OPEN) | `webhookMetrics.ts` |
 | `talenttrust_backend_*` | Various | Node.js runtime metrics (heap, CPU, GC, etc.) | `prom-client` |
+
+### Reputation observability labels
+
+Reputation metrics use only bounded values:
+
+- `operation`: `get_profile` or `create_rating`
+- `status`: `success`, `client_error`, or `server_error`
+- `error_cause`: `none`, a known HTTP cause such as `validation` or `authorization`, or `client_error`/`internal_error`
+- `status_code`: the numeric HTTP response code
+
+Request IDs, user IDs, request bodies, comments, headers, and raw exception
+messages are excluded from reputation metric labels and structured completion
+logs.
 
 For detailed information about each metric including labels, cardinality controls, and usage examples, see [Observability Metrics Catalog](./observability.md).
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -186,6 +186,12 @@ All label values on every exported series originate exclusively from one of thes
 - Timestamps or sequence numbers
 - Any unbounded runtime strings
 
+Reputation instrumentation follows the same rule. Its labels are limited to the
+two operation names, three status classes, HTTP status codes, and a finite error
+cause enumeration. Its structured completion event is `reputation_request` and
+contains method, operation, status, status code, error cause, and duration only;
+the request path and body are intentionally absent.
+
 ---
 
 ## Exported Metrics Catalog
@@ -196,6 +202,9 @@ All label values on every exported series originate exclusively from one of thes
 |-------------|------|--------|------|-------------|---------------|-------------------|
 | `http_requests_total` | Counter | `method`, `route`, `status_code` | total (dimensionless count) | Total number of HTTP requests. | `src/observability/metrics-service.ts` | N/A |
 | `http_request_duration_seconds` | Histogram | `method`, `route`, `status_code` | seconds | Duration of HTTP requests in seconds. Measures end-to-end request latency. | `src/observability/metrics-service.ts` | `0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, +Inf` |
+| `reputation_requests_total` | Counter | `operation`, `status`, `status_code`, `error_cause` | total (dimensionless count) | Reputation endpoint requests classified into success, client error, or server error with bounded causes. | `src/observability/metrics-service.ts` | N/A |
+| `reputation_request_duration_seconds` | Histogram | `operation`, `status`, `status_code`, `error_cause` | seconds | End-to-end reputation endpoint request duration. | `src/observability/metrics-service.ts` | `0.005, 0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, +Inf` |
+| `reputation_errors_total` | Counter | `operation`, `error_cause` | total (dimensionless count) | Reputation endpoint errors grouped by bounded cause. | `src/observability/metrics-service.ts` | N/A |
 | `service_health_status` | Gauge | `service` | dimensionless (encoded: `2=up`, `1=degraded`, `0=down`) | Current service health status based on runtime signals and dependency checks. See Health Status section for encoding details. | `src/observability/health-service.ts` | N/A |
 | `webhook_deliveries_total` | Counter | `outcome` | total (dimensionless count) | Total webhook delivery attempts by outcome. Possible outcomes: `success`, `failure`, `dlq`. Incremented by MetricsService. | `src/observability/metrics-service.ts` | N/A |
 | `webhook_dlq_depth` | Gauge | (no labels) | entries | Current number of entries in the webhook dead-letter queue. Represents absolute count, not a delta. Set by MetricsService. | `src/observability/metrics-service.ts` | N/A |

--- a/docs/reputation.md
+++ b/docs/reputation.md
@@ -600,6 +600,22 @@ The following guards are applied (in order) on every `PUT` request:
 
 ---
 
+## Observability
+
+Every `GET` and `PUT` reputation request emits:
+
+- `reputation_requests_total` with bounded operation, status, status-code, and error-cause labels
+- `reputation_request_duration_seconds` with the same bounded labels
+- `reputation_errors_total` for client and server failures
+- A structured `reputation_request` completion log with method, operation, status, status code, error cause, and duration
+
+The instrumentation runs before authentication and validation, so `401`, `403`,
+and `400` failures are included. It never logs or labels freelancer IDs,
+reviewer IDs, comments, request bodies, headers, or raw exception messages.
+Metrics are available from the Prometheus scrape endpoint at `GET /metrics`.
+
+---
+
 ## Related docs
 
 - [`docs/backend/reputation-system.md`](./backend/reputation-system.md) — internal architecture, DB schema, anti-abuse design.

--- a/jest.config.js
+++ b/jest.config.js
@@ -70,6 +70,12 @@ module.exports = {
       functions: 95,
       statements: 95,
     },
+    './src/observability/reputation-observability.ts': {
+      lines: 95,
+      branches: 95,
+      functions: 95,
+      statements: 95,
+    },
     './src/observability/health-service.ts': {
       lines: 95,
       branches: 94,

--- a/src/app.ts
+++ b/src/app.ts
@@ -24,10 +24,10 @@ import { createRequestLimitsMiddleware } from './middleware/requestLimits';
 import contractsModuleRouter from './routes/contracts.routes';
 import eventsRouter from './routes/events.routes';
 import disputesRouter from './routes/disputes.routes';
-import { createMetricsRouter } from './routes/metrics.routes';
+import { createMetricsRouter, createMetricsScrapeHandler } from './routes/metrics.routes';
 import { metricsAuthMiddleware } from './middleware/metricsAuth';
 
-import reputationRouter from './routes/reputation.routes';
+import reputationRouter, { createReputationRouter } from './routes/reputation.routes';
 import apiKeysRouter from './routes/apiKeys.routes';
 import authRouter from './routes/auth.routes';
 import configRouter from './routes/config.routes';
@@ -95,12 +95,17 @@ export function createApp(options?: AppFactoryOptions): express.Application {
   app.use('/api/v1', apiKeysRouter);
   app.use('/api/v1/contracts', contractsModuleRouter);
   app.use('/api/v1/disputes', disputesRouter);
-  app.use('/api/v1/reputation', reputationRouter);
+  const configuredReputationRouter =
+    typeof createReputationRouter === 'function'
+      ? createReputationRouter({ metricsService })
+      : reputationRouter;
+  app.use('/api/v1/reputation', configuredReputationRouter);
   app.use('/api/v1/dependency-scan', dependencyScanRouter);
   app.use('/api/v1/admin', adminRouter);
   app.use('/api/v1/admin/deploy', deployRouter);
   app.use('/api/v1/webhook-subscriptions', webhookSubscriptionRouter);
   app.use('/api/v1/metrics', metricsAuthMiddleware, createMetricsRouter(metricsService));
+  app.get('/metrics', metricsAuthMiddleware, createMetricsScrapeHandler(metricsService));
 
   if (includeTerminalHandlers) {
     attachTerminalHandlers(app);

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -5,7 +5,20 @@ export {
   type HealthServiceLike,
   type RuntimeSignalProviders,
 } from './health-service';
-export { MetricsService, type MetricsServiceLike, type WebhookOutcome } from './metrics-service';
+export {
+  MetricsService,
+  type MetricsServiceLike,
+  type ReputationErrorCause,
+  type ReputationOperation,
+  type ReputationRequestMetric,
+  type ReputationRequestStatus,
+  type WebhookOutcome,
+} from './metrics-service';
+export {
+  classifyReputationResponse,
+  createReputationObservabilityMiddleware,
+  type ReputationObservabilityOptions,
+} from './reputation-observability';
 export {
   readObservabilityConfig,
   type ObservabilityConfig,
@@ -16,4 +29,3 @@ export type {
   HealthReport,
   ServiceStatus,
 } from './types';
-

--- a/src/observability/metrics-service.test.ts
+++ b/src/observability/metrics-service.test.ts
@@ -100,6 +100,161 @@ describe('MetricsService — webhook metrics', () => {
   });
 });
 
+describe('MetricsService — reputation metrics', () => {
+  it('records success status, duration, and no error cause', async () => {
+    const { service, register } = makeService();
+
+    service.recordReputationRequest({
+      operation: 'get_profile',
+      status: 'success',
+      statusCode: 200,
+      errorCause: 'none',
+      durationSeconds: 0.125,
+    });
+
+    const metrics = await register.getMetricsAsJSON();
+    const requestCounter = metrics.find((m) => m.name === 'reputation_requests_total');
+    const duration = metrics.find((m) => m.name === 'reputation_request_duration_seconds');
+    const errors = metrics.find((m) => m.name === 'reputation_errors_total');
+
+    expect(requestCounter).toBeDefined();
+    expect(requestCounter!.values).toContainEqual({
+      labels: {
+        operation: 'get_profile',
+        status: 'success',
+        status_code: '200',
+        error_cause: 'none',
+      },
+      value: 1,
+    });
+    expect(duration!.values).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          labels: {
+            operation: 'get_profile',
+            status: 'success',
+            status_code: '200',
+            error_cause: 'none',
+            le: '+Inf',
+          },
+        }),
+        expect.objectContaining({
+          labels: {
+            operation: 'get_profile',
+            status: 'success',
+            status_code: '200',
+            error_cause: 'none',
+          },
+          value: 0.125,
+        }),
+      ]),
+    );
+    expect(errors!.values).toEqual([]);
+  });
+
+  it.each([
+    ['client_error', 400, 'bad_request'],
+    ['server_error', 500, 'internal_error'],
+  ] as const)('records %s and increments the bounded error cause counter', async (status, statusCode, errorCause) => {
+    const { service, register } = makeService();
+
+    service.recordReputationRequest({
+      operation: 'create_rating',
+      status,
+      statusCode,
+      errorCause,
+      durationSeconds: 0.25,
+    });
+
+    const metrics = await register.getMetricsAsJSON();
+    const errors = metrics.find((m) => m.name === 'reputation_errors_total');
+    const errorValue = (errors!.values as any[]).find(
+      (value) =>
+        value.labels.operation === 'create_rating' &&
+        value.labels.error_cause === errorCause,
+    );
+
+    expect(errorValue?.value).toBe(1);
+  });
+
+  it('rejects invalid metric input before mutating the registry', () => {
+    const { service } = makeService();
+
+    expect(() =>
+      service.recordReputationRequest({
+        operation: 'unknown' as any,
+        status: 'success',
+        statusCode: 200,
+        errorCause: 'none',
+        durationSeconds: 0,
+      }),
+    ).toThrow('Invalid reputation operation');
+    expect(() =>
+      service.recordReputationRequest({
+        operation: 'get_profile',
+        status: 'unknown' as any,
+        statusCode: 200,
+        errorCause: 'none',
+        durationSeconds: 0,
+      }),
+    ).toThrow('Invalid reputation request status');
+    expect(() =>
+      service.recordReputationRequest({
+        operation: 'get_profile',
+        status: 'success',
+        statusCode: 200,
+        errorCause: 'database_message' as any,
+        durationSeconds: 0,
+      }),
+    ).toThrow('Invalid reputation error cause');
+    expect(() =>
+      service.recordReputationRequest({
+        operation: 'get_profile',
+        status: 'success',
+        statusCode: 200,
+        errorCause: 'none',
+        durationSeconds: -1,
+      }),
+    ).toThrow('Invalid reputation request duration');
+    expect(() =>
+      service.recordReputationRequest({
+        operation: 'get_profile',
+        status: 'success',
+        statusCode: 99,
+        errorCause: 'none',
+        durationSeconds: 0,
+      }),
+    ).toThrow('Invalid reputation status code');
+    expect(() =>
+      service.recordReputationRequest({
+        operation: 'get_profile',
+        status: 'server_error',
+        statusCode: 600,
+        errorCause: 'internal_error',
+        durationSeconds: 0,
+      }),
+    ).toThrow('Invalid reputation status code');
+    expect(() =>
+      service.recordReputationRequest({
+        operation: 'get_profile',
+        status: 'success',
+        statusCode: 200.5,
+        errorCause: 'none',
+        durationSeconds: 0,
+      }),
+    ).toThrow('Invalid reputation status code');
+    expect(() =>
+      service.recordReputationRequest({
+        operation: 'get_profile',
+        status: 'success',
+        statusCode: 200,
+        errorCause: 'none',
+        durationSeconds: Number.NaN,
+      }),
+    ).toThrow('Invalid reputation request duration');
+  });
+});
+
 describe('MetricsService — HTTP route labels', () => {
   it('uses the mounted Express route template instead of concrete paths', async () => {
     const { service, register } = makeService();

--- a/src/observability/metrics-service.ts
+++ b/src/observability/metrics-service.ts
@@ -31,6 +31,9 @@ export type WebhookOutcome = ValidatedWebhookOutcome;
 export const CATALOG_METRIC_NAMES: readonly string[] = [
   'http_requests_total',
   'http_request_duration_seconds',
+  'reputation_requests_total',
+  'reputation_request_duration_seconds',
+  'reputation_errors_total',
   'service_health_status',
   'webhook_deliveries_total',
   'webhook_dlq_depth',
@@ -38,10 +41,39 @@ export const CATALOG_METRIC_NAMES: readonly string[] = [
   'webhook_rate_limit_queue_depth',
 ] as const;
 
+export const REPUTATION_OPERATIONS = ['get_profile', 'create_rating'] as const;
+export type ReputationOperation = (typeof REPUTATION_OPERATIONS)[number];
+
+export const REPUTATION_STATUSES = ['success', 'client_error', 'server_error'] as const;
+export type ReputationRequestStatus = (typeof REPUTATION_STATUSES)[number];
+
+export const REPUTATION_ERROR_CAUSES = [
+  'none',
+  'bad_request',
+  'authentication',
+  'authorization',
+  'not_found',
+  'conflict',
+  'validation',
+  'rate_limit',
+  'client_error',
+  'internal_error',
+] as const;
+export type ReputationErrorCause = (typeof REPUTATION_ERROR_CAUSES)[number];
+
+export interface ReputationRequestMetric {
+  operation: ReputationOperation;
+  status: ReputationRequestStatus;
+  statusCode: number;
+  errorCause: ReputationErrorCause;
+  durationSeconds: number;
+}
+
 export interface MetricsServiceLike {
   contentType: string;
   trackHttpRequest: (req: Request, res: Response, next: NextFunction) => void;
   getMetrics: () => Promise<string>;
+  recordReputationRequest: (metric: ReputationRequestMetric) => void;
   recordHealthStatus: (status: ServiceStatus) => void;
   recordWebhookDelivery: (outcome: WebhookOutcome) => void;
   setWebhookDlqDepth: (depth: number) => void;
@@ -81,6 +113,12 @@ export class MetricsService implements MetricsServiceLike {
   private readonly httpRequestsTotal: Counter;
 
   private readonly httpRequestDurationSeconds: Histogram;
+
+  private readonly reputationRequestsTotal: Counter;
+
+  private readonly reputationRequestDurationSeconds: Histogram;
+
+  private readonly reputationErrorsTotal: Counter;
 
   private readonly serviceHealthStatus: Gauge;
 
@@ -127,6 +165,28 @@ export class MetricsService implements MetricsServiceLike {
       help: 'Duration of HTTP requests in seconds.',
       labelNames: ['method', 'route', 'status_code'],
       buckets: resolvedBuckets,
+      registers: [this.register],
+    });
+
+    this.reputationRequestsTotal = new Counter({
+      name: 'reputation_requests_total',
+      help: 'Total reputation endpoint requests by operation, status, and error cause.',
+      labelNames: ['operation', 'status', 'status_code', 'error_cause'],
+      registers: [this.register],
+    });
+
+    this.reputationRequestDurationSeconds = new Histogram({
+      name: 'reputation_request_duration_seconds',
+      help: 'Duration of reputation endpoint requests in seconds.',
+      labelNames: ['operation', 'status', 'status_code', 'error_cause'],
+      buckets: resolvedBuckets,
+      registers: [this.register],
+    });
+
+    this.reputationErrorsTotal = new Counter({
+      name: 'reputation_errors_total',
+      help: 'Total reputation endpoint errors by operation and error cause.',
+      labelNames: ['operation', 'error_cause'],
       registers: [this.register],
     });
 
@@ -234,6 +294,27 @@ export class MetricsService implements MetricsServiceLike {
     return this.register.metrics();
   }
 
+  recordReputationRequest(metric: ReputationRequestMetric): void {
+    assertReputationRequestMetric(metric);
+
+    const labels = {
+      operation: metric.operation,
+      status: metric.status,
+      status_code: String(metric.statusCode),
+      error_cause: metric.errorCause,
+    };
+
+    this.reputationRequestsTotal.inc(labels);
+    this.reputationRequestDurationSeconds.observe(labels, metric.durationSeconds);
+
+    if (metric.errorCause !== 'none') {
+      this.reputationErrorsTotal.inc({
+        operation: metric.operation,
+        error_cause: metric.errorCause,
+      });
+    }
+  }
+
   private boundRouteLabel(route: string): string {
     // Never collapse unmatched routes — they are not user-controlled and must
     // always be tracked separately so operators can monitor 404 rates.
@@ -251,6 +332,28 @@ export class MetricsService implements MetricsServiceLike {
     }
 
     return OTHER_ROUTE_LABEL;
+  }
+}
+
+function assertReputationRequestMetric(metric: ReputationRequestMetric): void {
+  if (!REPUTATION_OPERATIONS.includes(metric.operation)) {
+    throw new Error('Invalid reputation operation');
+  }
+
+  if (!REPUTATION_STATUSES.includes(metric.status)) {
+    throw new Error('Invalid reputation request status');
+  }
+
+  if (!REPUTATION_ERROR_CAUSES.includes(metric.errorCause)) {
+    throw new Error('Invalid reputation error cause');
+  }
+
+  if (!Number.isInteger(metric.statusCode) || metric.statusCode < 100 || metric.statusCode > 599) {
+    throw new Error('Invalid reputation status code');
+  }
+
+  if (!Number.isFinite(metric.durationSeconds) || metric.durationSeconds < 0) {
+    throw new Error('Invalid reputation request duration');
   }
 }
 
@@ -337,5 +440,4 @@ function joinRouteParts(baseUrl: string, routePath: string): string {
 
   return `${baseUrl}${routePath}`;
 }
-
 

--- a/src/observability/reputation-observability.test.ts
+++ b/src/observability/reputation-observability.test.ts
@@ -1,0 +1,254 @@
+import express from 'express';
+import request from 'supertest';
+import { Logger } from '../logger';
+import {
+  classifyReputationResponse,
+  createReputationObservabilityMiddleware,
+} from './reputation-observability';
+import { ReputationRequestMetric } from './metrics-service';
+
+type LogRecord = {
+  message: string;
+  fields: Record<string, unknown>;
+};
+
+function createLoggerSpy(): {
+  logger: Pick<Logger, 'info' | 'warn' | 'error'>;
+  records: LogRecord[];
+} {
+  const records: LogRecord[] = [];
+  const record = (message: string, fields: Record<string, unknown> = {}): void => {
+    records.push({ message, fields });
+  };
+
+  return {
+    logger: {
+      info: jest.fn(record),
+      warn: jest.fn(record),
+      error: jest.fn(record),
+    },
+    records,
+  };
+}
+
+function createMetricsSpy(
+  implementation?: (metric: ReputationRequestMetric) => void,
+): { recordReputationRequest: jest.Mock<void, [ReputationRequestMetric]> } {
+  return {
+    recordReputationRequest: jest.fn(implementation),
+  };
+}
+
+function buildApp(
+  metrics: { recordReputationRequest: jest.Mock<void, [ReputationRequestMetric]> },
+  logger: Pick<Logger, 'info' | 'warn' | 'error'>,
+): express.Application {
+  const app = express();
+  app.use(express.json());
+  app.use(createReputationObservabilityMiddleware({ metricsService: metrics, log: logger }));
+  app.get('/:id', (req, res) => {
+    if (req.query['failure'] === 'server') {
+      throw new Error('database details must not be logged');
+    }
+    res.status(200).json({ ok: true });
+  });
+  app.put('/:id', (_req, res) => {
+    res.status(400).json({ error: 'invalid rating' });
+  });
+  app.use((_error: unknown, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    res.status(500).json({ error: 'internal error' });
+  });
+  return app;
+}
+
+describe('classifyReputationResponse', () => {
+  it.each([
+    [200, { status: 'success', errorCause: 'none' }],
+    [302, { status: 'success', errorCause: 'none' }],
+    [400, { status: 'client_error', errorCause: 'bad_request' }],
+    [401, { status: 'client_error', errorCause: 'authentication' }],
+    [403, { status: 'client_error', errorCause: 'authorization' }],
+    [404, { status: 'client_error', errorCause: 'not_found' }],
+    [409, { status: 'client_error', errorCause: 'conflict' }],
+    [422, { status: 'client_error', errorCause: 'validation' }],
+    [429, { status: 'client_error', errorCause: 'rate_limit' }],
+    [418, { status: 'client_error', errorCause: 'client_error' }],
+    [500, { status: 'server_error', errorCause: 'internal_error' }],
+  ])('maps status %i to bounded observability labels', (statusCode, expected) => {
+    expect(classifyReputationResponse(statusCode)).toEqual(expected);
+  });
+});
+
+describe('createReputationObservabilityMiddleware', () => {
+  it('records and logs a successful GET without PII', async () => {
+    const metrics = createMetricsSpy();
+    const { logger, records } = createLoggerSpy();
+    const app = buildApp(metrics, logger);
+    const privateId = 'freelancer-private-123';
+
+    const response = await request(app)
+      .get(`/${privateId}`)
+      .query({ note: 'private@example.com' });
+
+    expect(response.status).toBe(200);
+    expect(metrics.recordReputationRequest).toHaveBeenCalledTimes(1);
+    expect(metrics.recordReputationRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operation: 'get_profile',
+        status: 'success',
+        statusCode: 200,
+        errorCause: 'none',
+        durationSeconds: expect.any(Number),
+      }),
+    );
+    expect(records).toContainEqual({
+      message: 'reputation_request',
+      fields: expect.objectContaining({
+        method: 'GET',
+        operation: 'get_profile',
+        status: 'success',
+        statusCode: 200,
+        errorCause: 'none',
+        durationMs: expect.any(Number),
+      }),
+    });
+    expect(JSON.stringify(records)).not.toContain(privateId);
+    expect(JSON.stringify(records)).not.toContain('private@example.com');
+  });
+
+  it('records a client error with a validation cause and warns', async () => {
+    const metrics = createMetricsSpy();
+    const { logger, records } = createLoggerSpy();
+    const response = await request(buildApp(metrics, logger))
+      .put('/freelancer-private-456')
+      .send({ reviewerId: 'client-private-789', comment: 'private@example.com' });
+
+    expect(response.status).toBe(400);
+    expect(metrics.recordReputationRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operation: 'create_rating',
+        status: 'client_error',
+        statusCode: 400,
+        errorCause: 'bad_request',
+      }),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      'reputation_request',
+      expect.objectContaining({
+        status: 'client_error',
+        errorCause: 'bad_request',
+      }),
+    );
+    expect(logger.info).not.toHaveBeenCalled();
+    expect(JSON.stringify(records)).not.toContain('freelancer-private-456');
+    expect(JSON.stringify(records)).not.toContain('client-private-789');
+    expect(JSON.stringify(records)).not.toContain('private@example.com');
+  });
+
+  it('records a server error and emits an error-level log', async () => {
+    const metrics = createMetricsSpy();
+    const { logger } = createLoggerSpy();
+    const response = await request(buildApp(metrics, logger))
+      .get('/freelancer-private-999')
+      .query({ failure: 'server' });
+
+    expect(response.status).toBe(500);
+    expect(metrics.recordReputationRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operation: 'get_profile',
+        status: 'server_error',
+        statusCode: 500,
+        errorCause: 'internal_error',
+      }),
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      'reputation_request',
+      expect.objectContaining({
+        status: 'server_error',
+        errorCause: 'internal_error',
+      }),
+    );
+  });
+
+  it('does not instrument unsupported HTTP methods', async () => {
+    const metrics = createMetricsSpy();
+    const { logger } = createLoggerSpy();
+    const app = buildApp(metrics, logger);
+    app.patch('/:id', (_req, res) => res.status(204).send());
+
+    const response = await request(app).patch('/private-id');
+
+    expect(response.status).toBe(204);
+    expect(metrics.recordReputationRequest).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('does not let a metrics failure alter the completed response', async () => {
+    const metrics = createMetricsSpy(() => {
+      throw new Error('registry unavailable');
+    });
+    const { logger } = createLoggerSpy();
+
+    const response = await request(buildApp(metrics, logger)).get('/private-id');
+
+    expect(response.status).toBe(200);
+    expect(logger.error).toHaveBeenCalledWith(
+      'reputation_metrics_recording_failed',
+      expect.objectContaining({
+        operation: 'get_profile',
+        status: 'success',
+        statusCode: 200,
+      }),
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      'reputation_request',
+      expect.objectContaining({ status: 'success' }),
+    );
+  });
+
+  it('uses the request-scoped logger when one is available', async () => {
+    const metrics = createMetricsSpy();
+    const fallback = createLoggerSpy();
+    const requestScoped = createLoggerSpy();
+    const app = express();
+    app.use((_req, res, next) => {
+      res.locals['log'] = requestScoped.logger;
+      next();
+    });
+    app.use(createReputationObservabilityMiddleware({
+      metricsService: metrics,
+      log: fallback.logger,
+    }));
+    app.get('/:id', (_req, res) => res.status(200).send());
+
+    const response = await request(app).get('/private-id');
+
+    expect(response.status).toBe(200);
+    expect(requestScoped.logger.info).toHaveBeenCalledWith(
+      'reputation_request',
+      expect.objectContaining({ operation: 'get_profile' }),
+    );
+    expect(fallback.logger.info).not.toHaveBeenCalled();
+  });
+
+  it('supports logging without a metrics recorder', async () => {
+    const infoSpy = jest.spyOn(Logger.prototype, 'info').mockImplementation(() => {});
+    const app = express();
+    app.use(createReputationObservabilityMiddleware());
+    app.get('/:id', (_req, res) => res.status(200).send());
+
+    try {
+      const response = await request(app).get('/private-id');
+
+      expect(response.status).toBe(200);
+      expect(infoSpy).toHaveBeenCalledWith(
+        'reputation_request',
+        expect.objectContaining({ status: 'success' }),
+      );
+    } finally {
+      infoSpy.mockRestore();
+    }
+  });
+});

--- a/src/observability/reputation-observability.ts
+++ b/src/observability/reputation-observability.ts
@@ -1,0 +1,123 @@
+import { NextFunction, Request, Response } from 'express';
+import { Logger, logger as rootLogger } from '../logger';
+import {
+  MetricsServiceLike,
+  ReputationErrorCause,
+  ReputationOperation,
+  ReputationRequestMetric,
+  ReputationRequestStatus,
+} from './metrics-service';
+
+export interface ReputationObservabilityOptions {
+  metricsService?: Pick<MetricsServiceLike, 'recordReputationRequest'>;
+  log?: Pick<Logger, 'info' | 'warn' | 'error'>;
+}
+
+export interface ReputationResponseClassification {
+  status: ReputationRequestStatus;
+  errorCause: ReputationErrorCause;
+}
+
+const OPERATION_BY_METHOD: Partial<Record<string, ReputationOperation>> = {
+  GET: 'get_profile',
+  PUT: 'create_rating',
+};
+
+/**
+ * Instruments reputation requests without using request-controlled values as
+ * metric labels or log fields. Authentication and validation are intentionally
+ * observed because the middleware runs before the router's auth guard.
+ */
+export function createReputationObservabilityMiddleware(
+  options: ReputationObservabilityOptions = {},
+) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const operation = OPERATION_BY_METHOD[req.method];
+    if (!operation) {
+      next();
+      return;
+    }
+
+    const start = process.hrtime.bigint();
+
+    res.once('finish', () => {
+      const durationSeconds = Number(process.hrtime.bigint() - start) / 1_000_000_000;
+      const classification = classifyReputationResponse(res.statusCode);
+      const metric: ReputationRequestMetric = {
+        operation,
+        status: classification.status,
+        statusCode: res.statusCode,
+        errorCause: classification.errorCause,
+        durationSeconds,
+      };
+
+      const log = resolveLogger(res, options.log);
+      const logFields = {
+        method: req.method,
+        operation,
+        status: classification.status,
+        statusCode: res.statusCode,
+        errorCause: classification.errorCause,
+        durationMs: Number((durationSeconds * 1000).toFixed(3)),
+      };
+
+      if (options.metricsService) {
+        try {
+          options.metricsService.recordReputationRequest(metric);
+        } catch {
+          // Telemetry must never change the completed endpoint response.
+          log.error('reputation_metrics_recording_failed', {
+            operation,
+            status: classification.status,
+            statusCode: res.statusCode,
+          });
+        }
+      }
+
+      if (classification.status === 'server_error') {
+        log.error('reputation_request', logFields);
+      } else if (classification.status === 'client_error') {
+        log.warn('reputation_request', logFields);
+      } else {
+        log.info('reputation_request', logFields);
+      }
+    });
+
+    next();
+  };
+}
+
+export function classifyReputationResponse(
+  statusCode: number,
+): ReputationResponseClassification {
+  if (statusCode >= 500) {
+    return { status: 'server_error', errorCause: 'internal_error' };
+  }
+
+  if (statusCode < 400) {
+    return { status: 'success', errorCause: 'none' };
+  }
+
+  const causeByStatus: Record<number, ReputationErrorCause> = {
+    400: 'bad_request',
+    401: 'authentication',
+    403: 'authorization',
+    404: 'not_found',
+    409: 'conflict',
+    422: 'validation',
+    429: 'rate_limit',
+  };
+
+  return {
+    status: 'client_error',
+    errorCause: causeByStatus[statusCode] ?? 'client_error',
+  };
+}
+
+function resolveLogger(
+  res: Response,
+  fallback?: Pick<Logger, 'info' | 'warn' | 'error'>,
+): Pick<Logger, 'info' | 'warn' | 'error'> {
+  const requestLogger = res.locals['log'] as Pick<Logger, 'info' | 'warn' | 'error'> | undefined;
+  return requestLogger ?? fallback ?? rootLogger;
+}

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -85,10 +85,4 @@ healthRouter.post('/', validateRequest(HealthWriteBodySchema), (_req: Request, r
     timestamp: new Date().toISOString(),
     version: process.env.npm_package_version ?? '0.1.0',
   });
-healthRouter.get('/', (_req: Request, res: Response) => {
-  res.status(200).json({ status: 'ok', service: 'talenttrust-backend' });
-});
-
-healthRouter.post("/", (_req: Request, res: Response) => {
-  sendHealthResponse(res);
 });

--- a/src/routes/metrics.routes.test.ts
+++ b/src/routes/metrics.routes.test.ts
@@ -26,7 +26,7 @@
 
 import express from 'express';
 import request from 'supertest';
-import { createMetricsRouter } from './metrics.routes';
+import { createMetricsRouter, createMetricsScrapeHandler } from './metrics.routes';
 import { MetricsServiceLike } from '../observability/metrics-service';
 import { metricsAuthMiddleware } from '../middleware/metricsAuth';
 import { WebhookOutcome } from '../observability/metrics-validation';
@@ -41,6 +41,7 @@ function buildMockService(overrides?: Partial<MetricsServiceLike>): jest.Mocked<
     contentType: 'text/plain',
     trackHttpRequest: jest.fn(),
     getMetrics: jest.fn().mockResolvedValue(''),
+    recordReputationRequest: jest.fn(),
     recordHealthStatus: jest.fn(),
     recordWebhookDelivery: jest.fn(),
     setWebhookDlqDepth: jest.fn(),
@@ -73,6 +74,49 @@ function buildAppWithAuth(service: MetricsServiceLike): express.Application {
   app.use('/api/v1/metrics', metricsAuthMiddleware, createMetricsRouter(service));
   return app;
 }
+
+describe('GET /api/v1/metrics', () => {
+  it('serves the shared Prometheus registry payload', async () => {
+    const svc = buildMockService({
+      contentType: 'text/plain; version=0.0.4',
+      getMetrics: jest.fn().mockResolvedValue('# HELP reputation_requests_total'),
+    });
+
+    const res = await request(buildApp(svc)).get('/api/v1/metrics');
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/plain');
+    expect(res.text).toContain('reputation_requests_total');
+    expect(svc.getMetrics).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes scrape failures to the terminal error handler', async () => {
+    const svc = buildMockService({
+      getMetrics: jest.fn().mockRejectedValue(new Error('registry unavailable')),
+    });
+
+    const res = await request(buildApp(svc, true)).get('/api/v1/metrics');
+
+    expect(res.status).toBe(500);
+    expect(res.body.error.code).toBe('internal_error');
+  });
+});
+
+describe('createMetricsScrapeHandler', () => {
+  it('can be mounted directly on the canonical /metrics route', async () => {
+    const svc = buildMockService({
+      contentType: 'text/plain; version=0.0.4',
+      getMetrics: jest.fn().mockResolvedValue('reputation_requests_total 1'),
+    });
+    const app = express();
+    app.get('/metrics', createMetricsScrapeHandler(svc));
+
+    const res = await request(app).get('/metrics');
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('reputation_requests_total 1');
+  });
+});
 
 // ---------------------------------------------------------------------------
 // POST /api/v1/metrics/webhook/delivery

--- a/src/routes/metrics.routes.ts
+++ b/src/routes/metrics.routes.ts
@@ -23,7 +23,7 @@
  *  - Numeric values are bounded to prevent gauge/counter corruption.
  */
 
-import { Router, Request, Response } from "express";
+import { NextFunction, Router, Request, Response } from "express";
 import {
   WebhookDeliveryInputSchema,
   WebhookDlqDepthInputSchema,
@@ -39,24 +39,6 @@ import {
 import { validateMetricsRequestBody } from "./metrics-validation-handler";
 
 /**
- * Format a validation failure into the project's standard error envelope.
- */
-function validationErrorResponse(
-  res: Response,
-  failure: MetricsValidationFailure,
-  requestId?: string,
-): Response {
-  return res.status(400).json({
-    error: {
-      code: failure.code,
-      message: "Request validation failed",
-      requestId: requestId ?? res.locals.requestId ?? "unknown",
-      details: failure.issues,
-    },
-  });
-}
-
-/**
  * Create the metrics write router.
  *
  * @param metricsService - The MetricsService instance used to record metrics.
@@ -66,6 +48,8 @@ export function createMetricsRouter(
   metricsService: MetricsServiceLike,
 ): Router {
   const router = Router();
+
+  router.get("/", createMetricsScrapeHandler(metricsService));
 
   /**
    * POST /api/v1/metrics/webhook/delivery
@@ -218,4 +202,21 @@ export function createMetricsRouter(
   });
 
   return router;
+}
+
+/**
+ * Serve the Prometheus scrape payload from the MetricsService registry.
+ */
+export function createMetricsScrapeHandler(
+  metricsService: Pick<MetricsServiceLike, "contentType" | "getMetrics">,
+) {
+  return async (_req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      const metrics = await metricsService.getMetrics();
+      res.setHeader("Content-Type", metricsService.contentType);
+      res.status(200).send(metrics);
+    } catch (error) {
+      next(error);
+    }
+  };
 }

--- a/src/routes/reputation.routes.ts
+++ b/src/routes/reputation.routes.ts
@@ -5,12 +5,12 @@ import { updateReputationSchema } from '../modules/reputation/dto/reputation.dto
 import { validateSchema } from '../middleware/validate.middleware';
 import { requireAuth, requirePermission } from '../middleware/authorization';
 import { z } from 'zod';
-
-const router = Router();
+import {
+  createReputationObservabilityMiddleware,
+  ReputationObservabilityOptions,
+} from '../observability/reputation-observability';
 
 // ── Authentication guard — all reputation routes require a valid JWT ──────────
-router.use(requireAuth);
-
 registry.registerPath({
   method: 'get',
   path: '/reputation/{id}',
@@ -49,14 +49,6 @@ registry.registerPath({
   }
 });
 
-// GET /api/v1/reputation/:id - Retrieve reputation for a freelancer
-// All authenticated roles (admin, client, freelancer) may read reviews.
-router.get('/:id', requirePermission('reviews', 'read'), ReputationController.getProfile);
-
-/**
- * POST /api/v1/reputation/:id/rate
- * Create a new reputation rating. Requires authentication.
- */
 registry.registerPath({
   method: 'post',
   path: '/reputation/{id}/rate',
@@ -101,14 +93,31 @@ registry.registerPath({
   }
 });
 
-// PUT /api/v1/reputation/:id - Submit a reputation review for a freelancer.
-// Requires 'reviews.create' permission — granted to admin, client, freelancer.
-router.put(
-  '/:id',
-  requirePermission('reviews', 'create'),
-  validateSchema(z.object({ body: updateReputationSchema, params: z.object({ id: z.string().min(1) }) })),
-  ReputationController.createRating
-);
+export function createReputationRouter(
+  options: ReputationObservabilityOptions = {},
+): Router {
+  const router = Router();
+
+  // Run before auth and validation so 401/400 responses are observable too.
+  router.use(createReputationObservabilityMiddleware(options));
+  router.use(requireAuth);
+
+  // GET /api/v1/reputation/:id - Retrieve reputation for a freelancer
+  // All authenticated roles (admin, client, freelancer) may read reviews.
+  router.get('/:id', requirePermission('reviews', 'read'), ReputationController.getProfile);
+
+  // PUT /api/v1/reputation/:id - Submit a reputation review for a freelancer.
+  // Requires 'reviews.create' permission — granted to admin, client, freelancer.
+  router.put(
+    '/:id',
+    requirePermission('reviews', 'create'),
+    validateSchema(z.object({ body: updateReputationSchema, params: z.object({ id: z.string().min(1) }) })),
+    ReputationController.createRating
+  );
+
+  return router;
+}
+
+const router = createReputationRouter();
 
 export default router;
-


### PR DESCRIPTION
## Summary
- add structured, PII-free logs for reputation requests
- record request duration, status, status code, and bounded error-cause metrics
- expose the new collectors through the existing Prometheus metrics endpoints
- cover success, client-error, and server-error instrumentation paths
- document the new telemetry and metric labels

Closes #738

## Test output

Focused observability and route verification:
```text
Test Suites: 5 passed, 5 total
Tests:       258 passed, 258 total
```

Impacted-module coverage verification:
```text
metrics-service.ts                  99.08% statements | 97.56% branches | 100% functions | 99.07% lines
reputation-observability.ts        100% statements   | 100% branches   | 100% functions | 100% lines
Test Suites: passed
Tests:       56 passed, 56 total
```

Changed-file lint and diff validation:
```text
ESLint on all changed TypeScript files: passed
git diff --check: passed
```

Repository-wide commands were also attempted. They currently fail on pre-existing issues unrelated to this change:
```text
npm run lint
6 errors, 62 warnings in existing files

npm run build
Existing TypeScript failures in health types, duplicate contract schemas, rate limiting, and webhook pagination

npm test
Existing failures in contracts, health permissions, rate limiting, redaction, request limits, and contract DTO tests
```