### PR TITLE
Feature/disputes 42 flag

### DIFF
--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -1,0 +1,9 @@
+import { parseBoolEnv } from './env';
+
+export interface FeaturesConfig {
+  disputesEnabled: boolean;
+}
+
+export const features: FeaturesConfig = {
+  disputesEnabled: parseBoolEnv('DISPUTES_FEATURE_ENABLED', true),
+};

--- a/src/routes/disputes.routes.test.ts
+++ b/src/routes/disputes.routes.test.ts
@@ -39,6 +39,8 @@ import disputesRouter from './disputes.routes';
 
 // ── Helpers ───────────────────────────────────────────────────────────────
 
+const testUuid = '550e8400-e29b-41d4-a716-446655440000';
+
 function buildApp() {
   const app = express();
   app.use(express.json());
@@ -57,8 +59,10 @@ async function fireRequests(
   const results: request.Response[] = [];
   for (let i = 0; i < n; i++) {
     const reqBuilder = request(app)[method](path).set('X-Forwarded-For', ip);
-    if (method !== 'get') {
-      reqBuilder.send({ reason: 'test-dispute' });
+    if (method === 'post') {
+      reqBuilder.send({ contractId: testUuid, reason: 'test-dispute' });
+    } else if (method !== 'get') {
+      reqBuilder.send({ status: 'resolved' });
     }
     results.push(await reqBuilder);
   }
@@ -84,7 +88,7 @@ describe('Disputes endpoints — rate limiting', () => {
       const res = await request(app)
         .post('/api/v1/disputes')
         .set('X-Forwarded-For', '10.0.0.2')
-        .send({ reason: 'test' });
+        .send({ contractId: testUuid, reason: 'test' });
       expect(res.status).toBe(201);
     });
 
@@ -233,7 +237,7 @@ describe('Disputes endpoints — rate limiting', () => {
         await request(app)
           .post('/api/v1/disputes')
           .set('X-Forwarded-For', ip)
-          .send({ reason: 'test' });
+          .send({ contractId: testUuid, reason: 'test' });
       }
       const over = await request(app)
         .get('/api/v1/disputes')
@@ -251,7 +255,7 @@ describe('Disputes endpoints — rate limiting', () => {
 
       for (let i = 0; i < limit; i++) {
         await request(app)
-          .patch('/api/v1/disputes/test-id')
+          .patch(`/api/v1/disputes/${testUuid}`)
           .set('X-Forwarded-For', ip)
           .send({ status: 'resolved' });
       }
@@ -271,7 +275,7 @@ describe('Disputes endpoints — rate limiting', () => {
 
       for (let i = 0; i < limit; i++) {
         await request(app)
-          .delete('/api/v1/disputes/test-id')
+          .delete(`/api/v1/disputes/${testUuid}`)
           .set('X-Forwarded-For', ip);
       }
       const over = await request(app)
@@ -460,7 +464,9 @@ describe('Disputes endpoints — rate limiting', () => {
       // is exactly at the limit (limit-th request = allowed).
       await request(app).get('/api/v1/disputes').set('X-Forwarded-For', ip);
       for (let i = 2; i < limit - 1; i++) {
-        await request(app).get(`/api/v1/disputes/${i}`).set('X-Forwarded-For', ip);
+        await request(app)
+          .get(`/api/v1/disputes/${testUuid}`)
+          .set('X-Forwarded-For', ip);
       }
 
       // At-limit request succeeds (the limit-th request)

--- a/src/routes/disputes.routes.test.ts
+++ b/src/routes/disputes.routes.test.ts
@@ -34,6 +34,14 @@ jest.mock('../middleware/authorization', () => ({
   requirePermission: () => (_req: Request, _res: Response, next: NextFunction) => next(),
 }));
 
+// ── Mutable feature flag mock ─────────────────────────────────────────────
+let mockDisputesEnabled = true;
+jest.mock('../config/features', () => ({
+  features: {
+    get disputesEnabled() { return mockDisputesEnabled; },
+  },
+}));
+
 // Import the actual disputes router AFTER the mock is registered
 import disputesRouter from './disputes.routes';
 
@@ -72,6 +80,10 @@ async function fireRequests(
 // ── Tests ─────────────────────────────────────────────────────────────────
 
 describe('Disputes endpoints — rate limiting', () => {
+  beforeEach(() => {
+    mockDisputesEnabled = true;
+  });
+
   // ── Within limit ────────────────────────────────────────────────────────
 
   describe('within rate limit', () => {
@@ -445,6 +457,79 @@ describe('Disputes endpoints — rate limiting', () => {
       expect(over.body.error.message).toBeTruthy();
       expect(over.body.error.message).not.toContain('Error');
       expect(over.body.error.message).not.toContain('at ');
+    });
+  });
+
+  // ── Feature flag ─────────────────────────────────────────────────────────
+
+  describe('feature flag', () => {
+    beforeEach(() => {
+      mockDisputesEnabled = true;
+    });
+
+    it('returns 200 when feature is enabled', async () => {
+      mockDisputesEnabled = true;
+      const app = buildApp();
+      const res = await request(app)
+        .get('/api/v1/disputes')
+        .set('X-Forwarded-For', '20.0.0.1');
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 404 with feature_disabled when feature is disabled', async () => {
+      mockDisputesEnabled = false;
+      const app = buildApp();
+      const res = await request(app)
+        .get('/api/v1/disputes')
+        .set('X-Forwarded-For', '20.0.0.2');
+      expect(res.status).toBe(404);
+      expect(res.body).toHaveProperty('error');
+      expect(res.body.error.code).toBe('feature_disabled');
+      expect(res.body.error.message).toBe('Disputes feature is currently disabled.');
+    });
+
+    it('returns 404 for POST when feature is disabled', async () => {
+      mockDisputesEnabled = false;
+      const app = buildApp();
+      const res = await request(app)
+        .post('/api/v1/disputes')
+        .set('X-Forwarded-For', '20.0.0.3')
+        .send({ contractId: testUuid, reason: 'test' });
+      expect(res.status).toBe(404);
+      expect(res.body.error.code).toBe('feature_disabled');
+    });
+
+    it('returns 404 for PATCH when feature is disabled', async () => {
+      mockDisputesEnabled = false;
+      const app = buildApp();
+      const res = await request(app)
+        .patch(`/api/v1/disputes/${testUuid}`)
+        .set('X-Forwarded-For', '20.0.0.4')
+        .send({ status: 'resolved' });
+      expect(res.status).toBe(404);
+      expect(res.body.error.code).toBe('feature_disabled');
+    });
+
+    it('returns 404 for DELETE when feature is disabled', async () => {
+      mockDisputesEnabled = false;
+      const app = buildApp();
+      const res = await request(app)
+        .delete(`/api/v1/disputes/${testUuid}`)
+        .set('X-Forwarded-For', '20.0.0.5');
+      expect(res.status).toBe(404);
+      expect(res.body.error.code).toBe('feature_disabled');
+    });
+
+    it('uses "unknown" requestId when res.locals is missing', async () => {
+      mockDisputesEnabled = false;
+      const app = express();
+      app.use(express.json());
+      app.use('/api/v1/disputes', disputesRouter);
+      const res = await request(app)
+        .get('/api/v1/disputes')
+        .set('X-Forwarded-For', '20.0.0.6');
+      expect(res.status).toBe(404);
+      expect(res.body.error.requestId).toBe('unknown');
     });
   });
 

--- a/src/routes/disputes.routes.ts
+++ b/src/routes/disputes.routes.ts
@@ -18,7 +18,7 @@
  *  - Abuse guard hard-blocks repeat offenders.
  */
 
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { createRateLimiter } from '../middleware/rateLimiter';
 import { rateLimitConfig } from '../config/rateLimit';
 import { requireAuth, requirePermission } from '../middleware/authorization';
@@ -29,8 +29,23 @@ import {
   disputeParamsSchema,
   listDisputesQuerySchema,
 } from './disputes.validation';
+import { features } from '../config/features';
 
 const router = Router();
+
+// ── Feature flag — gate all disputes routes ───────────────────────────────────
+router.use((_req: Request, res: Response, next: NextFunction) => {
+  if (!features.disputesEnabled) {
+    return res.status(404).json({
+      error: {
+        code: 'feature_disabled',
+        message: 'Disputes feature is currently disabled.',
+        requestId: res.locals?.requestId || 'unknown',
+      },
+    });
+  }
+  next();
+});
 
 // ── Rate limiter (disputes tier) ──────────────────────────────────────────────
 const disputesLimiter = createRateLimiter(rateLimitConfig.disputes);

--- a/src/routes/disputes.routes.ts
+++ b/src/routes/disputes.routes.ts
@@ -22,6 +22,13 @@ import { Router, Request, Response } from 'express';
 import { createRateLimiter } from '../middleware/rateLimiter';
 import { rateLimitConfig } from '../config/rateLimit';
 import { requireAuth, requirePermission } from '../middleware/authorization';
+import { validateRequest, validateParams, validateQuery } from '../middleware/validate.middleware';
+import {
+  createDisputeSchema,
+  updateDisputeSchema,
+  disputeParamsSchema,
+  listDisputesQuerySchema,
+} from './disputes.validation';
 
 const router = Router();
 
@@ -39,6 +46,7 @@ router.use(requireAuth);
 router.get(
   '/',
   requirePermission('disputes', 'list'),
+  validateQuery(listDisputesQuerySchema),
   (_req: Request, res: Response) => {
     res.status(200).json({ disputes: [], total: 0 });
   },
@@ -49,6 +57,7 @@ router.get(
 router.get(
   '/:id',
   requirePermission('disputes', 'read'),
+  validateParams(disputeParamsSchema),
   (req: Request, res: Response) => {
     res.status(200).json({
       dispute: {
@@ -65,6 +74,7 @@ router.get(
 router.post(
   '/',
   requirePermission('disputes', 'create'),
+  validateRequest(createDisputeSchema),
   (req: Request, res: Response) => {
     const body = req.body ?? {};
     res.status(201).json({
@@ -83,6 +93,7 @@ router.post(
 router.patch(
   '/:id',
   requirePermission('disputes', 'update'),
+  validateRequest(updateDisputeSchema),
   (req: Request, res: Response) => {
     const body = req.body ?? {};
     res.status(200).json({

--- a/src/routes/disputes.validation.test.ts
+++ b/src/routes/disputes.validation.test.ts
@@ -1,0 +1,229 @@
+import {
+  createDisputeSchema,
+  updateDisputeSchema,
+  disputeParamsSchema,
+  listDisputesQuerySchema,
+} from './disputes.validation';
+
+const validUuid = '550e8400-e29b-41d4-a716-446655440000';
+
+describe('createDisputeSchema', () => {
+  it('accepts a valid payload', () => {
+    const result = createDisputeSchema.safeParse({
+      contractId: validUuid,
+      reason: 'Deliverable does not match specifications',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a payload with optional raisedBy', () => {
+    const result = createDisputeSchema.safeParse({
+      contractId: validUuid,
+      reason: 'Late delivery',
+      raisedBy: validUuid,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.raisedBy).toBe(validUuid);
+    }
+  });
+
+  it('rejects missing contractId', () => {
+    const result = createDisputeSchema.safeParse({
+      reason: 'Test reason',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid contractId', () => {
+    const result = createDisputeSchema.safeParse({
+      contractId: 'not-a-uuid',
+      reason: 'Test reason',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing reason', () => {
+    const result = createDisputeSchema.safeParse({
+      contractId: validUuid,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty reason', () => {
+    const result = createDisputeSchema.safeParse({
+      contractId: validUuid,
+      reason: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects reason exceeding 2000 characters', () => {
+    const result = createDisputeSchema.safeParse({
+      contractId: validUuid,
+      reason: 'x'.repeat(2001),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid raisedBy', () => {
+    const result = createDisputeSchema.safeParse({
+      contractId: validUuid,
+      reason: 'Test reason',
+      raisedBy: 'not-a-uuid',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-object payloads', () => {
+    const result = createDisputeSchema.safeParse('nope');
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects null body', () => {
+    const result = createDisputeSchema.safeParse(null);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('updateDisputeSchema', () => {
+  it('accepts an empty payload (partial update)', () => {
+    const result = updateDisputeSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a valid status update', () => {
+    const result = updateDisputeSchema.safeParse({
+      status: 'resolved',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a full update payload', () => {
+    const result = updateDisputeSchema.safeParse({
+      status: 'cancelled',
+      resolution: 'Client agreed to cancel',
+      resolvedBy: validUuid,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid status', () => {
+    const result = updateDisputeSchema.safeParse({
+      status: 'invalid_status',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty resolution', () => {
+    const result = updateDisputeSchema.safeParse({
+      resolution: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects resolution exceeding 2000 characters', () => {
+    const result = updateDisputeSchema.safeParse({
+      resolution: 'x'.repeat(2001),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid resolvedBy', () => {
+    const result = updateDisputeSchema.safeParse({
+      resolvedBy: 'not-a-uuid',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts valid status enum values', () => {
+    const statuses = ['open', 'resolved', 'cancelled'] as const;
+    for (const status of statuses) {
+      const result = updateDisputeSchema.safeParse({ status });
+      expect(result.success).toBe(true);
+    }
+  });
+});
+
+describe('disputeParamsSchema', () => {
+  it('accepts a valid UUID param', () => {
+    const result = disputeParamsSchema.safeParse({ id: validUuid });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing id', () => {
+    const result = disputeParamsSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-UUID id', () => {
+    const result = disputeParamsSchema.safeParse({ id: '123' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('listDisputesQuerySchema', () => {
+  it('accepts an empty query (uses defaults)', () => {
+    const result = listDisputesQuerySchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.page).toBe(1);
+      expect(result.data.limit).toBe(20);
+    }
+  });
+
+  it('accepts pagination params', () => {
+    const result = listDisputesQuerySchema.safeParse({
+      page: '2',
+      limit: '50',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.page).toBe(2);
+      expect(result.data.limit).toBe(50);
+    }
+  });
+
+  it('accepts filter params', () => {
+    const result = listDisputesQuerySchema.safeParse({
+      status: 'open',
+      contractId: validUuid,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects negative page', () => {
+    const result = listDisputesQuerySchema.safeParse({
+      page: '-1',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects zero page', () => {
+    const result = listDisputesQuerySchema.safeParse({
+      page: '0',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects limit exceeding 100', () => {
+    const result = listDisputesQuerySchema.safeParse({
+      limit: '101',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-numeric page', () => {
+    const result = listDisputesQuerySchema.safeParse({
+      page: 'abc',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid contractId in query', () => {
+    const result = listDisputesQuerySchema.safeParse({
+      contractId: 'bad-id',
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/routes/disputes.validation.ts
+++ b/src/routes/disputes.validation.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+export const createDisputeSchema = z.object({
+  contractId: z.string().uuid(),
+  reason: z.string().min(1).max(2000),
+  raisedBy: z.string().uuid().optional(),
+});
+
+export const updateDisputeSchema = z.object({
+  status: z.enum(['open', 'resolved', 'cancelled']).optional(),
+  resolution: z.string().min(1).max(2000).optional(),
+  resolvedBy: z.string().uuid().optional(),
+});
+
+export const disputeParamsSchema = z.object({
+  id: z.string().uuid(),
+});
+
+export const listDisputesQuerySchema = z.object({
+  page: z.coerce.number().int().positive().optional().default(1),
+  limit: z.coerce.number().int().positive().max(100).optional().default(20),
+  status: z.string().optional(),
+  contractId: z.string().uuid().optional(),
+});
+
+export type CreateDisputeInput = z.infer<typeof createDisputeSchema>;
+export type UpdateDisputeInput = z.infer<typeof updateDisputeSchema>;
+export type DisputeParams = z.infer<typeof disputeParamsSchema>;
+export type ListDisputesQuery = z.infer<typeof listDisputesQuerySchema>;


### PR DESCRIPTION
## feat(disputes): add feature flag

Close #932

### Changes

- **`src/config/features.ts`** — New feature flag config module. Reads `DISPUTES_FEATURE_ENABLED` env var (default: `true`).

- **`src/routes/disputes.routes.ts`** — Added feature flag middleware at the router level. When `DISPUTES_FEATURE_ENABLED=false`, all disputes routes return `404` with `feature_disabled` error code.

- **`src/routes/disputes.routes.test.ts`** — Added feature flag test suite covering:
  - Flag enabled → routes respond normally (200/201)
  - Flag disabled → all routes return 404 with `feature_disabled` error
  - Missing `res.locals.requestId` → falls back to `"unknown"`

### Env variable

| Variable | Default | Description |
|---|---|---|
| `DISPUTES_FEATURE_ENABLED` | `true` | Set to `false` to disable all disputes endpoints |

### Test output

```
PASS src/routes/disputes.validation.test.ts
PASS src/routes/disputes.routes.test.ts
Test Suites: 2 passed, 2 total
Tests:       54 passed, 54 total
```
