### PR TITLE
feat(webhooks): add WEBHOOKS_ENABLED feature flag (#942)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,6 +87,13 @@ SOROBAN_CONTRACT_ID=
 # Default: 3600000 (1 hour). Re-submissions after expiry are processed fresh.
 # IDEMPOTENCY_TTL_MS=3600000
 
+# Webhooks Feature Flag
+# Set to false to disable all webhook behavior at runtime without a deploy.
+# When false: WebhookService.trigger() becomes a no-op (no deliveries, no DLQ writes),
+# and the /api/v1/webhook-subscriptions router is not mounted (all endpoints return 404).
+# Default: true (webhooks are enabled)
+# WEBHOOKS_ENABLED=true
+
 # Audit Feature Flag
 # Set to false to disable all audit subsystem behavior at runtime without a deploy.
 # When false: res.locals.audit.log() becomes a no-op, protectedEndpointMiddleware

--- a/README.md
+++ b/README.md
@@ -479,6 +479,14 @@ All configuration is managed through `src/config/` and validated at startup usin
 | `GREEN_PORT` | `3002` | Port for the 'green' backend |
 | `HTTP_METRICS_ROUTE_LABEL_LIMIT` | `100` | Maximum distinct HTTP route template labels before new routes are recorded as `other` |
 
+## Webhooks Feature Flag
+
+| Variable | Default | Description |
+|---|---|---|
+| `WEBHOOKS_ENABLED` | `true` | Enable/disable the webhooks subsystem at runtime. When `false`, `WebhookService.trigger()` becomes a no-op (no subscriptions queried, no deliveries attempted, no DLQ writes), and the `/api/v1/webhook-subscriptions` router is not mounted (all subscription management endpoints return `404`). Omit the variable to keep webhooks enabled (safe default). |
+
+See [docs/webhooks.md](docs/webhooks.md) for full webhook documentation and [docs/backend/config.md](docs/backend/config.md) for all configuration options.
+
 ## Milestones Feature Flag
 
 | Variable | Default | Description |

--- a/docs/backend/config.md
+++ b/docs/backend/config.md
@@ -32,6 +32,7 @@ Feature flags are boolean environment variables that toggle product behaviour at
 | Variable | Default | Description |
 |---|---|---|
 | `MILESTONES_ENABLED` | `true` | Enable or disable the milestones feature. When `false`, any `milestones` field in a request body is silently stripped before the service layer — no validation errors are raised and contracts are processed as if no milestones were provided. Set to `false` to disable the feature during a rollout pause. |
+| `WEBHOOKS_ENABLED` | `true` | Enable or disable the webhooks subsystem. When `false`, `WebhookService.trigger()` is a no-op (no subscriptions queried, no deliveries attempted, no DLQ writes) and the `/api/v1/webhook-subscriptions` router is not mounted (all endpoints return `404`). Omit the variable to keep webhooks enabled (safe default). |
 
 ### Toggling `MILESTONES_ENABLED`
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -878,3 +878,43 @@ We recommend always providing a `secret` for security.
 - [queue-system.md](backend/queue-system.md) — Background job queue architecture
 - [DLQ Implementation](../DLQ_IMPLEMENTATION_SUMMARY.md) — Dead-letter queue design and operations
 
+
+
+---
+
+## Feature Flag: WEBHOOKS_ENABLED
+
+The entire webhooks subsystem is gated behind the `WEBHOOKS_ENABLED` environment variable.
+
+### Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `WEBHOOKS_ENABLED` | `true` | Enable/disable the webhooks subsystem at runtime. |
+
+### Behaviour
+
+| State | `WEBHOOKS_ENABLED=true` | `WEBHOOKS_ENABLED=false` |
+|-------|------------------------|--------------------------|
+| `WebhookService.trigger()` | Queries subscriptions and delivers events | Immediate no-op — no subscriptions queried, no HTTP deliveries, no DLQ writes |
+| `/api/v1/webhook-subscriptions` router | Mounted and functional | Not mounted — all endpoints return `404` |
+
+### Safe default
+
+Omitting `WEBHOOKS_ENABLED` from the environment is equivalent to `WEBHOOKS_ENABLED=true`. Webhooks remain enabled unless explicitly disabled.
+
+### Usage examples
+
+```bash
+# Disable webhooks (e.g. during an incident or maintenance window)
+WEBHOOKS_ENABLED=false npm start
+
+# Re-enable (default — also achieved by omitting the variable)
+WEBHOOKS_ENABLED=true npm start
+```
+
+### Notes
+
+- The flag is read once at process startup via `parseBoolEnv`. Changing the variable at runtime requires a restart.
+- The `features.webhooksEnabled` field in `src/config/features.ts` exposes the resolved boolean for use outside the service constructor.
+- All non-trigger methods on `WebhookService` (DLQ reads, replays, stats) remain functional regardless of the flag.

--- a/package-lock.json
+++ b/package-lock.json
@@ -394,7 +394,6 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -471,7 +470,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -2493,7 +2491,6 @@
       "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -2676,7 +2673,6 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -2901,7 +2897,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2950,7 +2945,6 @@
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3133,7 +3127,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
       "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
@@ -3624,7 +3617,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -4094,6 +4086,60 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/content-disposition": {
@@ -4720,7 +4766,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6301,7 +6346,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -10402,7 +10446,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10576,7 +10619,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -10790,7 +10832,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11288,7 +11329,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app.ts
+++ b/src/app.ts
@@ -37,6 +37,7 @@ import dependencyScanRouter from './routes/dependency-scan.routes';
 import { adminRouter } from './routes/admin.routes';
 import { deployRouter } from './routes/deploy.routes';
 import { webhookSubscriptionRouter } from './routes/webhook-subscription.routes';
+import { features } from './config/features';
 import { requestIdMiddleware } from './middleware/requestId';
 import { httpLoggerMiddleware } from './middleware/httpLogger';
 import { ReputationService } from './services/reputation.service';
@@ -112,7 +113,9 @@ export function createApp(options?: AppFactoryOptions): express.Application {
   app.use('/api/v1', apiKeysRouter);
   app.use('/api/v1/admin', adminRouter);
   app.use('/api/v1/admin/deploy', deployRouter);
-  app.use('/api/v1/webhook-subscriptions', webhookSubscriptionRouter);
+  if (features.webhooksEnabled) {
+    app.use('/api/v1/webhook-subscriptions', webhookSubscriptionRouter);
+  }
   app.use('/api/v1/metrics', metricsAuthMiddleware, createMetricsRouter(metricsService));
 
   if (includeTerminalHandlers) {

--- a/src/config/env.schema.ts
+++ b/src/config/env.schema.ts
@@ -323,6 +323,22 @@ export const envSchema = z.object({
 
   SENDGRID_API_KEY: z.string().optional(),
 
+  // ── Webhooks Feature Flag ───────────────────────────────────────────────────
+  /**
+   * WEBHOOKS_ENABLED — master switch for the webhooks subsystem.
+   *
+   * When `false`:
+   *  - `WebhookService.trigger()` is a no-op and returns immediately without
+   *    delivering any events or touching subscriptions.
+   *  - The `/api/v1/webhook-subscriptions` router is not mounted on the
+   *    Express app and all subscription endpoints return `404`.
+   *
+   * Default: `true` (webhooks are on unless explicitly disabled).
+   */
+  WEBHOOKS_ENABLED: z.string()
+    .optional()
+    .transform((val) => val !== 'false'),
+
   // ── Audit Feature Flag ──────────────────────────────────────────────────────
   /**
    * AUDIT_ENABLED — master switch for the audit subsystem.

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -2,8 +2,10 @@ import { parseBoolEnv } from './env';
 
 export interface FeaturesConfig {
   disputesEnabled: boolean;
+  webhooksEnabled: boolean;
 }
 
 export const features: FeaturesConfig = {
   disputesEnabled: parseBoolEnv('DISPUTES_FEATURE_ENABLED', true),
+  webhooksEnabled: parseBoolEnv('WEBHOOKS_ENABLED', true),
 };

--- a/src/routes/webhook-subscription.flag.test.ts
+++ b/src/routes/webhook-subscription.flag.test.ts
@@ -1,0 +1,308 @@
+/**
+ * @file webhook-subscription.flag.test.ts
+ *
+ * Integration tests for the WEBHOOKS_ENABLED feature flag on the
+ * webhook subscription routes mounted in the Express app.
+ *
+ * Covers:
+ *  - Default behaviour (flag is true when env var is absent)
+ *  - Flag ON  — /api/v1/webhook-subscriptions routes are active and reachable
+ *  - Flag OFF — /api/v1/webhook-subscriptions routes are NOT mounted → 404
+ *  - env schema validation of WEBHOOKS_ENABLED
+ *  - features.ts webhooksEnabled field
+ */
+
+import request from 'supertest';
+import express from 'express';
+
+// ── Shared minimum env ────────────────────────────────────────────────────────
+const MIN_ENV: NodeJS.ProcessEnv = {
+  NODE_ENV: 'test',
+  COMPLIANCE_AUDIT_SECRET: 'a'.repeat(32),
+};
+
+// ── Subject imports ───────────────────────────────────────────────────────────
+import { validateEnv } from '../config/env.schema';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Schema — WEBHOOKS_ENABLED parsing
+// ─────────────────────────────────────────────────────────────────────────────
+describe('env schema — WEBHOOKS_ENABLED', () => {
+  const base = { ...MIN_ENV };
+
+  it('defaults to true when WEBHOOKS_ENABLED is absent', () => {
+    const env = validateEnv({ ...base });
+    expect(env.WEBHOOKS_ENABLED).toBe(true);
+  });
+
+  it('defaults to true when WEBHOOKS_ENABLED is empty string', () => {
+    const env = validateEnv({ ...base, WEBHOOKS_ENABLED: '' });
+    expect(env.WEBHOOKS_ENABLED).toBe(true);
+  });
+
+  it('is true when WEBHOOKS_ENABLED=true', () => {
+    const env = validateEnv({ ...base, WEBHOOKS_ENABLED: 'true' });
+    expect(env.WEBHOOKS_ENABLED).toBe(true);
+  });
+
+  it('is false when WEBHOOKS_ENABLED=false', () => {
+    const env = validateEnv({ ...base, WEBHOOKS_ENABLED: 'false' });
+    expect(env.WEBHOOKS_ENABLED).toBe(false);
+  });
+
+  it('is true for any value other than "false"', () => {
+    const env = validateEnv({ ...base, WEBHOOKS_ENABLED: 'yes' });
+    expect(env.WEBHOOKS_ENABLED).toBe(true);
+  });
+
+  it('is false only when explicitly set to "false"', () => {
+    const env = validateEnv({ ...base, WEBHOOKS_ENABLED: 'false' });
+    expect(env.WEBHOOKS_ENABLED).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. features.ts — webhooksEnabled field
+// ─────────────────────────────────────────────────────────────────────────────
+describe('features.ts — webhooksEnabled', () => {
+  const originalEnv = process.env.WEBHOOKS_ENABLED;
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.WEBHOOKS_ENABLED;
+    } else {
+      process.env.WEBHOOKS_ENABLED = originalEnv;
+    }
+    // Reset the module registry so parseBoolEnv is re-evaluated fresh
+    jest.resetModules();
+  });
+
+  it('exports webhooksEnabled as boolean', async () => {
+    delete process.env.WEBHOOKS_ENABLED;
+    const { features } = await import('../config/features');
+    expect(typeof features.webhooksEnabled).toBe('boolean');
+  });
+
+  it('webhooksEnabled defaults to true when env var is absent', async () => {
+    delete process.env.WEBHOOKS_ENABLED;
+    const { features } = await import('../config/features');
+    expect(features.webhooksEnabled).toBe(true);
+  });
+
+  it('webhooksEnabled is true when WEBHOOKS_ENABLED=true', async () => {
+    process.env.WEBHOOKS_ENABLED = 'true';
+    const { features } = await import('../config/features');
+    expect(features.webhooksEnabled).toBe(true);
+  });
+
+  it('webhooksEnabled is false when WEBHOOKS_ENABLED=false', async () => {
+    process.env.WEBHOOKS_ENABLED = 'false';
+    const { features } = await import('../config/features');
+    expect(features.webhooksEnabled).toBe(false);
+  });
+
+  it('webhooksEnabled is true when WEBHOOKS_ENABLED=1', async () => {
+    process.env.WEBHOOKS_ENABLED = '1';
+    const { features } = await import('../config/features');
+    expect(features.webhooksEnabled).toBe(true);
+  });
+
+  it('webhooksEnabled is false when WEBHOOKS_ENABLED=0', async () => {
+    process.env.WEBHOOKS_ENABLED = '0';
+    const { features } = await import('../config/features');
+    expect(features.webhooksEnabled).toBe(false);
+  });
+
+  it('features object also preserves disputesEnabled field alongside webhooksEnabled', async () => {
+    delete process.env.WEBHOOKS_ENABLED;
+    const { features } = await import('../config/features');
+    expect(features).toHaveProperty('disputesEnabled');
+    expect(features).toHaveProperty('webhooksEnabled');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Route gating — webhook subscription endpoints
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal Express app that mounts the webhook subscription router
+ * only when the `webhooksEnabled` flag is true. This mirrors the production
+ * app factory behaviour without spinning up the full createApp() stack.
+ */
+function buildTestApp(webhooksEnabled: boolean): express.Application {
+  const app = express();
+  app.use(express.json());
+
+  // Minimal auth stubs so route middleware doesn't crash
+  app.use((req: any, _res, next) => {
+    req.user = { id: 'test-user', roles: ['admin'] };
+    next();
+  });
+
+  if (webhooksEnabled) {
+    // Mount a simple echo router to represent the real subscription router
+    // We test the gating logic here, not the full subscription CRUD
+    const { webhookSubscriptionRouter } = require('../routes/webhook-subscription.routes');
+    app.use('/api/v1/webhook-subscriptions', webhookSubscriptionRouter);
+  }
+
+  // 404 fallback
+  app.use((_req, res) => {
+    res.status(404).json({ error: { code: 'not_found', message: 'Not found' } });
+  });
+
+  return app;
+}
+
+// Mock dependencies that the route requires
+jest.mock('../db/database', () => ({
+  getDb: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../repositories/webhook-subscription.repository', () => ({
+  SqliteWebhookSubscriptionRepository: jest.fn().mockImplementation(() => ({
+    create: jest.fn(),
+    findAll: jest.fn().mockResolvedValue([]),
+    findAllPaginated: jest.fn().mockResolvedValue({
+      data: [],
+      nextCursor: null,
+      hasNextPage: false,
+      limit: 20,
+    }),
+    findById: jest.fn().mockResolvedValue(null),
+    update: jest.fn(),
+    delete: jest.fn(),
+  })),
+}));
+
+jest.mock('../lib/rateLimitStore', () => ({
+  RateLimitStore: jest.fn().mockImplementation(() => ({
+    get: jest.fn().mockReturnValue(null),
+    set: jest.fn(),
+    destroy: jest.fn(),
+  })),
+}));
+
+jest.mock('../middleware/rateLimiter', () => ({
+  createRateLimiter: jest.fn().mockReturnValue((_req: any, _res: any, next: any) => next()),
+}));
+
+jest.mock('../middleware/authorization', () => ({
+  requireAuth: (_req: any, _res: any, next: any) => next(),
+  requireRole: () => (_req: any, _res: any, next: any) => next(),
+}));
+
+jest.mock('../middleware/validate.middleware', () => ({
+  validateSchema: () => (_req: any, _res: any, next: any) => next(),
+}));
+
+jest.mock('../middleware/idempotency', () => ({
+  idempotencyMiddleware: (_req: any, _res: any, next: any) => next(),
+}));
+
+jest.mock('../contracts/cursor.repository', () => ({
+  decodeCursor: jest.fn(),
+}));
+
+jest.mock('../config/rateLimit', () => ({
+  rateLimitConfig: { webhooksApi: { max: 100, windowMs: 60000 } },
+}));
+
+jest.mock('../auth/rateLimitKey', () => ({
+  authRateLimitKeyFn: jest.fn(),
+}));
+
+describe('Webhook subscription route gating — flag ON', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = buildTestApp(true);
+  });
+
+  it('GET /api/v1/webhook-subscriptions returns 200 (not 404) when flag is ON', async () => {
+    const res = await request(app).get('/api/v1/webhook-subscriptions');
+    // Route is mounted — may return 200, 400, 401, 403 depending on middleware
+    // but must NOT be 404 (which would mean the router isn't mounted)
+    expect(res.status).not.toBe(404);
+  });
+
+  it('POST /api/v1/webhook-subscriptions is reachable when flag is ON', async () => {
+    const res = await request(app)
+      .post('/api/v1/webhook-subscriptions')
+      .send({ url: 'https://example.com/hook', eventType: 'contract.created' });
+    // Route is mounted — anything other than 404 confirms the router is active
+    expect(res.status).not.toBe(404);
+  });
+
+  it('DELETE /api/v1/webhook-subscriptions/:id is reachable when flag is ON', async () => {
+    // The DELETE route will return 404 from the *handler* (subscription not found),
+    // not from the missing router. We verify the router is mounted by checking
+    // the response has a webhook-specific JSON body, not the generic not_found envelope.
+    const res = await request(app).delete(
+      '/api/v1/webhook-subscriptions/00000000-0000-0000-0000-000000000001',
+    );
+    // A 404 from the handler will have a different body than our fallback 404
+    // — both are acceptable since the route IS mounted
+    expect([200, 400, 401, 403, 404, 500]).toContain(res.status);
+  });
+});
+
+describe('Webhook subscription route gating — flag OFF', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = buildTestApp(false);
+  });
+
+  it('GET /api/v1/webhook-subscriptions returns 404 when flag is OFF', async () => {
+    const res = await request(app).get('/api/v1/webhook-subscriptions');
+    expect(res.status).toBe(404);
+  });
+
+  it('POST /api/v1/webhook-subscriptions returns 404 when flag is OFF', async () => {
+    const res = await request(app)
+      .post('/api/v1/webhook-subscriptions')
+      .send({ url: 'https://example.com/hook', eventType: 'contract.created' });
+    expect(res.status).toBe(404);
+  });
+
+  it('GET /api/v1/webhook-subscriptions/:id returns 404 when flag is OFF', async () => {
+    const res = await request(app).get(
+      '/api/v1/webhook-subscriptions/00000000-0000-0000-0000-000000000001',
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('PATCH /api/v1/webhook-subscriptions/:id returns 404 when flag is OFF', async () => {
+    const res = await request(app)
+      .patch('/api/v1/webhook-subscriptions/00000000-0000-0000-0000-000000000001')
+      .send({ active: false });
+    expect(res.status).toBe(404);
+  });
+
+  it('DELETE /api/v1/webhook-subscriptions/:id returns 404 when flag is OFF', async () => {
+    const res = await request(app).delete(
+      '/api/v1/webhook-subscriptions/00000000-0000-0000-0000-000000000001',
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Default path — route mounted when env var is absent
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Webhook subscription route gating — default (no env var)', () => {
+  it('routes are accessible by default (safe default = enabled)', async () => {
+    // Build with the same defaulting logic as production (no injection)
+    delete process.env.WEBHOOKS_ENABLED;
+
+    const { parseBoolEnv } = require('../config/env');
+    const webhooksEnabled = parseBoolEnv('WEBHOOKS_ENABLED', true);
+    const app = buildTestApp(webhooksEnabled);
+
+    const res = await request(app).get('/api/v1/webhook-subscriptions');
+    expect(res.status).not.toBe(404);
+    expect(webhooksEnabled).toBe(true);
+  });
+});

--- a/src/services/webhook.service.ts
+++ b/src/services/webhook.service.ts
@@ -9,6 +9,7 @@ import { isSafeUrl } from '../utils/ssrf';
 import { RateLimitStore } from '../lib/rateLimitStore';
 import { MetricsServiceLike } from '../observability';
 import { validateEnv } from '../config/env.schema';
+import { parseBoolEnv } from '../config/env';
 
 import { getDb } from '../db/database';
 import { SqliteWebhookSubscriptionRepository } from '../repositories/webhook-subscription.repository';
@@ -53,6 +54,15 @@ export class WebhookService {
   private static hostRateStore = new RateLimitStore({ sweepIntervalMs: HOST_RATE_LIMIT_WINDOW_MS });
 
   /**
+   * When `false`, `trigger()` is a no-op: no subscriptions are queried,
+   * no deliveries are attempted, and no DLQ entries are written.
+   *
+   * Defaults to `true` (read from `WEBHOOKS_ENABLED` env var at construction
+   * time) so the flag can be injected in tests without touching `process.env`.
+   */
+  private readonly webhooksEnabled: boolean;
+
+  /**
    * Applies a per-host sliding-window rate limit.
    *
    * @param hostname - The destination hostname extracted from the webhook URL.
@@ -82,17 +92,26 @@ export class WebhookService {
     return entry.count <= HOST_RATE_LIMIT_MAX;
   }
 
-  constructor(private readonly metrics?: MetricsServiceLike) {}
+  constructor(private readonly metrics?: MetricsServiceLike, webhooksEnabled?: boolean) {
+    this.webhooksEnabled = webhooksEnabled ?? parseBoolEnv('WEBHOOKS_ENABLED', true);
+  }
 
   /**
    * Triggers a webhook event. It retrieves all active subscriptions matching the event type,
    * constructs a delivery payload, and delivers to each matching subscription URL asynchronously.
+   *
+   * When `WEBHOOKS_ENABLED=false` this method returns immediately without querying
+   * subscriptions, sending any deliveries, or touching the DLQ.
    *
    * @param eventType - The event type name.
    * @param data - The event body/data.
    * @param correlationId - Optional correlation ID.
    */
   async trigger(eventType: string, data: unknown, correlationId?: string): Promise<void> {
+    if (!this.webhooksEnabled) {
+      return;
+    }
+
     const subscriptions = await this.repo.findAll({ eventType, active: true });
     console.log("TRIGGER FINDALL:", subscriptions.length, "subs for", eventType);
     

--- a/src/services/webhooks.flag.test.ts
+++ b/src/services/webhooks.flag.test.ts
@@ -1,0 +1,300 @@
+/**
+ * @file webhooks.flag.test.ts
+ *
+ * Unit tests for the WEBHOOKS_ENABLED feature flag in WebhookService.
+ *
+ * Covers:
+ *  - Default behaviour (flag is true when env var is absent)
+ *  - Flag ON  — trigger() queries subscriptions and delivers events
+ *  - Flag OFF — trigger() is a no-op: no repo calls, no deliveries, no DLQ
+ *  - Constructor injection (no process.env mutation needed in individual tests)
+ *  - parseBoolEnv reading from process.env at construction time
+ *  - Edge cases: empty string, 'true', 'false', '1', '0'
+ */
+
+import { WebhookService } from './webhook.service';
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+jest.mock('axios');
+
+// Capture a stable reference to the mock findAll so we can assert on it
+const mockFindAll = jest.fn().mockResolvedValue([]);
+
+jest.mock('../db/database', () => ({
+  getDb: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../repositories/webhook-subscription.repository', () => ({
+  SqliteWebhookSubscriptionRepository: jest.fn().mockImplementation(() => ({
+    findAll: mockFindAll,
+    create: jest.fn(),
+    findAllPaginated: jest.fn(),
+    findById: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  })),
+}));
+
+jest.mock('../queue/webhook-dlq', () => ({
+  getWebhookDLQStorage: jest.fn().mockReturnValue({
+    addEntry: jest.fn().mockResolvedValue(undefined),
+    listEntries: jest.fn().mockReturnValue([]),
+    getEntry: jest.fn().mockReturnValue(null),
+    getStats: jest.fn().mockReturnValue({ total: 0, pending: 0, replayed: 0 }),
+    checkDedupe: jest.fn().mockReturnValue({ exists: false }),
+    markReplayed: jest.fn(),
+  }),
+}));
+
+jest.mock('../utils/ssrf', () => ({
+  isSafeUrl: jest.fn().mockReturnValue(true),
+}));
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFindAll.mockResolvedValue([]);
+  delete process.env.WEBHOOKS_ENABLED;
+});
+
+afterAll(() => {
+  delete process.env.WEBHOOKS_ENABLED;
+});
+
+// ── Default behaviour ─────────────────────────────────────────────────────────
+
+describe('WEBHOOKS_ENABLED default behaviour', () => {
+  it('defaults to enabled (true) when env var is absent', () => {
+    delete process.env.WEBHOOKS_ENABLED;
+    const service = new WebhookService();
+    expect((service as any).webhooksEnabled).toBe(true);
+  });
+
+  it('defaults to enabled when env var is empty string', () => {
+    process.env.WEBHOOKS_ENABLED = '';
+    // parseBoolEnv treats empty string as undefined → uses default true
+    const service = new WebhookService();
+    expect((service as any).webhooksEnabled).toBe(true);
+  });
+});
+
+// ── Constructor injection ─────────────────────────────────────────────────────
+
+describe('constructor injection', () => {
+  it('respects webhooksEnabled=true injected directly', () => {
+    const service = new WebhookService(undefined, true);
+    expect((service as any).webhooksEnabled).toBe(true);
+  });
+
+  it('respects webhooksEnabled=false injected directly', () => {
+    const service = new WebhookService(undefined, false);
+    expect((service as any).webhooksEnabled).toBe(false);
+  });
+
+  it('injected flag takes precedence over process.env', () => {
+    process.env.WEBHOOKS_ENABLED = 'false';
+    const service = new WebhookService(undefined, true);
+    expect((service as any).webhooksEnabled).toBe(true);
+  });
+});
+
+// ── process.env reading ───────────────────────────────────────────────────────
+
+describe('WEBHOOKS_ENABLED env var reading', () => {
+  it('reads true when WEBHOOKS_ENABLED=true', () => {
+    process.env.WEBHOOKS_ENABLED = 'true';
+    const service = new WebhookService();
+    expect((service as any).webhooksEnabled).toBe(true);
+  });
+
+  it('reads false when WEBHOOKS_ENABLED=false', () => {
+    process.env.WEBHOOKS_ENABLED = 'false';
+    const service = new WebhookService();
+    expect((service as any).webhooksEnabled).toBe(false);
+  });
+
+  it('reads true when WEBHOOKS_ENABLED=1', () => {
+    process.env.WEBHOOKS_ENABLED = '1';
+    const service = new WebhookService();
+    expect((service as any).webhooksEnabled).toBe(true);
+  });
+
+  it('reads false when WEBHOOKS_ENABLED=0', () => {
+    process.env.WEBHOOKS_ENABLED = '0';
+    const service = new WebhookService();
+    expect((service as any).webhooksEnabled).toBe(false);
+  });
+
+  it('reads true when WEBHOOKS_ENABLED=TRUE (case-insensitive)', () => {
+    process.env.WEBHOOKS_ENABLED = 'TRUE';
+    const service = new WebhookService();
+    expect((service as any).webhooksEnabled).toBe(true);
+  });
+
+  it('reads false when WEBHOOKS_ENABLED=FALSE (case-insensitive)', () => {
+    process.env.WEBHOOKS_ENABLED = 'FALSE';
+    const service = new WebhookService();
+    expect((service as any).webhooksEnabled).toBe(false);
+  });
+});
+
+// ── Flag ON behaviour ─────────────────────────────────────────────────────────
+
+describe('WEBHOOKS_ENABLED=true (flag ON)', () => {
+  it('trigger() queries subscriptions when flag is on', async () => {
+    const service = new WebhookService(undefined, true);
+    await service.trigger('contract.created', { id: 'abc' });
+
+    expect(mockFindAll).toHaveBeenCalledTimes(1);
+    expect(mockFindAll).toHaveBeenCalledWith({ eventType: 'contract.created', active: true });
+  });
+
+  it('trigger() delivers to each active matching subscription', async () => {
+    const mockSubscriptions = [
+      { id: 'sub-1', url: 'https://example.com/webhook', eventType: 'contract.created', secret: 'secret1', active: true },
+      { id: 'sub-2', url: 'https://other.com/hook', eventType: 'contract.created', secret: undefined, active: true },
+    ];
+    mockFindAll.mockResolvedValueOnce(mockSubscriptions);
+
+    const axios = require('axios');
+    axios.post = jest.fn().mockResolvedValue({ status: 200 });
+
+    const service = new WebhookService(undefined, true);
+    await service.trigger('contract.created', { id: 'abc' });
+
+    // Both subscriptions should have received delivery attempts
+    expect(axios.post).toHaveBeenCalledTimes(2);
+    expect(axios.post).toHaveBeenCalledWith(
+      'https://example.com/webhook',
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(axios.post).toHaveBeenCalledWith(
+      'https://other.com/hook',
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it('trigger() passes correlationId through to deliveries', async () => {
+    const mockSubscriptions = [
+      { id: 'sub-1', url: 'https://example.com/webhook', eventType: 'dispute.resolved', secret: undefined, active: true },
+    ];
+    mockFindAll.mockResolvedValueOnce(mockSubscriptions);
+
+    const axios = require('axios');
+    axios.post = jest.fn().mockResolvedValue({ status: 200 });
+
+    const service = new WebhookService(undefined, true);
+    await service.trigger('dispute.resolved', { disputeId: 'xyz' }, 'corr-abc-123');
+
+    expect(axios.post).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.anything(),
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'X-Correlation-Id': 'corr-abc-123' }),
+      }),
+    );
+  });
+
+  it('trigger() with no matching subscriptions calls findAll but sends nothing', async () => {
+    mockFindAll.mockResolvedValueOnce([]);
+
+    const axios = require('axios');
+    axios.post = jest.fn();
+
+    const service = new WebhookService(undefined, true);
+    await service.trigger('contract.created', { id: 'abc' });
+
+    expect(mockFindAll).toHaveBeenCalledTimes(1);
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+});
+
+// ── Flag OFF behaviour ────────────────────────────────────────────────────────
+
+describe('WEBHOOKS_ENABLED=false (flag OFF)', () => {
+  it('trigger() returns immediately without querying subscriptions', async () => {
+    const service = new WebhookService(undefined, false);
+    await service.trigger('contract.created', { id: 'abc' });
+
+    expect(mockFindAll).not.toHaveBeenCalled();
+  });
+
+  it('trigger() does not make any HTTP delivery calls', async () => {
+    const axios = require('axios');
+    axios.post = jest.fn();
+
+    const service = new WebhookService(undefined, false);
+    await service.trigger('contract.created', { id: 'abc' });
+
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+
+  it('trigger() does not write to DLQ', async () => {
+    const { getWebhookDLQStorage } = require('../queue/webhook-dlq');
+    const dlqStorage = getWebhookDLQStorage();
+
+    const service = new WebhookService(undefined, false);
+    await service.trigger('contract.created', { id: 'abc' });
+
+    expect(dlqStorage.addEntry).not.toHaveBeenCalled();
+  });
+
+  it('trigger() resolves successfully (no exception thrown)', async () => {
+    const service = new WebhookService(undefined, false);
+    await expect(service.trigger('contract.created', { id: 'abc' })).resolves.toBeUndefined();
+  });
+
+  it('trigger() is a no-op for any event type when disabled', async () => {
+    const service = new WebhookService(undefined, false);
+    await service.trigger('contract.created', {});
+    await service.trigger('dispute.initiated', {});
+    await service.trigger('escrow.completed', {});
+
+    expect(mockFindAll).not.toHaveBeenCalled();
+  });
+
+  it('trigger() is a no-op when flag is read from WEBHOOKS_ENABLED=false env var', async () => {
+    process.env.WEBHOOKS_ENABLED = 'false';
+    const service = new WebhookService();
+    await service.trigger('contract.created', { id: 'abc' });
+
+    expect(mockFindAll).not.toHaveBeenCalled();
+  });
+
+  it('trigger() is a no-op when WEBHOOKS_ENABLED=0', async () => {
+    process.env.WEBHOOKS_ENABLED = '0';
+    const service = new WebhookService();
+    await service.trigger('contract.created', { id: 'abc' });
+
+    expect(mockFindAll).not.toHaveBeenCalled();
+  });
+});
+
+// ── Non-trigger methods unaffected by flag ────────────────────────────────────
+
+describe('non-trigger methods are unaffected by the flag', () => {
+  it('getDLQ() works regardless of flag value', () => {
+    const serviceOn = new WebhookService(undefined, true);
+    const serviceOff = new WebhookService(undefined, false);
+    expect(serviceOn.getDLQ()).toEqual([]);
+    expect(serviceOff.getDLQ()).toEqual([]);
+  });
+
+  it('getDLQStats() works regardless of flag value', async () => {
+    const serviceOn = new WebhookService(undefined, true);
+    const serviceOff = new WebhookService(undefined, false);
+    await expect(serviceOn.getDLQStats()).resolves.toEqual({ total: 0, pending: 0, replayed: 0 });
+    await expect(serviceOff.getDLQStats()).resolves.toEqual({ total: 0, pending: 0, replayed: 0 });
+  });
+
+  it('getDLQEntry() works regardless of flag value', async () => {
+    const serviceOn = new WebhookService(undefined, true);
+    const serviceOff = new WebhookService(undefined, false);
+    await expect(serviceOn.getDLQEntry('nonexistent')).resolves.toBeNull();
+    await expect(serviceOff.getDLQEntry('nonexistent')).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #942.

Gates the entire webhooks subsystem behind a `WEBHOOKS_ENABLED` runtime feature flag so it can be toggled without a deploy.

---

## Changes

### Config
- **`src/config/env.schema.ts`** — Added `WEBHOOKS_ENABLED` field (Zod-validated, default `true`).
- **`src/config/features.ts`** — Added `webhooksEnabled: parseBoolEnv('WEBHOOKS_ENABLED', true)` to `FeaturesConfig`.

### Runtime gating
- **`src/services/webhook.service.ts`** — `trigger()` returns immediately (no-op) when the flag is off. No subscription queries, no HTTP deliveries, no DLQ writes. Flag is injectable via the constructor for testability.
- **`src/app.ts`** — `/api/v1/webhook-subscriptions` router is only mounted when `features.webhooksEnabled === true`. All subscription management endpoints return `404` when the flag is off.

### Tests (47 new, all passing)
- **`src/services/webhooks.flag.test.ts`** — 25 tests: default, constructor injection, env var edge cases, flag ON delivery, flag OFF no-op
- **`src/routes/webhook-subscription.flag.test.ts`** — 22 tests: schema parsing, features field, route gating ON/OFF, default behaviour

### Documentation
- **`.env.example`**, **`README.md`**, **`docs/webhooks.md`**, **`docs/backend/config.md`** updated

---

## Behaviour

| State | `WEBHOOKS_ENABLED=true` (default) | `WEBHOOKS_ENABLED=false` |
|---|---|---|
| `WebhookService.trigger()` | Queries subscriptions, delivers events | Immediate no-op |
| `/api/v1/webhook-subscriptions` router | Mounted and functional | Not mounted — all endpoints 404 |

---

## Test output

```
PASS src/services/webhooks.flag.test.ts    — 25 tests
PASS src/routes/webhook-subscription.flag.test.ts — 22 tests
Tests: 47 passed, 0 failed
```