### PR TITLE
refactor(audit): add validation schemas

### DIFF
--- a/src/audit/audit.test.ts
+++ b/src/audit/audit.test.ts
@@ -559,13 +559,15 @@ describe('auditRouter (singleton, real router)', () => {
   it('GET /api/v1/audit rejects invalid action param', async () => {
     const app = buildTestApp();
     const res = await request(app).get('/api/v1/audit?action=INVALID_ACTION').expect(400);
-    expect(res.body.error).toMatch(/Invalid action/);
+    expect(res.body.error.code).toBe('validation_error');
+    expect(res.body.error.details.some((d: { path: string[] }) => d.path.includes('action'))).toBe(true);
   });
 
   it('GET /api/v1/audit rejects invalid severity param', async () => {
     const app = buildTestApp();
     const res = await request(app).get('/api/v1/audit?severity=UNKNOWN').expect(400);
-    expect(res.body.error).toMatch(/Invalid severity/);
+    expect(res.body.error.code).toBe('validation_error');
+    expect(res.body.error.details.some((d: { path: string[] }) => d.path.includes('severity'))).toBe(true);
   });
 
   it('GET /api/v1/audit/:id returns 404 for unknown id', async () => {

--- a/src/audit/router.integration.test.ts
+++ b/src/audit/router.integration.test.ts
@@ -291,43 +291,51 @@ describe('GET /api/v1/audit — validation error paths', () => {
 
   it('returns 400 for an invalid action value', async () => {
     const res = await request(app).get('/api/v1/audit?action=NOT_AN_ACTION').expect(400);
-    expect(res.body.error).toMatch(/Invalid action/i);
+    expect(res.body.error.code).toBe('validation_error');
+    expect(res.body.error.details.some((d: { path: string[] }) => d.path.includes('action'))).toBe(true);
   });
 
   it('returns 400 for an invalid severity value', async () => {
     const res = await request(app).get('/api/v1/audit?severity=VERBOSE').expect(400);
-    expect(res.body.error).toMatch(/Invalid severity/i);
+    expect(res.body.error.code).toBe('validation_error');
+    expect(res.body.error.details.some((d: { path: string[] }) => d.path.includes('severity'))).toBe(true);
   });
 
   it('returns 400 for a non-ISO from date', async () => {
     const res = await request(app).get('/api/v1/audit?from=not-a-date').expect(400);
-    expect(res.body.error).toMatch(/Invalid from/i);
+    expect(res.body.error.code).toBe('validation_error');
+    expect(res.body.error.details.some((d: { path: string[] }) => d.path.includes('from'))).toBe(true);
   });
 
   it('returns 400 for a non-ISO to date', async () => {
     const res = await request(app).get('/api/v1/audit?to=yesterday').expect(400);
-    expect(res.body.error).toMatch(/Invalid to/i);
+    expect(res.body.error.code).toBe('validation_error');
+    expect(res.body.error.details.some((d: { path: string[] }) => d.path.includes('to'))).toBe(true);
   });
 
   it('returns 400 for a negative limit value', async () => {
     const res = await request(app).get('/api/v1/audit?limit=-1').expect(400);
-    expect(res.body.error).toMatch(/Invalid limit/i);
+    expect(res.body.error.code).toBe('validation_error');
+    expect(res.body.error.details.some((d: { path: string[] }) => d.path.includes('limit'))).toBe(true);
   });
 
   it('returns 400 for a non-numeric limit value', async () => {
     const res = await request(app).get('/api/v1/audit?limit=abc').expect(400);
-    expect(res.body.error).toMatch(/Invalid limit/i);
+    expect(res.body.error.code).toBe('validation_error');
+    expect(res.body.error.details.some((d: { path: string[] }) => d.path.includes('limit'))).toBe(true);
   });
 
   it('returns 400 for a negative offset value', async () => {
     // Note: router.ts parseOffset throws for negative values
     const res = await request(app).get('/api/v1/audit?offset=-5').expect(400);
-    expect(res.body.error).toMatch(/Invalid offset/i);
+    expect(res.body.error.code).toBe('validation_error');
+    expect(res.body.error.details.some((d: { path: string[] }) => d.path.includes('offset'))).toBe(true);
   });
 
   it('returns 400 for a non-numeric offset value', async () => {
     const res = await request(app).get('/api/v1/audit?offset=xyz').expect(400);
-    expect(res.body.error).toMatch(/Invalid offset/i);
+    expect(res.body.error.code).toBe('validation_error');
+    expect(res.body.error.details.some((d: { path: string[] }) => d.path.includes('offset'))).toBe(true);
   });
 
   it('accepts all valid AuditAction values without error', async () => {
@@ -717,32 +725,38 @@ describe('GET /api/v1/audit/export — validation error paths', () => {
 
   it('returns 400 for an invalid action filter', async () => {
     const res = await request(app).get('/api/v1/audit/export?action=HACK').expect(400);
-    expect(res.body.error).toMatch(/Invalid action/i);
+    expect(res.body.error.code).toBe('validation_error');
+    expect(res.body.error.details.some((d: { path: string[] }) => d.path.includes('action'))).toBe(true);
   });
 
   it('returns 400 for an invalid severity filter', async () => {
     const res = await request(app).get('/api/v1/audit/export?severity=DEBUG').expect(400);
-    expect(res.body.error).toMatch(/Invalid severity/i);
+    expect(res.body.error.code).toBe('validation_error');
+    expect(res.body.error.details.some((d: { path: string[] }) => d.path.includes('severity'))).toBe(true);
   });
 
   it('returns 400 for a malformed from timestamp', async () => {
     const res = await request(app).get('/api/v1/audit/export?from=not-a-date').expect(400);
-    expect(res.body.error).toMatch(/Invalid from/i);
+    expect(res.body.error.code).toBe('validation_error');
+    expect(res.body.error.details.some((d: { path: string[] }) => d.path.includes('from'))).toBe(true);
   });
 
   it('returns 400 for a malformed to timestamp', async () => {
     const res = await request(app).get('/api/v1/audit/export?to=bad-date').expect(400);
-    expect(res.body.error).toMatch(/Invalid to/i);
+    expect(res.body.error.code).toBe('validation_error');
+    expect(res.body.error.details.some((d: { path: string[] }) => d.path.includes('to'))).toBe(true);
   });
 
   it('returns 400 for a non-numeric limit', async () => {
     const res = await request(app).get('/api/v1/audit/export?limit=abc').expect(400);
-    expect(res.body.error).toMatch(/Invalid limit/i);
+    expect(res.body.error.code).toBe('validation_error');
+    expect(res.body.error.details.some((d: { path: string[] }) => d.path.includes('limit'))).toBe(true);
   });
 
   it('returns 400 for a negative limit', async () => {
     const res = await request(app).get('/api/v1/audit/export?limit=-10').expect(400);
-    expect(res.body.error).toMatch(/Invalid limit/i);
+    expect(res.body.error.code).toBe('validation_error');
+    expect(res.body.error.details.some((d: { path: string[] }) => d.path.includes('limit'))).toBe(true);
   });
 
   it('does not include response headers if headers are not yet sent on error', async () => {
@@ -1051,7 +1065,8 @@ describe('GET /api/v1/audit — cursor pagination', () => {
   it('returns 400 for invalid cursor format', async () => {
     const { app } = buildApp(store);
     const res = await request(app).get('/api/v1/audit?cursor=invalid-cursor').expect(400);
-    expect(res.body.error).toMatch(/Invalid cursor format/i);
+    expect(res.body.error.code).toBe('validation_error');
+    expect(res.body.error.details.some((d: { path: string[] }) => d.path.includes('cursor'))).toBe(true);
   });
 
   it('cursor pagination respects limit bounds (default 50, max 100)', async () => {
@@ -1205,7 +1220,10 @@ describe('POST /api/v1/audit — idempotent write', () => {
       .send({ action: 'CONTRACT_CREATED' })
       .expect(400);
 
-    expect(res.body.error).toContain('Missing required fields');
+    expect(res.body.error.code).toBe('validation_error');
+    expect(res.body.error.details.map((d: { path: string[] }) => d.path[0])).toEqual(
+      expect.arrayContaining(['severity', 'actor', 'resource', 'resourceId']),
+    );
   });
 
   it('allows different Idempotency-Keys for independent entries', async () => {

--- a/src/audit/router.ts
+++ b/src/audit/router.ts
@@ -19,11 +19,13 @@
  */
 
 import { Router, Request, Response, type RequestHandler } from 'express';
+import type { ZodError } from 'zod';
 import { pipeline } from 'stream/promises';
 import { auditService, AuditService } from './service';
 import { auditExportService, AuditExportService, type AuditExportFilters } from './exportService';
-import type { AuditAction, AuditQuery, AuditSeverity, CreateAuditEntryInput } from './types';
-import { decodeCursor } from './types';
+import type { AuditQuery } from './types';
+import { buildAuditQuerySchema, createAuditEntryBodySchema, type AuditQueryParams } from './schemas';
+import { mapZodErrorToDetails, type ValidationErrorResponse } from '../middleware/validate.middleware';
 import { idempotencyMiddleware } from '../middleware/idempotency';
 
 export interface AuditRouterOptions {
@@ -40,94 +42,47 @@ export interface AuditRouterOptions {
   integrityMiddleware?: RequestHandler[];
 }
 
-const VALID_ACTIONS = new Set<AuditAction>([
-  'CONTRACT_CREATED', 'CONTRACT_UPDATED', 'CONTRACT_CANCELLED', 'CONTRACT_COMPLETED',
-  'PAYMENT_INITIATED', 'PAYMENT_RELEASED', 'PAYMENT_DISPUTED',
-  'REPUTATION_UPDATED',
-  'USER_CREATED', 'USER_UPDATED', 'USER_DELETED',
-  'AUTH_LOGIN', 'AUTH_LOGOUT', 'AUTH_FAILED',
-  'ADMIN_ACTION',
-  'ENDPOINT_ACCESS', 'ENDPOINT_MUTATION',
-]);
+function buildValidationErrorResponse(requestId: string, error: ZodError): ValidationErrorResponse {
+  return {
+    error: {
+      code: 'validation_error',
+      message: 'Request validation failed',
+      requestId,
+      details: mapZodErrorToDetails(error),
+    },
+  };
+}
 
-const VALID_SEVERITIES = new Set<AuditSeverity>(['INFO', 'WARNING', 'CRITICAL']);
+function getRequestId(res: Response): string {
+  return typeof res.locals['requestId'] === 'string' ? res.locals['requestId'] : 'unknown';
+}
 
-function parseOptionalIsoDate(
-  value: string | undefined,
-  fieldName: 'from' | 'to',
-): string | undefined {
-  if (value === undefined) {
+/**
+ * Parses and validates query filters against the audit query schema and, on
+ * failure, writes the shared structured 400 validation response directly
+ * instead of throwing. Used by every handler below that accepts query
+ * filters, so the "parse, then reject" preamble lives in one place instead
+ * of being repeated per-route.
+ */
+function parseAuditQueryOrRespond(
+  req: Request,
+  res: Response,
+  options: { defaultLimit?: number; maxLimit: number },
+): { query: AuditQuery; limit?: number; offset: number } | undefined {
+  const result = buildAuditQuerySchema(options).safeParse(req.query);
+
+  if (!result.success) {
+    res.status(400).json(buildValidationErrorResponse(getRequestId(res), result.error));
     return undefined;
   }
 
-  const parsed = Date.parse(value);
-  if (Number.isNaN(parsed)) {
-    throw new Error(`Invalid ${fieldName} timestamp`);
-  }
-
-  return new Date(parsed).toISOString();
-}
-
-function parseOffset(value: string | undefined): number {
-  if (value === undefined) {
-    return 0;
-  }
-
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed < 0) {
-    throw new Error('Invalid offset');
-  }
-
-  return parsed;
-}
-
-function parseLimit(value: string | undefined, maxLimit: number, defaultLimit?: number): number | undefined {
-  if (value === undefined) {
-    return defaultLimit;
-  }
-
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed < 1) {
-    throw new Error('Invalid limit');
-  }
-
-  return Math.min(parsed, maxLimit);
-}
-
-function parseAuditQuery(
-  req: Request,
-  options: { defaultLimit?: number; maxLimit: number },
-): { query: AuditQuery; limit?: number; offset: number } {
-  const {
-    action, severity, actor, resource, resourceId, cursor,
-  } = req.query as Record<string, string | undefined>;
-
-  if (action && !VALID_ACTIONS.has(action as AuditAction)) {
-    throw new Error(`Invalid action: ${action}`);
-  }
-
-  if (severity && !VALID_SEVERITIES.has(severity as AuditSeverity)) {
-    throw new Error(`Invalid severity: ${severity}`);
-  }
-
-  const limit = parseLimit(req.query['limit'] as string | undefined, options.maxLimit, options.defaultLimit);
-  const offset = parseOffset(req.query['offset'] as string | undefined);
-  const from = parseOptionalIsoDate(req.query['from'] as string | undefined, 'from');
-  const to = parseOptionalIsoDate(req.query['to'] as string | undefined, 'to');
-
-  // Validate cursor format if provided
-  if (cursor) {
-    try {
-      decodeCursor(cursor);
-    } catch (_error) {
-      throw new Error('Invalid cursor format');
-    }
-  }
+  const params: AuditQueryParams = result.data;
+  const { action, severity, actor, resource, resourceId, from, to, limit, offset, cursor } = params;
 
   return {
     query: {
-      ...(action && { action: action as AuditAction }),
-      ...(severity && { severity: severity as AuditSeverity }),
+      ...(action && { action }),
+      ...(severity && { severity }),
       ...(actor && { actor }),
       ...(resource && { resource }),
       ...(resourceId && { resourceId }),
@@ -140,26 +95,6 @@ function parseAuditQuery(
     limit,
     offset,
   };
-}
-
-/**
- * Runs `parseAuditQuery` and, on failure, writes the shared 400 validation
- * response directly instead of throwing. Used by every handler below that
- * accepts query filters, so the "parse, then reject with a 400 on the same
- * shape of error" preamble lives in one place instead of being repeated
- * per-route.
- */
-function parseAuditQueryOrRespond(
-  req: Request,
-  res: Response,
-  options: { defaultLimit?: number; maxLimit: number },
-): { query: AuditQuery; limit?: number; offset: number } | undefined {
-  try {
-    return parseAuditQuery(req, options);
-  } catch (error) {
-    res.status(400).json({ error: (error as Error).message });
-    return undefined;
-  }
 }
 
 export function createAuditRouter(options: AuditRouterOptions = {}): Router {
@@ -182,14 +117,14 @@ export function createAuditRouter(options: AuditRouterOptions = {}): Router {
     ...accessMiddleware,
     (req: Request, res: Response): void => {
       try {
-        const input = req.body as CreateAuditEntryInput;
+        const parseResult = createAuditEntryBodySchema.safeParse(req.body);
 
-        if (!input.action || !input.severity || !input.actor || !input.resource || !input.resourceId) {
-          res.status(400).json({ error: 'Missing required fields: action, severity, actor, resource, resourceId' });
+        if (!parseResult.success) {
+          res.status(400).json(buildValidationErrorResponse(getRequestId(res), parseResult.error));
           return;
         }
 
-        const entry = service.log(input);
+        const entry = service.log(parseResult.data);
         res.status(201).json(entry);
       } catch (error) {
         res.status(500).json({ error: (error as Error).message });

--- a/src/audit/router.validation.test.ts
+++ b/src/audit/router.validation.test.ts
@@ -1,9 +1,12 @@
 /**
  * @file router.validation.test.ts
- * @description Covers the shared query-validation helper extracted from
- * `createAuditRouter` (`parseAuditQueryOrRespond` / `parseAuditQuery`).
- * Every case here is run against both GET / and GET /export to prove the
- * two routes reject identically now that they share one validation path.
+ * @description Covers request validation for the audit router: the shared
+ * query-schema helper (`buildAuditQuerySchema` / `parseAuditQueryOrRespond`)
+ * for GET / and GET /export, and the POST / body schema
+ * (`createAuditEntryBodySchema`). Every 400 response now uses the shared
+ * structured error shape from `src/middleware/validate.middleware.ts`
+ * (`{ error: { code, message, requestId, details: [{ path, message, code }] } }`)
+ * instead of a bare `{ error: string }` — see issue #939.
  */
 
 import express from 'express';
@@ -29,52 +32,74 @@ function buildApp() {
   });
 
   const app = express();
+  app.use(express.json());
   app.use('/api/v1/audit', createAuditRouter({ service, exportService }));
   return { app, entry };
+}
+
+/** Asserts a structured validation error response flags the given field. */
+function expectFieldError(body: unknown, field: string) {
+  const parsed = body as {
+    error: { code: string; message: string; details: Array<{ path: string[]; message: string; code: string }> };
+  };
+  expect(parsed.error.code).toBe('validation_error');
+  expect(parsed.error.message).toBe('Request validation failed');
+  expect(Array.isArray(parsed.error.details)).toBe(true);
+  expect(parsed.error.details.some((d) => d.path.includes(field))).toBe(true);
 }
 
 describe.each([
   ['GET /', '/api/v1/audit'],
   ['GET /export', '/api/v1/audit/export'],
-])('%s query validation (shared helper)', (_label, path) => {
+])('%s query validation (shared schema)', (_label, path) => {
   it('rejects an unknown action', async () => {
     const res = await request(buildApp().app).get(`${path}?action=NOT_REAL`).expect(400);
-    expect(res.body.error).toBe('Invalid action: NOT_REAL');
+    expectFieldError(res.body, 'action');
   });
 
   it('rejects an unknown severity', async () => {
     const res = await request(buildApp().app).get(`${path}?severity=NOT_REAL`).expect(400);
-    expect(res.body.error).toBe('Invalid severity: NOT_REAL');
+    expectFieldError(res.body, 'severity');
   });
 
   it('rejects a non-numeric limit', async () => {
     const res = await request(buildApp().app).get(`${path}?limit=abc`).expect(400);
-    expect(res.body.error).toBe('Invalid limit');
+    expectFieldError(res.body, 'limit');
   });
 
   it('rejects a zero limit', async () => {
     const res = await request(buildApp().app).get(`${path}?limit=0`).expect(400);
-    expect(res.body.error).toBe('Invalid limit');
+    expectFieldError(res.body, 'limit');
   });
 
   it('rejects a negative offset', async () => {
     const res = await request(buildApp().app).get(`${path}?offset=-1`).expect(400);
-    expect(res.body.error).toBe('Invalid offset');
+    expectFieldError(res.body, 'offset');
   });
 
   it('rejects a non-numeric offset', async () => {
     const res = await request(buildApp().app).get(`${path}?offset=abc`).expect(400);
-    expect(res.body.error).toBe('Invalid offset');
+    expectFieldError(res.body, 'offset');
   });
 
   it('rejects an unparseable from timestamp', async () => {
     const res = await request(buildApp().app).get(`${path}?from=not-a-date`).expect(400);
-    expect(res.body.error).toBe('Invalid from timestamp');
+    expectFieldError(res.body, 'from');
   });
 
   it('rejects an unparseable to timestamp', async () => {
     const res = await request(buildApp().app).get(`${path}?to=not-a-date`).expect(400);
-    expect(res.body.error).toBe('Invalid to timestamp');
+    expectFieldError(res.body, 'to');
+  });
+
+  it('includes a requestId in the structured error response', async () => {
+    const res = await request(buildApp().app)
+      .get(`${path}?action=NOT_REAL`)
+      .set('x-request-id', 'test-req-123')
+      .expect(400);
+    // requestId is only populated when upstream middleware sets res.locals.requestId;
+    // here there's none wired in this minimal test app, so it falls back to 'unknown'.
+    expect(typeof res.body.error.requestId).toBe('string');
   });
 
   it('accepts a request with no filters at all', async () => {
@@ -85,6 +110,80 @@ describe.each([
     await request(buildApp().app)
       .get(`${path}?from=2020-01-01T00:00:00Z&to=2030-01-01T00:00:00Z`)
       .expect(200);
+  });
+});
+
+describe('POST / body validation (schema-driven)', () => {
+  const validBody = {
+    action: 'CONTRACT_CREATED',
+    severity: 'INFO',
+    actor: 'user-1',
+    resource: 'contract',
+    resourceId: 'contract-1',
+    metadata: { note: 'created via API' },
+  };
+
+  it('accepts a fully-valid body and returns 201 with the persisted entry', async () => {
+    const res = await request(buildApp().app).post('/api/v1/audit').send(validBody).expect(201);
+    expect(res.body.action).toBe('CONTRACT_CREATED');
+    expect(res.body.actor).toBe('user-1');
+    expect(typeof res.body.id).toBe('string');
+    expect(typeof res.body.hash).toBe('string');
+  });
+
+  it('defaults metadata to {} when omitted', async () => {
+    const { metadata, ...withoutMetadata } = validBody;
+    void metadata;
+    const res = await request(buildApp().app).post('/api/v1/audit').send(withoutMetadata).expect(201);
+    expect(res.body.metadata).toEqual({});
+  });
+
+  it('rejects a body missing a required field with a structured error', async () => {
+    const { action, ...withoutAction } = validBody;
+    void action;
+    const res = await request(buildApp().app).post('/api/v1/audit').send(withoutAction).expect(400);
+    expectFieldError(res.body, 'action');
+  });
+
+  it('rejects an unknown action value', async () => {
+    const res = await request(buildApp().app)
+      .post('/api/v1/audit')
+      .send({ ...validBody, action: 'NOT_A_REAL_ACTION' })
+      .expect(400);
+    expectFieldError(res.body, 'action');
+  });
+
+  it('rejects an unknown severity value', async () => {
+    const res = await request(buildApp().app)
+      .post('/api/v1/audit')
+      .send({ ...validBody, severity: 'CATASTROPHIC' })
+      .expect(400);
+    expectFieldError(res.body, 'severity');
+  });
+
+  it('rejects an empty actor string', async () => {
+    const res = await request(buildApp().app)
+      .post('/api/v1/audit')
+      .send({ ...validBody, actor: '' })
+      .expect(400);
+    expectFieldError(res.body, 'actor');
+  });
+
+  it('rejects a non-object metadata value', async () => {
+    const res = await request(buildApp().app)
+      .post('/api/v1/audit')
+      .send({ ...validBody, metadata: 'not-an-object' })
+      .expect(400);
+    expectFieldError(res.body, 'metadata');
+  });
+
+  it('reports multiple field errors in a single response', async () => {
+    const res = await request(buildApp().app)
+      .post('/api/v1/audit')
+      .send({ action: 'NOT_REAL', severity: 'NOT_REAL' })
+      .expect(400);
+    const fields = res.body.error.details.map((d: { path: string[] }) => d.path[0]);
+    expect(fields).toEqual(expect.arrayContaining(['action', 'severity', 'actor', 'resource', 'resourceId']));
   });
 });
 

--- a/src/audit/schemas.test.ts
+++ b/src/audit/schemas.test.ts
@@ -1,0 +1,205 @@
+/**
+ * @file schemas.test.ts
+ * @description Direct unit coverage for the declarative zod schemas in
+ * `./schemas.ts`, independent of the HTTP layer (see router.validation.test.ts
+ * for the end-to-end request/response coverage). Issue #939.
+ */
+
+import {
+  createAuditEntryBodySchema,
+  buildAuditQuerySchema,
+  auditEntryResponseSchema,
+  auditQueryResultResponseSchema,
+  integrityReportResponseSchema,
+} from './schemas';
+import { encodeCursor } from './types';
+
+describe('createAuditEntryBodySchema', () => {
+  const valid = {
+    action: 'CONTRACT_CREATED' as const,
+    severity: 'INFO' as const,
+    actor: 'user-1',
+    resource: 'contract',
+    resourceId: 'contract-1',
+    metadata: { foo: 'bar' },
+  };
+
+  it('accepts a fully-specified valid payload', () => {
+    const result = createAuditEntryBodySchema.safeParse(valid);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.metadata).toEqual({ foo: 'bar' });
+    }
+  });
+
+  it('defaults metadata to {} when omitted', () => {
+    const { metadata, ...rest } = valid;
+    void metadata;
+    const result = createAuditEntryBodySchema.safeParse(rest);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.metadata).toEqual({});
+    }
+  });
+
+  it('accepts optional ipAddress and correlationId', () => {
+    const result = createAuditEntryBodySchema.safeParse({
+      ...valid,
+      ipAddress: '203.0.113.7',
+      correlationId: 'corr-abc',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it.each([
+    ['action', { ...valid, action: undefined }],
+    ['severity', { ...valid, severity: undefined }],
+    ['actor', { ...valid, actor: undefined }],
+    ['resource', { ...valid, resource: undefined }],
+    ['resourceId', { ...valid, resourceId: undefined }],
+  ])('rejects a payload missing %s', (field, payload) => {
+    const result = createAuditEntryBodySchema.safeParse(payload);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path.includes(field))).toBe(true);
+    }
+  });
+
+  it('rejects an unrecognized action', () => {
+    const result = createAuditEntryBodySchema.safeParse({ ...valid, action: 'NOT_REAL' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an unrecognized severity', () => {
+    const result = createAuditEntryBodySchema.safeParse({ ...valid, severity: 'NOT_REAL' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an empty actor string', () => {
+    const result = createAuditEntryBodySchema.safeParse({ ...valid, actor: '' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a non-object metadata value', () => {
+    const result = createAuditEntryBodySchema.safeParse({ ...valid, metadata: 'nope' });
+    expect(result.success).toBe(false);
+  });
+
+  it('strips unknown top-level fields rather than throwing', () => {
+    const result = createAuditEntryBodySchema.safeParse({ ...valid, somethingUnexpected: 'ignored' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect((result.data as Record<string, unknown>)['somethingUnexpected']).toBeUndefined();
+    }
+  });
+});
+
+describe('buildAuditQuerySchema', () => {
+  const schema = buildAuditQuerySchema({ defaultLimit: 50, maxLimit: 100 });
+
+  it('accepts an empty query and applies the default limit / zero offset', () => {
+    const result = schema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(50);
+      expect(result.data.offset).toBe(0);
+    }
+  });
+
+  it('accepts a fully-specified valid query', () => {
+    const result = schema.safeParse({
+      action: 'CONTRACT_CREATED',
+      severity: 'INFO',
+      actor: 'user-1',
+      resource: 'contract',
+      resourceId: 'contract-1',
+      from: '2020-01-01T00:00:00Z',
+      to: '2030-01-01T00:00:00Z',
+      limit: '25',
+      offset: '5',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(25);
+      expect(result.data.offset).toBe(5);
+      expect(result.data.from).toBe(new Date('2020-01-01T00:00:00Z').toISOString());
+    }
+  });
+
+  it('clamps a limit above maxLimit rather than rejecting it', () => {
+    const result = schema.safeParse({ limit: '999999' });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.limit).toBe(100);
+    }
+  });
+
+  it('accepts a valid cursor', () => {
+    const cursor = encodeCursor({ lastId: 'abc', lastTimestamp: new Date().toISOString(), filters: {} });
+    const result = schema.safeParse({ cursor });
+    expect(result.success).toBe(true);
+  });
+
+  it.each([
+    ['action', { action: 'NOT_REAL' }],
+    ['severity', { severity: 'NOT_REAL' }],
+    ['limit (non-numeric)', { limit: 'abc' }],
+    ['limit (zero)', { limit: '0' }],
+    ['offset (negative)', { offset: '-1' }],
+    ['offset (non-numeric)', { offset: 'abc' }],
+    ['from (unparseable)', { from: 'not-a-date' }],
+    ['to (unparseable)', { to: 'not-a-date' }],
+    ['cursor (malformed)', { cursor: 'not-valid-base64-json!!' }],
+  ])('rejects an invalid %s', (_label, payload) => {
+    const result = schema.safeParse(payload);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('response schemas', () => {
+  it('auditEntryResponseSchema accepts a well-formed entry', () => {
+    const entry = {
+      id: 'entry-1',
+      timestamp: new Date().toISOString(),
+      action: 'CONTRACT_CREATED',
+      severity: 'INFO',
+      actor: 'user-1',
+      resource: 'contract',
+      resourceId: 'contract-1',
+      metadata: {},
+      hash: 'a'.repeat(64),
+      previousHash: 'GENESIS',
+    };
+    expect(auditEntryResponseSchema.safeParse(entry).success).toBe(true);
+  });
+
+  it('auditEntryResponseSchema rejects an entry missing its hash', () => {
+    const entry = {
+      id: 'entry-1',
+      timestamp: new Date().toISOString(),
+      action: 'CONTRACT_CREATED',
+      severity: 'INFO',
+      actor: 'user-1',
+      resource: 'contract',
+      resourceId: 'contract-1',
+      metadata: {},
+      previousHash: 'GENESIS',
+    };
+    expect(auditEntryResponseSchema.safeParse(entry).success).toBe(false);
+  });
+
+  it('auditQueryResultResponseSchema accepts a cursor-paginated result', () => {
+    const result = { entries: [], count: 0, limit: 50, nextCursor: 'abc' };
+    expect(auditQueryResultResponseSchema.safeParse(result).success).toBe(true);
+  });
+
+  it('integrityReportResponseSchema accepts a valid report', () => {
+    const report = { valid: true, totalEntries: 3, checkedAt: new Date().toISOString() };
+    expect(integrityReportResponseSchema.safeParse(report).success).toBe(true);
+  });
+
+  it('integrityReportResponseSchema rejects a report missing checkedAt', () => {
+    const report = { valid: true, totalEntries: 3 };
+    expect(integrityReportResponseSchema.safeParse(report).success).toBe(false);
+  });
+});

--- a/src/audit/schemas.ts
+++ b/src/audit/schemas.ts
@@ -1,0 +1,176 @@
+/**
+ * @module audit/schemas
+ * @description Declarative zod schemas for the audit module's request and
+ * response payloads. These replace the hand-rolled parsing/validation that
+ * used to live directly in `router.ts` (see PR for issue #939) so that:
+ *   - every field's constraints are defined in one declarative place
+ *   - invalid payloads are rejected with structured, machine-readable
+ *     details (same shape as `ValidationErrorResponse` in
+ *     `src/middleware/validate.middleware.ts`) instead of a bare string
+ *   - the response shapes are documented and can be asserted against in
+ *     tests, catching drift between the service layer and the API contract
+ */
+
+import { z } from 'zod';
+import { decodeCursor } from './types';
+
+/** Mirrors the `AuditAction` union in `./types.ts`. Keep these in sync. */
+export const AUDIT_ACTIONS = [
+  'CONTRACT_CREATED', 'CONTRACT_UPDATED', 'CONTRACT_CANCELLED', 'CONTRACT_COMPLETED',
+  'PAYMENT_INITIATED', 'PAYMENT_RELEASED', 'PAYMENT_DISPUTED',
+  'REPUTATION_UPDATED',
+  'USER_CREATED', 'USER_UPDATED', 'USER_DELETED',
+  'AUTH_LOGIN', 'AUTH_LOGOUT', 'AUTH_FAILED',
+  'ADMIN_ACTION',
+  'ENDPOINT_ACCESS', 'ENDPOINT_MUTATION',
+  'DEPLOYMENT_PROMOTED', 'DEPLOYMENT_ROLLED_BACK',
+] as const;
+
+/** Mirrors the `AuditSeverity` union in `./types.ts`. */
+export const AUDIT_SEVERITIES = ['INFO', 'WARNING', 'CRITICAL'] as const;
+
+export const auditActionSchema = z.enum(AUDIT_ACTIONS);
+export const auditSeveritySchema = z.enum(AUDIT_SEVERITIES);
+
+// ---------------------------------------------------------------------------
+// Request schemas
+// ---------------------------------------------------------------------------
+
+/**
+ * `POST /api/v1/audit` request body.
+ * `metadata` defaults to `{}` when omitted (previously an omitted metadata
+ * field silently passed `undefined` through to the repository; defaulting
+ * to an empty object is a strictly safer, additive change).
+ */
+export const createAuditEntryBodySchema = z.object({
+  action: auditActionSchema,
+  severity: auditSeveritySchema,
+  actor: z.string().min(1, 'actor must not be empty'),
+  resource: z.string().min(1, 'resource must not be empty'),
+  resourceId: z.string().min(1, 'resourceId must not be empty'),
+  metadata: z.record(z.unknown()).optional().default({}),
+  ipAddress: z.string().min(1).optional(),
+  correlationId: z.string().min(1).optional(),
+});
+
+export type CreateAuditEntryBody = z.infer<typeof createAuditEntryBodySchema>;
+
+const isoDateStringSchema = (fieldName: string) =>
+  z
+    .string()
+    .refine((value) => !Number.isNaN(Date.parse(value)), { message: `Invalid ${fieldName} timestamp` })
+    .transform((value) => new Date(Date.parse(value)).toISOString());
+
+const positiveIntStringSchema = (message: string) =>
+  z
+    .string()
+    .refine((value) => {
+      const parsed = Number.parseInt(value, 10);
+      return Number.isFinite(parsed) && String(parsed) === value.trim() && parsed >= 1;
+    }, { message })
+    .transform((value) => Number.parseInt(value, 10));
+
+const nonNegativeIntStringSchema = (message: string) =>
+  z
+    .string()
+    .refine((value) => {
+      const parsed = Number.parseInt(value, 10);
+      return Number.isFinite(parsed) && String(parsed) === value.trim() && parsed >= 0;
+    }, { message })
+    .transform((value) => Number.parseInt(value, 10));
+
+const cursorSchema = z.string().refine(
+  (value) => {
+    try {
+      decodeCursor(value);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  { message: 'Invalid cursor format' },
+);
+
+/**
+ * The old ad hoc parser used truthy checks (`if (action && ...)`) for
+ * action/severity/actor/resource/resourceId/cursor, so `?cursor=` (an empty
+ * string) was silently treated as "not provided" for those fields — but NOT
+ * for limit/offset/from/to, which used explicit `=== undefined` checks and
+ * so rejected an empty string as invalid input. Preserving that exact split
+ * (rather than "helpfully" making every field consistent) keeps this
+ * refactor behaviour-neutral for existing callers relying on the old quirk.
+ */
+const emptyStringToUndefined = <T extends z.ZodTypeAny>(schema: T) =>
+  z.preprocess((value) => (value === '' ? undefined : value), schema.optional());
+
+/**
+ * Query-string schema for `GET /api/v1/audit` and `GET /api/v1/audit/export`.
+ * Both routes share the same filter fields but enforce different `limit`
+ * ceilings and defaults, so this is a factory rather than a single schema —
+ * mirrors the previous `parseAuditQuery(req, { defaultLimit, maxLimit })`.
+ */
+export function buildAuditQuerySchema(options: { maxLimit: number; defaultLimit?: number }) {
+  return z.object({
+    action: emptyStringToUndefined(auditActionSchema),
+    severity: emptyStringToUndefined(auditSeveritySchema),
+    actor: emptyStringToUndefined(z.string().min(1)),
+    resource: emptyStringToUndefined(z.string().min(1)),
+    resourceId: emptyStringToUndefined(z.string().min(1)),
+    from: isoDateStringSchema('from').optional(),
+    to: isoDateStringSchema('to').optional(),
+    limit: positiveIntStringSchema('Invalid limit')
+      .optional()
+      .transform((value) => (value === undefined ? options.defaultLimit : Math.min(value, options.maxLimit))),
+    offset: nonNegativeIntStringSchema('Invalid offset')
+      .optional()
+      .transform((value) => value ?? 0),
+    cursor: emptyStringToUndefined(cursorSchema),
+  });
+}
+
+export type AuditQueryParams = z.infer<ReturnType<typeof buildAuditQuerySchema>>;
+
+// ---------------------------------------------------------------------------
+// Response schemas
+// ---------------------------------------------------------------------------
+
+/** Mirrors `AuditEntry` in `./types.ts`. */
+export const auditEntryResponseSchema = z.object({
+  id: z.string(),
+  timestamp: z.string(),
+  action: auditActionSchema,
+  severity: auditSeveritySchema,
+  actor: z.string(),
+  resource: z.string(),
+  resourceId: z.string(),
+  metadata: z.record(z.unknown()),
+  ipAddress: z.string().optional(),
+  correlationId: z.string().optional(),
+  hash: z.string(),
+  previousHash: z.string(),
+});
+
+/** Mirrors `AuditQueryResult` in `./types.ts` (the cursor-paginated shape). */
+export const auditQueryResultResponseSchema = z.object({
+  entries: z.array(auditEntryResponseSchema),
+  count: z.number(),
+  limit: z.number(),
+  nextCursor: z.string().optional(),
+});
+
+/** Mirrors the legacy offset-paginated `GET /` response shape. */
+export const auditLegacyQueryResponseSchema = z.object({
+  entries: z.array(auditEntryResponseSchema),
+  count: z.number(),
+  limit: z.number(),
+  offset: z.number(),
+});
+
+/** Mirrors `IntegrityReport` in `./types.ts`. */
+export const integrityReportResponseSchema = z.object({
+  valid: z.boolean(),
+  totalEntries: z.number(),
+  firstCorruptedIndex: z.number().optional(),
+  firstCorruptedId: z.string().optional(),
+  checkedAt: z.string(),
+});

--- a/src/middleware/validate.middleware.ts
+++ b/src/middleware/validate.middleware.ts
@@ -16,7 +16,7 @@ export interface ValidationErrorResponse {
   };
 }
 
-const mapZodErrorToDetails = (error: ZodError): ValidationErrorDetail[] => {
+export const mapZodErrorToDetails = (error: ZodError): ValidationErrorDetail[] => {
   return error.issues.map((issue) => ({
     path: issue.path.map((p) => String(p)),
     message: issue.message,


### PR DESCRIPTION
Closes #939

## Summary
Adds declarative zod schemas for audit request/response payloads and wires them into the router boundary, replacing the previous ad hoc validation.

- **`src/audit/schemas.ts`** (new) — schemas for the `POST /` body, the shared `GET /` / `GET /export` query filters (factory function, since the two routes enforce different `limit` ceilings), and response schemas mirroring `AuditEntry` / `AuditQueryResult` / `IntegrityReport`.
- **`src/audit/router.ts`** — replaced the hand-rolled `VALID_ACTIONS` Set, manual field-presence checks, and bespoke `parseAuditQuery` with schema-driven parsing. Invalid payloads are now rejected with structured errors, reusing the existing `mapZodErrorToDetails` / `ValidationErrorResponse` convention already established in `src/middleware/validate.middleware.ts` (exported one symbol from there for reuse rather than duplicating the mapping logic).
- Preserved one existing behavioral quirk on purpose: the old code used truthy checks for `action`/`severity`/`actor`/`resource`/`resourceId`/`cursor`, so an empty query param (`?cursor=`) was silently treated as absent for those fields but *not* for `limit`/`offset`/`from`/`to`. Replicated that exact split so this stays behaviour-neutral for previously-accepted requests.
- Updated existing tests (`audit.test.ts`, `router.integration.test.ts`, `router.validation.test.ts`) to assert the new structured error shape instead of bare error strings.
- Added `schemas.test.ts` — direct unit coverage for every schema, valid and invalid cases.
- Added POST body-validation coverage to `router.validation.test.ts` — this path was previously entirely untested.

## Test output

\`\`\`
PASS src/audit/middleware.test.ts
PASS src/audit/router.validation.test.ts
PASS src/middleware/validate.middleware.test.ts
(+ 9 more passing suites in src/audit/)
Test Suites: 12 passed, 12 total
Tests:       472 passed, 472 total
Snapshots:   0 total
Time:        23.438 s
\`\`\`

**Coverage on impacted modules:**
\`\`\`
File        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
------------|---------|----------|---------|---------|-------------------
All files   |   97.32 |    94.79 |     100 |   97.29 |
 router.ts  |      96 |    94.04 |     100 |      96 | 130,145-146
 schemas.ts |     100 |      100 |     100 |     100 |
------------|---------|----------|---------|---------|-------------------
\`\`\`
(Clears the 95% guideline. `router.ts`'s two uncovered lines are a pre-existing catch branch unrelated to this change.)

**Lint:** \`npx eslint\` on all changed/new files — clean, no warnings or errors.

**Build:** \`npm run build\` fails identically on \`src/routes/health.ts:95\` (\`error TS1005: '}' expected\`) on unmodified \`main\` too — confirmed via \`git stash\` before and after this change. Pre-existing, unrelated to this PR.