### PR TITLE
feat(audit): add AUDIT_ENABLED feature flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,3 +82,10 @@ SOROBAN_CONTRACT_ID=
 # How long (ms) idempotency keys are retained before eviction.
 # Default: 3600000 (1 hour). Re-submissions after expiry are processed fresh.
 # IDEMPOTENCY_TTL_MS=3600000
+
+# Audit Feature Flag
+# Set to false to disable all audit subsystem behavior at runtime without a deploy.
+# When false: res.locals.audit.log() becomes a no-op, protectedEndpointMiddleware
+# skips its finish listener, and the /api/v1/audit router is not mounted.
+# Default: true (audit is enabled)
+# AUDIT_ENABLED=true

--- a/src/audit/audit.flag.test.ts
+++ b/src/audit/audit.flag.test.ts
@@ -1,0 +1,492 @@
+/**
+ * @file audit.flag.test.ts
+ * @description Comprehensive tests for the `AUDIT_ENABLED` feature flag.
+ *
+ * This test suite verifies three runtime paths for every gated component:
+ *
+ * 1. Flag ON (default / `AUDIT_ENABLED=true`)  — audit fully active.
+ * 2. Flag OFF (`AUDIT_ENABLED=false`)           — no entries written, no-op helpers.
+ * 3. Flag absent (env var unset)               — should default to ON.
+ *
+ * Components under test
+ * ─────────────────────
+ * • env schema (`validateEnv`) — parses and defaults AUDIT_ENABLED correctly.
+ * • `auditMiddleware`          — attaches real vs no-op helper.
+ * • `createProtectedEndpointAuditMiddleware` — registers vs skips finish listener.
+ *
+ * Isolation strategy
+ * ──────────────────
+ * Each test group sets `process.env.AUDIT_ENABLED` in `beforeEach` and
+ * restores the original environment in `afterEach`.  Because `validateEnv()`
+ * is called at middleware invocation time (not module import time), toggling
+ * `process.env.AUDIT_ENABLED` between tests is sufficient without resetting
+ * the module registry.
+ */
+
+import express, { ErrorRequestHandler } from 'express';
+import request from 'supertest';
+
+// ── Shared minimum env ────────────────────────────────────────────────────────
+// `validateEnv()` requires COMPLIANCE_AUDIT_SECRET to be present.
+const MIN_ENV: NodeJS.ProcessEnv = {
+  NODE_ENV: 'test',
+  COMPLIANCE_AUDIT_SECRET: 'a'.repeat(32),
+};
+
+// ── Subject imports ───────────────────────────────────────────────────────────
+import { validateEnv } from '../config/env.schema';
+import { auditMiddleware } from './middleware';
+import { auditService } from './service';
+import { createProtectedEndpointAuditMiddleware } from './protectedEndpointMiddleware';
+import type { CreateAuditEntryInput } from './types';
+
+// ── Minimal audit input helper ────────────────────────────────────────────────
+function makeAuditInput(
+  overrides: Partial<Omit<CreateAuditEntryInput, 'ipAddress' | 'correlationId'>> = {},
+): Omit<CreateAuditEntryInput, 'ipAddress' | 'correlationId'> {
+  return {
+    action: 'CONTRACT_CREATED',
+    severity: 'INFO',
+    actor: 'user-flag-test',
+    resource: 'contract',
+    resourceId: 'contract-flag-1',
+    metadata: {},
+    ...overrides,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Schema — AUDIT_ENABLED parsing
+// ─────────────────────────────────────────────────────────────────────────────
+describe('AUDIT_ENABLED env schema', () => {
+  const savedEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...MIN_ENV };
+  });
+
+  afterEach(() => {
+    process.env = savedEnv;
+  });
+
+  it('defaults to true when AUDIT_ENABLED is not set', () => {
+    delete process.env.AUDIT_ENABLED;
+    const config = validateEnv();
+    expect(config.AUDIT_ENABLED).toBe(true);
+  });
+
+  it('is true when AUDIT_ENABLED=true', () => {
+    process.env.AUDIT_ENABLED = 'true';
+    const config = validateEnv();
+    expect(config.AUDIT_ENABLED).toBe(true);
+  });
+
+  it('is false when AUDIT_ENABLED=false', () => {
+    process.env.AUDIT_ENABLED = 'false';
+    const config = validateEnv();
+    expect(config.AUDIT_ENABLED).toBe(false);
+  });
+
+  it('treats any non-"false" string as true (e.g. "1")', () => {
+    process.env.AUDIT_ENABLED = '1';
+    const config = validateEnv();
+    expect(config.AUDIT_ENABLED).toBe(true);
+  });
+
+  it('treats any non-"false" string as true (e.g. "yes")', () => {
+    process.env.AUDIT_ENABLED = 'yes';
+    const config = validateEnv();
+    expect(config.AUDIT_ENABLED).toBe(true);
+  });
+
+  it('treats empty string as true (safe default)', () => {
+    process.env.AUDIT_ENABLED = '';
+    const config = validateEnv();
+    // empty string → undefined after Zod optional, transform runs on undefined → true
+    expect(config.AUDIT_ENABLED).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. auditMiddleware — flag ON
+// ─────────────────────────────────────────────────────────────────────────────
+describe('auditMiddleware — AUDIT_ENABLED=true (default)', () => {
+  const savedEnv = process.env;
+  let logSpy: jest.SpiedFunction<typeof auditService.log>;
+
+  beforeEach(() => {
+    process.env = { ...MIN_ENV, AUDIT_ENABLED: 'true' };
+    logSpy = jest.spyOn(auditService, 'log').mockImplementation((input) => ({
+      id: 'stub-id',
+      timestamp: new Date().toISOString(),
+      hash: 'a'.repeat(64),
+      previousHash: 'GENESIS',
+      ...input,
+    }));
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    process.env = savedEnv;
+  });
+
+  it('attaches a real log helper and calls next()', async () => {
+    const app = express();
+    app.use(auditMiddleware);
+    app.get('/probe', (_req, res) => {
+      expect(typeof res.locals.audit.log).toBe('function');
+      res.status(204).send();
+    });
+
+    await request(app).get('/probe').expect(204);
+  });
+
+  it('writes an audit entry when res.locals.audit.log is called', async () => {
+    const app = express();
+    app.use(auditMiddleware);
+    app.post('/contracts', (_req, res) => {
+      res.locals.audit.log(makeAuditInput());
+      res.status(201).json({ ok: true });
+    });
+
+    await request(app).post('/contracts').expect(201);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'CONTRACT_CREATED', actor: 'user-flag-test' }),
+    );
+  });
+
+  it('injects correlationId from X-Correlation-ID header', async () => {
+    const app = express();
+    app.use(auditMiddleware);
+    app.get('/ping', (_req, res) => {
+      res.locals.audit.log(makeAuditInput());
+      res.json({ ok: true });
+    });
+
+    await request(app)
+      .get('/ping')
+      .set('X-Correlation-ID', 'test-corr-id')
+      .expect(200);
+
+    expect(logSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ correlationId: 'test-corr-id' }),
+    );
+  });
+
+  it('returns the persisted entry from log()', async () => {
+    const app = express();
+    app.use(auditMiddleware);
+    app.get('/echo', (_req, res) => {
+      const entry = res.locals.audit.log(makeAuditInput());
+      res.json({ id: entry.id });
+    });
+
+    const response = await request(app).get('/echo').expect(200);
+    expect(response.body.id).toBe('stub-id');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. auditMiddleware — flag OFF
+// ─────────────────────────────────────────────────────────────────────────────
+describe('auditMiddleware — AUDIT_ENABLED=false', () => {
+  const savedEnv = process.env;
+  let logSpy: jest.SpiedFunction<typeof auditService.log>;
+
+  beforeEach(() => {
+    process.env = { ...MIN_ENV, AUDIT_ENABLED: 'false' };
+    logSpy = jest.spyOn(auditService, 'log').mockImplementation((input) => ({
+      id: 'stub-id',
+      timestamp: new Date().toISOString(),
+      hash: 'a'.repeat(64),
+      previousHash: 'GENESIS',
+      ...input,
+    }));
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    process.env = savedEnv;
+  });
+
+  it('still calls next() when flag is off', async () => {
+    const app = express();
+    app.use(auditMiddleware);
+    app.get('/probe', (_req, res) => {
+      res.status(204).send();
+    });
+
+    await request(app).get('/probe').expect(204);
+  });
+
+  it('attaches a no-op log helper — does NOT call auditService.log', async () => {
+    const app = express();
+    app.use(auditMiddleware);
+    app.post('/contracts', (_req, res) => {
+      res.locals.audit.log(makeAuditInput());
+      res.status(201).json({ ok: true });
+    });
+
+    await request(app).post('/contracts').expect(201);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('no-op log returns a stub AuditEntry with matching fields', async () => {
+    const app = express();
+    app.use(auditMiddleware);
+    app.get('/echo', (_req, res) => {
+      const entry = res.locals.audit.log(makeAuditInput());
+      res.json({
+        action: entry.action,
+        actor: entry.actor,
+        resource: entry.resource,
+        resourceId: entry.resourceId,
+      });
+    });
+
+    const response = await request(app).get('/echo').expect(200);
+    expect(response.body).toMatchObject({
+      action: 'CONTRACT_CREATED',
+      actor: 'user-flag-test',
+      resource: 'contract',
+      resourceId: 'contract-flag-1',
+    });
+    // Still no real write
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it('no-op stub has a timestamp property', async () => {
+    const app = express();
+    app.use(auditMiddleware);
+    app.get('/ts', (_req, res) => {
+      const entry = res.locals.audit.log(makeAuditInput());
+      res.json({ timestamp: entry.timestamp });
+    });
+
+    const response = await request(app).get('/ts').expect(200);
+    expect(response.body.timestamp).toBeDefined();
+  });
+
+  it('route handlers continue to function normally (no errors)', async () => {
+    const app = express();
+    app.use(auditMiddleware);
+    app.get('/normal', (_req, res) => {
+      res.locals.audit.log(makeAuditInput({ action: 'AUTH_LOGIN', severity: 'INFO' }));
+      res.json({ status: 'ok' });
+    });
+
+    const response = await request(app).get('/normal').expect(200);
+    expect(response.body.status).toBe('ok');
+  });
+
+  it('error path still produces a response (no disruption)', async () => {
+    const errorHandler: ErrorRequestHandler = (_err, _req, res, _next) => {
+      res.status(500).json({ error: 'server error' });
+    };
+    const app = express();
+    app.use(auditMiddleware);
+    app.get('/fail', (_req, res) => {
+      res.locals.audit.log(makeAuditInput());
+      throw new Error('boom');
+    });
+    app.use(errorHandler);
+
+    await request(app).get('/fail').expect(500);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. auditMiddleware — flag absent (defaults to ON)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('auditMiddleware — AUDIT_ENABLED absent (defaults to true)', () => {
+  const savedEnv = process.env;
+  let logSpy: jest.SpiedFunction<typeof auditService.log>;
+
+  beforeEach(() => {
+    process.env = { ...MIN_ENV };
+    delete process.env['AUDIT_ENABLED'];
+    logSpy = jest.spyOn(auditService, 'log').mockImplementation((input) => ({
+      id: 'stub-default',
+      timestamp: new Date().toISOString(),
+      hash: 'b'.repeat(64),
+      previousHash: 'GENESIS',
+      ...input,
+    }));
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    process.env = savedEnv;
+  });
+
+  it('writes audit entries when AUDIT_ENABLED is unset', async () => {
+    const app = express();
+    app.use(auditMiddleware);
+    app.get('/default', (_req, res) => {
+      res.locals.audit.log(makeAuditInput());
+      res.json({ ok: true });
+    });
+
+    await request(app).get('/default').expect(200);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. createProtectedEndpointAuditMiddleware — flag ON
+// ─────────────────────────────────────────────────────────────────────────────
+describe('createProtectedEndpointAuditMiddleware — AUDIT_ENABLED=true', () => {
+  const savedEnv = process.env;
+  let logSpy: jest.SpiedFunction<typeof auditService.log>;
+
+  beforeEach(() => {
+    process.env = { ...MIN_ENV, AUDIT_ENABLED: 'true' };
+    logSpy = jest.spyOn(auditService, 'log').mockImplementation((input) => ({
+      id: 'prot-stub',
+      timestamp: new Date().toISOString(),
+      hash: 'c'.repeat(64),
+      previousHash: 'GENESIS',
+      ...input,
+    }));
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    process.env = savedEnv;
+  });
+
+  it('calls next() and writes an audit entry on finish', async () => {
+    const mockService = { log: jest.fn(logSpy) } as any;
+    const middleware = createProtectedEndpointAuditMiddleware(mockService);
+
+    const app = express();
+    app.use(middleware);
+    app.get('/api/v1/contracts/abc', (_req, res) => {
+      res.json({ ok: true });
+    });
+
+    await request(app).get('/api/v1/contracts/abc').expect(200);
+
+    // finish listener fires after response
+    expect(mockService.log).toHaveBeenCalledTimes(1);
+    expect(mockService.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'ENDPOINT_ACCESS',
+        resource: 'contracts',
+      }),
+    );
+  });
+
+  it('records AUTH_FAILED for 401 responses', async () => {
+    const mockService = { log: jest.fn(logSpy) } as any;
+    const middleware = createProtectedEndpointAuditMiddleware(mockService);
+
+    const app = express();
+    app.use(middleware);
+    app.get('/api/v1/contracts', (_req, res) => {
+      res.status(401).json({ error: 'unauthorized' });
+    });
+
+    await request(app).get('/api/v1/contracts').expect(401);
+    expect(mockService.log).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'AUTH_FAILED', severity: 'WARNING' }),
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6. createProtectedEndpointAuditMiddleware — flag OFF
+// ─────────────────────────────────────────────────────────────────────────────
+describe('createProtectedEndpointAuditMiddleware — AUDIT_ENABLED=false', () => {
+  const savedEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...MIN_ENV, AUDIT_ENABLED: 'false' };
+  });
+
+  afterEach(() => {
+    process.env = savedEnv;
+  });
+
+  it('calls next() and does NOT write any audit entry', async () => {
+    const mockService = { log: jest.fn() } as any;
+    const middleware = createProtectedEndpointAuditMiddleware(mockService);
+
+    const app = express();
+    app.use(middleware);
+    app.get('/api/v1/contracts/abc', (_req, res) => {
+      res.json({ ok: true });
+    });
+
+    await request(app).get('/api/v1/contracts/abc').expect(200);
+    expect(mockService.log).not.toHaveBeenCalled();
+  });
+
+  it('does not write an entry for 401 responses either', async () => {
+    const mockService = { log: jest.fn() } as any;
+    const middleware = createProtectedEndpointAuditMiddleware(mockService);
+
+    const app = express();
+    app.use(middleware);
+    app.get('/protected', (_req, res) => {
+      res.status(401).json({ error: 'unauthorized' });
+    });
+
+    await request(app).get('/protected').expect(401);
+    expect(mockService.log).not.toHaveBeenCalled();
+  });
+
+  it('downstream handlers still work normally', async () => {
+    const mockService = { log: jest.fn() } as any;
+    const middleware = createProtectedEndpointAuditMiddleware(mockService);
+
+    const app = express();
+    app.use(middleware);
+    app.post('/api/v1/contracts', (_req, res) => {
+      res.status(201).json({ created: true });
+    });
+
+    const response = await request(app)
+      .post('/api/v1/contracts')
+      .send({ title: 'New Contract' })
+      .expect(201);
+
+    expect(response.body.created).toBe(true);
+    expect(mockService.log).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 7. createProtectedEndpointAuditMiddleware — flag absent (defaults to ON)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('createProtectedEndpointAuditMiddleware — AUDIT_ENABLED absent (defaults to true)', () => {
+  const savedEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...MIN_ENV };
+    delete process.env['AUDIT_ENABLED'];
+  });
+
+  afterEach(() => {
+    process.env = savedEnv;
+  });
+
+  it('writes an audit entry on finish when flag is absent', async () => {
+    const mockService = { log: jest.fn() } as any;
+    const middleware = createProtectedEndpointAuditMiddleware(mockService);
+
+    const app = express();
+    app.use(middleware);
+    app.get('/api/v1/reputation/u1', (_req, res) => {
+      res.json({ score: 95 });
+    });
+
+    await request(app).get('/api/v1/reputation/u1').expect(200);
+    expect(mockService.log).toHaveBeenCalledTimes(1);
+    expect(mockService.log).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'ENDPOINT_ACCESS' }),
+    );
+  });
+});

--- a/src/audit/middleware.ts
+++ b/src/audit/middleware.ts
@@ -5,6 +5,10 @@
  * Attaches a per-request audit helper to `res.locals.audit` so route handlers
  * can emit structured audit events without importing the service directly.
  *
+ * When `AUDIT_ENABLED=false` the middleware attaches a no-op helper so that
+ * callers compiled against `res.locals.audit.log(...)` continue to work
+ * without error — they simply produce no stored entry.
+ *
  * Security notes:
  * - IP addresses are extracted from X-Forwarded-For only when the app is
  *   behind a trusted proxy. Set `app.set('trust proxy', true)` accordingly.
@@ -15,12 +19,14 @@
 import type { Request, Response, NextFunction } from 'express';
 import { auditService } from './service';
 import type { AuditEntry, CreateAuditEntryInput } from './types';
+import { validateEnv } from '../config/env.schema';
 
 /** Helper attached to res.locals for route-level audit logging. */
 export interface RequestAuditHelper {
   /**
    * Emits an audit event scoped to the current HTTP request.
    * Automatically injects ipAddress and correlationId from the request.
+   * When AUDIT_ENABLED=false this is a no-op and returns a stub entry.
    */
   log(input: Omit<CreateAuditEntryInput, 'ipAddress' | 'correlationId'>): AuditEntry;
 }
@@ -38,6 +44,9 @@ declare global {
  * Attaches `res.locals.audit` to every request.
  * Mount this before your route handlers.
  *
+ * When `AUDIT_ENABLED=false` (runtime env), the attached helper is a no-op:
+ * it returns a stub `AuditEntry` without writing anything to the store.
+ *
  * @example
  * ```ts
  * app.use(auditMiddleware);
@@ -48,6 +57,31 @@ declare global {
  * ```
  */
 export function auditMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const env = validateEnv();
+
+  if (!env.AUDIT_ENABLED) {
+    // Feature flag off — attach a no-op helper so route code compiles and
+    // runs without branching on the flag themselves.
+    res.locals.audit = {
+      log(_input: Omit<CreateAuditEntryInput, 'ipAddress' | 'correlationId'>): AuditEntry {
+        return {
+          id: '',
+          timestamp: new Date().toISOString(),
+          hash: '',
+          previousHash: '',
+          action: _input.action,
+          severity: _input.severity,
+          actor: _input.actor,
+          resource: _input.resource,
+          resourceId: _input.resourceId,
+          metadata: _input.metadata,
+        };
+      },
+    } satisfies RequestAuditHelper;
+    next();
+    return;
+  }
+
   const ipAddress = (req.ip ?? req.socket?.remoteAddress) as string | undefined;
   const correlationId = req.headers['x-correlation-id'] as string | undefined;
 

--- a/src/audit/protectedEndpointMiddleware.ts
+++ b/src/audit/protectedEndpointMiddleware.ts
@@ -56,6 +56,7 @@ import type { AuditAction, AuditSeverity } from './types';
 import type { AuthenticatedRequest } from '../auth/authenticate';
 import { buildAuditMetadata } from './redact';
 import { auditService, AuditService } from './service';
+import { validateEnv } from '../config/env.schema';
 
 // ─── Internal helpers ─────────────────────────────────────────────────────────
 
@@ -126,6 +127,15 @@ export function createProtectedEndpointAuditMiddleware(
     res: Response,
     next: NextFunction,
   ): void {
+    const env = validateEnv();
+
+    if (!env.AUDIT_ENABLED) {
+      // Feature flag off — skip the finish listener entirely; no audit entries
+      // are written for protected-endpoint traffic.
+      next();
+      return;
+    }
+
     res.on('finish', () => {
       try {
         // req.user is populated by authenticateMiddleware after this runs

--- a/src/config/env.schema.ts
+++ b/src/config/env.schema.ts
@@ -235,6 +235,24 @@ export const envSchema = z.object({
   AWS_REGION: z.string().optional(),
 
   SENDGRID_API_KEY: z.string().optional(),
+
+  // ── Audit Feature Flag ──────────────────────────────────────────────────────
+  /**
+   * AUDIT_ENABLED — master switch for the audit subsystem.
+   *
+   * When `false`:
+   *  - `auditMiddleware` attaches a no-op helper to `res.locals.audit` so
+   *    route handlers continue to compile and run without changes.
+   *  - `protectedEndpointAuditMiddleware` skips registering its `finish`
+   *    listener, so no entries are written for protected-endpoint traffic.
+   *  - The `/api/v1/audit` router is not mounted on the Express app.
+   *
+   * Default: `true` (audit is on unless explicitly disabled).
+   */
+  AUDIT_ENABLED: z.string()
+    .optional()
+    .transform((val) => val !== 'false'),
+
 }).superRefine((obj, ctx) => {
   const requireForEmailProvider = (field: keyof typeof obj, message: string): void => {
     if (!obj[field]) {

--- a/src/config/env.test.ts
+++ b/src/config/env.test.ts
@@ -46,4 +46,36 @@ describe('Environment validation', () => {
 
     expect(() => validateEnv()).toThrow(/WEBHOOK_DELIVERY_TIMEOUT_MS/);
   });
+
+  describe('AUDIT_ENABLED feature flag', () => {
+    beforeEach(() => {
+      process.env.NODE_ENV = 'test';
+      process.env.COMPLIANCE_AUDIT_SECRET = 'a'.repeat(32);
+    });
+
+    it('defaults to true when AUDIT_ENABLED is not set', () => {
+      delete process.env.AUDIT_ENABLED;
+      expect(validateEnv().AUDIT_ENABLED).toBe(true);
+    });
+
+    it('is true when AUDIT_ENABLED=true', () => {
+      process.env.AUDIT_ENABLED = 'true';
+      expect(validateEnv().AUDIT_ENABLED).toBe(true);
+    });
+
+    it('is false when AUDIT_ENABLED=false', () => {
+      process.env.AUDIT_ENABLED = 'false';
+      expect(validateEnv().AUDIT_ENABLED).toBe(false);
+    });
+
+    it('treats non-"false" strings as true', () => {
+      process.env.AUDIT_ENABLED = '1';
+      expect(validateEnv().AUDIT_ENABLED).toBe(true);
+    });
+
+    it('treats empty string as true (safe default)', () => {
+      process.env.AUDIT_ENABLED = '';
+      expect(validateEnv().AUDIT_ENABLED).toBe(true);
+    });
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { requireAuth, requireRole } from './middleware/authorization';
 import { authMiddleware, type AuthenticatedRequest } from './middleware/auth';
 import { adminAuthGuard } from './middleware/adminAuthGuard';
 import { registerShutdownHandlers } from './shutdown';
+import { validateEnv } from './config/env.schema';
 
 const queueManager = QueueManager.getInstance();
 
@@ -46,14 +47,18 @@ const auditIntegrityLimiter = createRateLimiter({
   keyFn: auditActorKeyFn('audit-integrity'),
 });
 
-app.use(
-  '/api/v1/audit',
-  createAuditRouter({
-    accessMiddleware: [requireAuth, requireRole('admin', 'auditor'), auditQueryLimiter],
-    exportMiddleware: [auditExportLimiter],
-    integrityMiddleware: [auditIntegrityLimiter],
-  }),
-);
+// Mount the audit router only when the AUDIT_ENABLED feature flag is on.
+// When disabled, all /api/v1/audit/* requests fall through to the 404 handler.
+if (validateEnv().AUDIT_ENABLED) {
+  app.use(
+    '/api/v1/audit',
+    createAuditRouter({
+      accessMiddleware: [requireAuth, requireRole('admin', 'auditor'), auditQueryLimiter],
+      exportMiddleware: [auditExportLimiter],
+      integrityMiddleware: [auditIntegrityLimiter],
+    }),
+  );
+}
 
 const DLQ_DEFAULT_LIMIT = 50;
 const DLQ_MAX_LIMIT = 100;


### PR DESCRIPTION
## Summary

Gates the audit subsystem behind a runtime config flag so audit behavior can be toggled without a redeploy.

## Changes

| File | Change |
|---|---|
| `src/config/env.schema.ts` | Add `AUDIT_ENABLED` (optional string, transforms to boolean, **default `true`**) |
| `src/audit/middleware.ts` | Attach no-op `res.locals.audit` helper when flag is off |
| `src/audit/protectedEndpointMiddleware.ts` | Skip `finish` listener when flag is off |
| `src/index.ts` | Guard `/api/v1/audit` router mount behind the flag |
| `.env.example` | Document the new flag |
| `src/audit/audit.flag.test.ts` | Comprehensive flag ON / OFF / absent tests |
| `src/config/env.test.ts` | 5 new AUDIT_ENABLED schema parse cases |

## Behavior when `AUDIT_ENABLED=false`

- `auditMiddleware` attaches a **no-op helper** to `res.locals.audit` — route handlers continue to call `.log()` without errors, they just produce no stored entry.
- `protectedEndpointAuditMiddleware` skips its `finish` listener entirely — no entries written for protected-endpoint traffic.
- `/api/v1/audit` router is **not mounted** — all audit endpoints return 404.

## Default

`AUDIT_ENABLED` defaults to `true` — existing behavior is preserved unless explicitly disabled.

## Test output

```
PASS src/audit/audit.flag.test.ts
PASS src/config/env.test.ts
PASS src/audit/middleware.test.ts
PASS src/audit/protectedEndpointMiddleware.test.ts
PASS src/audit/router.integration.test.ts
PASS src/audit/audit.test.ts
... (all 11 audit suites)

Test Suites: 11 passed, 11 total
Tests:       439 passed (audit) + 47 new = 486 passed
```

Pre-existing failures on `main` (13 suites / 61 tests in unrelated modules) are unaffected.

## Documentation

```bash
# Audit Feature Flag
# Set to false to disable all audit subsystem behavior at runtime without a deploy.
# Default: true (audit is enabled)
# AUDIT_ENABLED=true
```

Closes #937