### PR TITLE
refactor(milestones): extract string constants (#61)

### DIFF
--- a/src/controllers/milestones.softdelete.controller.ts
+++ b/src/controllers/milestones.softdelete.controller.ts
@@ -7,6 +7,7 @@ import {
 import { SoftDeleteRetentionError } from '../utils/softDelete';
 import { fail, ok } from '../utils/apiResponse';
 import { createMilestoneSchema, type CreateMilestoneInput } from '../modules/contracts/dto/milestones.dto';
+import { MILESTONE_CONTROLLER_MSGS } from '../modules/contracts/milestones.constants';
 
 function serializeMilestone(m: {
   id: string;
@@ -89,7 +90,7 @@ export class MilestonesSoftDeleteController {
       const deleted = milestonesService.softDelete(contractId, milestoneId);
       ok(res, {
         milestone: serializeMilestone(deleted),
-        message: `Milestone ${milestoneId} soft-deleted`,
+        message: MILESTONE_CONTROLLER_MSGS.softDeleted(milestoneId),
       });
     } catch (error) {
       if (mapMilestoneError(res, error)) return;
@@ -104,7 +105,7 @@ export class MilestonesSoftDeleteController {
       const restored = milestonesService.restore(contractId, milestoneId);
       ok(res, {
         milestone: serializeMilestone(restored),
-        message: `Milestone ${milestoneId} restored`,
+        message: MILESTONE_CONTROLLER_MSGS.restored(milestoneId),
       });
     } catch (error) {
       if (mapMilestoneError(res, error)) return;

--- a/src/modules/contracts/dto/milestones.dto.ts
+++ b/src/modules/contracts/dto/milestones.dto.ts
@@ -19,6 +19,9 @@ import { registry } from '../../../docs/openapi-registry';
 import {
   MAX_CONTRACT_AMOUNT_STROOPS,
 } from '../../../contracts/bounds';
+import {
+  MILESTONE_VALIDATION_MSGS,
+} from '../milestones.constants';
 
 // ─── Field-level constants ────────────────────────────────────────────────────
 
@@ -44,8 +47,8 @@ const DATETIME_MAX_LENGTH = 64;
  */
 const datetimeField = z
   .string()
-  .max(DATETIME_MAX_LENGTH, `Datetime string must not exceed ${DATETIME_MAX_LENGTH} characters`)
-  .datetime({ message: 'Must be a valid ISO-8601 datetime string' });
+  .max(DATETIME_MAX_LENGTH, MILESTONE_VALIDATION_MSGS.datetimeMax(DATETIME_MAX_LENGTH))
+  .datetime({ message: MILESTONE_VALIDATION_MSGS.datetimeFormat });
 
 // ─── Request schemas ───────────────────────────────────────────────────────────
 
@@ -67,17 +70,17 @@ export const createMilestoneSchema = z
   .object({
     title: z
       .string()
-      .min(MILESTONE_TITLE_MIN_LENGTH, `Milestone title must be at least ${MILESTONE_TITLE_MIN_LENGTH} character`)
-      .max(MILESTONE_TITLE_MAX_LENGTH, `Milestone title must not exceed ${MILESTONE_TITLE_MAX_LENGTH} characters`),
+      .min(MILESTONE_TITLE_MIN_LENGTH, MILESTONE_VALIDATION_MSGS.titleMin(MILESTONE_TITLE_MIN_LENGTH))
+      .max(MILESTONE_TITLE_MAX_LENGTH, MILESTONE_VALIDATION_MSGS.titleMax(MILESTONE_TITLE_MAX_LENGTH)),
     description: z
       .string()
-      .min(MILESTONE_DESCRIPTION_MIN_LENGTH, `Milestone description must be at least ${MILESTONE_DESCRIPTION_MIN_LENGTH} character`)
-      .max(MILESTONE_DESCRIPTION_MAX_LENGTH, `Milestone description must not exceed ${MILESTONE_DESCRIPTION_MAX_LENGTH} characters`)
+      .min(MILESTONE_DESCRIPTION_MIN_LENGTH, MILESTONE_VALIDATION_MSGS.descriptionMin(MILESTONE_DESCRIPTION_MIN_LENGTH))
+      .max(MILESTONE_DESCRIPTION_MAX_LENGTH, MILESTONE_VALIDATION_MSGS.descriptionMax(MILESTONE_DESCRIPTION_MAX_LENGTH))
       .optional(),
     amount: z
-      .number({ invalid_type_error: 'Milestone amount must be a number' })
-      .positive('Milestone amount must be a positive number')
-      .max(MAX_CONTRACT_AMOUNT_STROOPS, `Milestone amount must not exceed ${MAX_CONTRACT_AMOUNT_STROOPS}`),
+      .number({ invalid_type_error: MILESTONE_VALIDATION_MSGS.amountType })
+      .positive(MILESTONE_VALIDATION_MSGS.amountPositive)
+      .max(MAX_CONTRACT_AMOUNT_STROOPS, MILESTONE_VALIDATION_MSGS.amountMax(MAX_CONTRACT_AMOUNT_STROOPS)),
     deadline: datetimeField.optional(),
     completed: z.boolean().optional(),
   })
@@ -93,18 +96,18 @@ export const updateMilestoneSchema = z
   .object({
     title: z
       .string()
-      .min(MILESTONE_TITLE_MIN_LENGTH, `Milestone title must be at least ${MILESTONE_TITLE_MIN_LENGTH} character`)
-      .max(MILESTONE_TITLE_MAX_LENGTH, `Milestone title must not exceed ${MILESTONE_TITLE_MAX_LENGTH} characters`)
+      .min(MILESTONE_TITLE_MIN_LENGTH, MILESTONE_VALIDATION_MSGS.titleMin(MILESTONE_TITLE_MIN_LENGTH))
+      .max(MILESTONE_TITLE_MAX_LENGTH, MILESTONE_VALIDATION_MSGS.titleMax(MILESTONE_TITLE_MAX_LENGTH))
       .optional(),
     description: z
       .string()
-      .min(MILESTONE_DESCRIPTION_MIN_LENGTH, `Milestone description must be at least ${MILESTONE_DESCRIPTION_MIN_LENGTH} character`)
-      .max(MILESTONE_DESCRIPTION_MAX_LENGTH, `Milestone description must not exceed ${MILESTONE_DESCRIPTION_MAX_LENGTH} characters`)
+      .min(MILESTONE_DESCRIPTION_MIN_LENGTH, MILESTONE_VALIDATION_MSGS.descriptionMin(MILESTONE_DESCRIPTION_MIN_LENGTH))
+      .max(MILESTONE_DESCRIPTION_MAX_LENGTH, MILESTONE_VALIDATION_MSGS.descriptionMax(MILESTONE_DESCRIPTION_MAX_LENGTH))
       .optional(),
     amount: z
-      .number({ invalid_type_error: 'Milestone amount must be a number' })
-      .positive('Milestone amount must be a positive number')
-      .max(MAX_CONTRACT_AMOUNT_STROOPS, `Milestone amount must not exceed ${MAX_CONTRACT_AMOUNT_STROOPS}`)
+      .number({ invalid_type_error: MILESTONE_VALIDATION_MSGS.amountType })
+      .positive(MILESTONE_VALIDATION_MSGS.amountPositive)
+      .max(MAX_CONTRACT_AMOUNT_STROOPS, MILESTONE_VALIDATION_MSGS.amountMax(MAX_CONTRACT_AMOUNT_STROOPS))
       .optional(),
     deadline: datetimeField.optional(),
     completed: z.boolean().optional(),
@@ -145,7 +148,7 @@ export const milestonesListResponseSchema = z.object({
  * Must be a valid UUID.
  */
 export const milestoneIdParamSchema = z.object({
-  milestoneId: z.string().uuid('Milestone ID must be a valid UUID'),
+  milestoneId: z.string().uuid(MILESTONE_VALIDATION_MSGS.milestoneIdUuid),
 });
 
 // ─── Query parameter schemas ───────────────────────────────────────────────────

--- a/src/modules/contracts/milestones.constants.ts
+++ b/src/modules/contracts/milestones.constants.ts
@@ -1,0 +1,142 @@
+/**
+ * @file milestones.constants.ts
+ * @description Centralised string constants for the milestones subsystem.
+ *
+ * All error codes, error names, audit action names, environment-variable keys,
+ * and user-facing message templates used across the milestones service,
+ * controller, DTO, and audit modules live here.  Referencing these constants
+ * instead of inline literals ensures:
+ *
+ *  - A single source of truth that is easy to grep and audit.
+ *  - Typo-proof refactors: the compiler catches every reference when a
+ *    constant is renamed.
+ *  - Stable API contract strings – tests can import the same constant rather
+ *    than duplicating the raw string.
+ *
+ * ## Grouping
+ *
+ * Constants are grouped by concern:
+ *
+ *  1. `MILESTONE_ERROR_CODES`      – machine-readable error code strings.
+ *  2. `MILESTONE_ERROR_NAMES`      – Error subclass `.name` properties.
+ *  3. `MILESTONE_AUDIT_ACTIONS`    – AuditAction values emitted by the audit helper.
+ *  4. `MILESTONE_ENV_KEYS`         – process.env key names consumed by the service.
+ *  5. `MILESTONE_MESSAGES`         – parameterised user-facing message factories.
+ *  6. `MILESTONE_CONTROLLER_MSGS`  – response message snippets emitted by the controller.
+ *  7. `MILESTONE_VALIDATION_MSGS`  – Zod validation error message strings from the DTO.
+ */
+
+// ─── 1. Error codes ──────────────────────────────────────────────────────────
+
+/**
+ * Machine-readable error codes used in MilestoneNotFoundError and
+ * MilestoneConflictError.  Clients may switch on these values; do not rename
+ * or remove existing entries without a breaking-change notice.
+ */
+export const MILESTONE_ERROR_CODES = {
+  NOT_FOUND: 'milestone_not_found',
+  CONFLICT: 'milestone_conflict',
+} as const;
+
+// ─── 2. Error names ──────────────────────────────────────────────────────────
+
+/**
+ * The `.name` property set on each custom Error subclass.  These appear in
+ * stack traces and structured log records.
+ */
+export const MILESTONE_ERROR_NAMES = {
+  NOT_FOUND: 'MilestoneNotFoundError',
+  CONFLICT: 'MilestoneConflictError',
+} as const;
+
+// ─── 3. Audit action names ───────────────────────────────────────────────────
+
+/**
+ * AuditAction strings emitted by `determineMilestonesAction`.
+ * Must stay in sync with the `AuditAction` union in `src/audit/types.ts`.
+ */
+export const MILESTONE_AUDIT_ACTIONS = {
+  CREATED: 'MILESTONES_CREATED',
+  UPDATED: 'MILESTONES_UPDATED',
+  DELETED: 'MILESTONES_DELETED',
+} as const;
+
+// ─── 4. Environment variable keys ───────────────────────────────────────────
+
+/**
+ * Names of environment variables read by the milestones subsystem.
+ */
+export const MILESTONE_ENV_KEYS = {
+  SOFT_DELETE_RETENTION_DAYS: 'MILESTONES_SOFT_DELETE_RETENTION_DAYS',
+} as const;
+
+// ─── 5. Message factories ────────────────────────────────────────────────────
+
+/**
+ * Parameterised message factories for runtime error messages.
+ * Using functions (rather than template literals inlined at the call-site)
+ * keeps the shape of every message in one place and makes them independently
+ * testable.
+ */
+export const MILESTONE_MESSAGES = {
+  notFound: (milestoneId: string, contractId: string): string =>
+    `Milestone ${milestoneId} not found for contract ${contractId}`,
+
+  alreadySoftDeleted: (milestoneId: string): string =>
+    `Milestone ${milestoneId} is already soft-deleted`,
+
+  notSoftDeleted: (milestoneId: string): string =>
+    `Milestone ${milestoneId} is not soft-deleted`,
+
+  retentionWindowExpired: (milestoneId: string, retentionDays: number): string =>
+    `Milestone ${milestoneId} retention window of ${retentionDays} days has expired`,
+
+  totalExceedsBudget: (total: number, budget: number): string =>
+    `Total milestone amount exceeds maximum contract amount ` +
+    `(milestones total ${total} exceeds budget of ${budget})`,
+} as const;
+
+// ─── 6. Controller response messages ────────────────────────────────────────
+
+/**
+ * Short status messages returned in the `message` field of soft-delete and
+ * restore responses.
+ */
+export const MILESTONE_CONTROLLER_MSGS = {
+  softDeleted: (milestoneId: string): string => `Milestone ${milestoneId} soft-deleted`,
+  restored: (milestoneId: string): string => `Milestone ${milestoneId} restored`,
+} as const;
+
+// ─── 7. DTO / Zod validation messages ───────────────────────────────────────
+
+/**
+ * Zod error message strings referenced inside `milestones.dto.ts` schema
+ * definitions.  Centralising them here means integration tests and DTO tests
+ * can import the exact expected string rather than embedding it twice.
+ */
+export const MILESTONE_VALIDATION_MSGS = {
+  // title
+  titleMin: (min: number): string =>
+    `Milestone title must be at least ${min} character`,
+  titleMax: (max: number): string =>
+    `Milestone title must not exceed ${max} characters`,
+
+  // description
+  descriptionMin: (min: number): string =>
+    `Milestone description must be at least ${min} character`,
+  descriptionMax: (max: number): string =>
+    `Milestone description must not exceed ${max} characters`,
+
+  // amount
+  amountType: 'Milestone amount must be a number',
+  amountPositive: 'Milestone amount must be a positive number',
+  amountMax: (max: number): string => `Milestone amount must not exceed ${max}`,
+
+  // deadline
+  datetimeMax: (max: number): string =>
+    `Datetime string must not exceed ${max} characters`,
+  datetimeFormat: 'Must be a valid ISO-8601 datetime string',
+
+  // milestoneId param
+  milestoneIdUuid: 'Milestone ID must be a valid UUID',
+} as const;

--- a/src/modules/contracts/milestonesAudit.ts
+++ b/src/modules/contracts/milestonesAudit.ts
@@ -33,6 +33,7 @@ import type { AuditAction } from '../../audit/types';
 import type { AuditService } from '../../audit/service';
 import { redactBody } from '../../audit/redact';
 import type { ContractMilestoneDto } from './dto/contracts-boundary.dto';
+import { MILESTONE_AUDIT_ACTIONS } from './milestones.constants';
 
 /** Maximum number of individual milestone items retained in one audit summary. */
 export const MAX_SUMMARY_ITEMS = 50;
@@ -146,13 +147,13 @@ export function determineMilestonesAction(
   const hasAfter = after !== null && after.count > 0;
 
   if (!hadBefore && !hasAfter) return null;
-  if (!hadBefore && hasAfter) return 'MILESTONES_CREATED';
-  if (hadBefore && !hasAfter) return 'MILESTONES_DELETED';
+  if (!hadBefore && hasAfter) return MILESTONE_AUDIT_ACTIONS.CREATED;
+  if (hadBefore && !hasAfter) return MILESTONE_AUDIT_ACTIONS.DELETED;
 
   // Both present: only log when the content actually changed, so replaying
   // an identical PATCH does not spam the log with no-op entries.
   if (deepEqual(before, after)) return null;
-  return 'MILESTONES_UPDATED';
+  return MILESTONE_AUDIT_ACTIONS.UPDATED;
 }
 
 /** Builds the audit-entry metadata payload for a milestones write. */

--- a/src/services/milestones.service.ts
+++ b/src/services/milestones.service.ts
@@ -8,10 +8,21 @@ import {
   isWithinRetentionWindow,
   parseRetentionDays,
 } from '../utils/softDelete';
+import {
+  MILESTONE_ERROR_CODES,
+  MILESTONE_ERROR_NAMES,
+  MILESTONE_ENV_KEYS,
+  MILESTONE_MESSAGES,
+} from '../modules/contracts/milestones.constants';
 
-/** Env key for milestones soft-delete retention window (days). */
+/**
+ * Env key for milestones soft-delete retention window (days).
+ * @deprecated Import `MILESTONE_ENV_KEYS.SOFT_DELETE_RETENTION_DAYS` from
+ * `milestones.constants` directly.  This re-export is kept for backwards
+ * compatibility with existing tests and callers.
+ */
 export const MILESTONES_SOFT_DELETE_RETENTION_DAYS_ENV =
-  'MILESTONES_SOFT_DELETE_RETENTION_DAYS';
+  MILESTONE_ENV_KEYS.SOFT_DELETE_RETENTION_DAYS;
 
 /**
  * Persisted milestone record with soft-delete metadata.
@@ -40,22 +51,22 @@ export interface CreateMilestoneInput {
 }
 
 export class MilestoneNotFoundError extends Error {
-  public readonly code = 'milestone_not_found';
+  public readonly code = MILESTONE_ERROR_CODES.NOT_FOUND;
   public readonly statusCode = 404;
 
   constructor(message: string) {
     super(message);
-    this.name = 'MilestoneNotFoundError';
+    this.name = MILESTONE_ERROR_NAMES.NOT_FOUND;
   }
 }
 
 export class MilestoneConflictError extends Error {
-  public readonly code = 'milestone_conflict';
+  public readonly code = MILESTONE_ERROR_CODES.CONFLICT;
   public readonly statusCode = 409;
 
   constructor(message: string) {
     super(message);
-    this.name = 'MilestoneConflictError';
+    this.name = MILESTONE_ERROR_NAMES.CONFLICT;
   }
 }
 
@@ -70,7 +81,7 @@ export class MilestonesService {
    * Retention window in days. Overridable via env for tests and ops.
    */
   public getRetentionDays(): number {
-    return parseRetentionDays(process.env[MILESTONES_SOFT_DELETE_RETENTION_DAYS_ENV]);
+    return parseRetentionDays(process.env[MILESTONE_ENV_KEYS.SOFT_DELETE_RETENTION_DAYS]);
   }
 
   /**
@@ -105,8 +116,7 @@ export class MilestonesService {
       );
       if (totalMilestoneAmount > budget) {
         throw new ContractBoundsError(
-          `Total milestone amount exceeds maximum contract amount ` +
-            `(milestones total ${totalMilestoneAmount} exceeds budget of ${budget})`,
+          MILESTONE_MESSAGES.totalExceedsBudget(totalMilestoneAmount, budget),
         );
       }
     }
@@ -162,12 +172,12 @@ export class MilestonesService {
     const record = milestoneStore.get(milestoneId);
     if (!record || record.contractId !== contractId) {
       throw new MilestoneNotFoundError(
-        `Milestone ${milestoneId} not found for contract ${contractId}`,
+        MILESTONE_MESSAGES.notFound(milestoneId, contractId),
       );
     }
     if (!options.includeDeleted && isSoftDeleted(record.deletedAt)) {
       throw new MilestoneNotFoundError(
-        `Milestone ${milestoneId} not found for contract ${contractId}`,
+        MILESTONE_MESSAGES.notFound(milestoneId, contractId),
       );
     }
     return { ...record };
@@ -181,11 +191,11 @@ export class MilestonesService {
     const record = milestoneStore.get(milestoneId);
     if (!record || record.contractId !== contractId) {
       throw new MilestoneNotFoundError(
-        `Milestone ${milestoneId} not found for contract ${contractId}`,
+        MILESTONE_MESSAGES.notFound(milestoneId, contractId),
       );
     }
     if (isSoftDeleted(record.deletedAt)) {
-      throw new MilestoneConflictError(`Milestone ${milestoneId} is already soft-deleted`);
+      throw new MilestoneConflictError(MILESTONE_MESSAGES.alreadySoftDeleted(milestoneId));
     }
 
     const updated: MilestoneRecord = {
@@ -210,17 +220,17 @@ export class MilestonesService {
     const record = milestoneStore.get(milestoneId);
     if (!record || record.contractId !== contractId) {
       throw new MilestoneNotFoundError(
-        `Milestone ${milestoneId} not found for contract ${contractId}`,
+        MILESTONE_MESSAGES.notFound(milestoneId, contractId),
       );
     }
     if (!isSoftDeleted(record.deletedAt) || !record.deletedAt) {
-      throw new MilestoneConflictError(`Milestone ${milestoneId} is not soft-deleted`);
+      throw new MilestoneConflictError(MILESTONE_MESSAGES.notSoftDeleted(milestoneId));
     }
 
     const retentionDays = this.getRetentionDays();
     if (!isWithinRetentionWindow(record.deletedAt, retentionDays, now)) {
       throw new SoftDeleteRetentionError(
-        `Milestone ${milestoneId} retention window of ${retentionDays} days has expired`,
+        MILESTONE_MESSAGES.retentionWindowExpired(milestoneId, retentionDays),
       );
     }
 


### PR DESCRIPTION
## Summary

Closes #61

Centralises all repeated inline string literals from the milestones subsystem into a single constants module.

No string values were changed. Behaviour is identical.

---

## Changes

### New file
`src/modules/contracts/milestones.constants.ts`

Seven constant groups:

| Export | Contents |
|---|---|
| `MILESTONE_ERROR_CODES` | `'milestone_not_found'`, `'milestone_conflict'` |
| `MILESTONE_ERROR_NAMES` | `'MilestoneNotFoundError'`, `'MilestoneConflictError'` |
| `MILESTONE_AUDIT_ACTIONS` | `'MILESTONES_CREATED'`, `'MILESTONES_UPDATED'`, `'MILESTONES_DELETED'` |
| `MILESTONE_ENV_KEYS` | `'MILESTONES_SOFT_DELETE_RETENTION_DAYS'` |
| `MILESTONE_MESSAGES` | 5 parameterised message factories |
| `MILESTONE_CONTROLLER_MSGS` | soft-delete / restore response messages |
| `MILESTONE_VALIDATION_MSGS` | 9 Zod validation error strings |

### Updated files
- `src/services/milestones.service.ts` — error codes, names, env key, message templates
- `src/modules/contracts/milestonesAudit.ts` — audit action strings
- `src/modules/contracts/dto/milestones.dto.ts` — all Zod validation messages
- `src/controllers/milestones.softdelete.controller.ts` — response messages

### Backwards compatibility
`MILESTONES_SOFT_DELETE_RETENTION_DAYS_ENV` is kept as a re-export in `milestones.service.ts` so existing tests and callers need no changes.