### PR TITLE
Closes #627 — Honor upstream Retry-After headers in retry backoff utility

### DIFF
--- a/src/utils/retry.test.ts
+++ b/src/utils/retry.test.ts
@@ -1,4 +1,35 @@
-import { withRetry, calculateDelay } from './retry';
+import { withRetry, calculateDelay, parseRetryAfter } from './retry';
+
+describe('parseRetryAfter', () => {
+  it('parses delta-seconds as milliseconds', () => {
+    expect(parseRetryAfter('120', 300000)).toBe(120000);
+    expect(parseRetryAfter('0')).toBe(0);
+    expect(parseRetryAfter('1')).toBe(1000);
+  });
+
+  it('clamps to maxRetryAfterMs', () => {
+    expect(parseRetryAfter('999999', 5000)).toBe(5000);
+  });
+
+  it('parses HTTP-date format', () => {
+    const future = new Date(Date.now() + 30000);
+    const result = parseRetryAfter(future.toUTCString(), 60000);
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThanOrEqual(60000);
+  });
+
+  it('returns 0 for past HTTP-date', () => {
+    const past = new Date(Date.now() - 60000);
+    expect(parseRetryAfter(past.toUTCString())).toBe(0);
+  });
+
+  it('returns null for malformed values', () => {
+    expect(parseRetryAfter('not-a-date')).toBeNull();
+    expect(parseRetryAfter('')).toBeNull();
+    expect(parseRetryAfter(null)).toBeNull();
+    expect(parseRetryAfter(undefined)).toBeNull();
+  });
+});
 
 describe('calculateDelay', () => {
   it('returns exponential backoff', () => {
@@ -48,5 +79,14 @@ describe('withRetry', () => {
       withRetry(fn, { isRetryable: () => false, baseDelayMs: 0 })
     ).rejects.toThrow();
     expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('honors retryAfterHeader over calculated backoff', async () => {
+    const fn = jest.fn()
+      .mockRejectedValueOnce(new Error('throttled'))
+      .mockResolvedValue('ok');
+    await expect(
+      withRetry(fn, { maxAttempts: 2, retryAfterHeader: '1' })
+    ).resolves.toBe('ok');
   });
 });

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -12,6 +12,10 @@ export interface RetryOptions {
   maxDelayMs?: number;
   jitter?: boolean;
   isRetryable?: (error: unknown) => boolean;
+  /** Maximum milliseconds to honor from a Retry-After header (safety ceiling). */
+  maxRetryAfterMs?: number;
+  /** Optional Retry-After header value from upstream response. */
+  retryAfterHeader?: string | null;
 }
 
 const DEFAULT_OPTIONS: Required<RetryOptions> = {
@@ -20,6 +24,8 @@ const DEFAULT_OPTIONS: Required<RetryOptions> = {
   maxDelayMs: 5000,
   jitter: true,
   isRetryable: () => true,
+  maxRetryAfterMs: 60000,
+  retryAfterHeader: null,
 };
 
 
@@ -31,6 +37,44 @@ export function calculateDelay(
 ): number {
   const exponential = Math.min(baseDelayMs * 2 ** attempt, maxDelayMs);
   return jitter ? exponential * (0.5 + Math.random() * 0.5) : exponential;
+}
+
+/**
+ * Parse an HTTP `Retry-After` header value and return the delay in milliseconds.
+ *
+ * Supports both delta-seconds and HTTP-date formats.
+ * Returns `null` for malformed values.
+ *
+ * @param headerValue - The raw `Retry-After` header value
+ * @param maxRetryAfterMs - Safety ceiling to clamp the result (default 60s)
+ * @returns Delay in milliseconds, or `null` if unparseable
+ */
+export function parseRetryAfter(
+  headerValue: string | null | undefined,
+  maxRetryAfterMs: number = 60000
+): number | null {
+  if (!headerValue) return null;
+
+  const trimmed = headerValue.trim();
+
+  // Try delta-seconds format (integer or decimal)
+  const delta = parseInt(trimmed, 10);
+  if (!isNaN(delta) && delta >= 0 && String(delta) === trimmed) {
+    return Math.min(delta * 1000, maxRetryAfterMs);
+  }
+
+  // Try HTTP-date format (RFC 1123)
+  const parsed = Date.parse(trimmed);
+  if (!isNaN(parsed)) {
+    const now = Date.now();
+    const diff = parsed - now;
+    if (diff > 0) {
+      return Math.min(diff, maxRetryAfterMs);
+    }
+    return 0; // date is in the past, no delay needed
+  }
+
+  return null; // malformed
 }
 
 /**
@@ -62,12 +106,12 @@ export async function withRetry<T>(
         throw error;
       }
 
-      const delay = calculateDelay(
-        attempt,
-        opts.baseDelayMs,
-        opts.maxDelayMs,
-        opts.jitter
-      );
+      // Check for Retry-After header override (takes precedence over backoff)
+      const retryAfterMs = parseRetryAfter(opts.retryAfterHeader, opts.maxRetryAfterMs);
+
+      const delay = retryAfterMs !== null
+        ? retryAfterMs
+        : calculateDelay(attempt, opts.baseDelayMs, opts.maxDelayMs, opts.jitter);
       await sleep(delay);
     }
   }


### PR DESCRIPTION
Adds Retry-After header parsing to retry backoff with configurable max ceiling. Closes #627