### PR TITLE
feat(webhooks): add response caching with invalidation to subscriptio…

### DIFF
--- a/src/routes/webhook-subscription.routes.ts
+++ b/src/routes/webhook-subscription.routes.ts
@@ -20,6 +20,10 @@ import { validateWebhookUrl, findSubscriptionOrFail } from './webhook-subscripti
 import { createRateLimiter } from '../middleware/rateLimiter';
 import { rateLimitConfig } from '../config/rateLimit';
 import { authRateLimitKeyFn } from '../auth/rateLimitKey';
+import {
+  WebhookSubscriptionCacheService,
+  loadWebhookCacheConfig,
+} from '../services/webhookSubscriptionCache.service';
 
 const router = Router();
 
@@ -30,6 +34,14 @@ const webhookRateLimiter = createRateLimiter({
   ...rateLimitConfig.webhooksApi,
   keyFn: authRateLimitKeyFn,
 });
+
+/**
+ * Module-level cache singleton, configured from environment variables.
+ * A separate Registry is used so these metrics are isolated from the global
+ * MetricsService registry and do not cause duplicate-registration errors in
+ * tests that spin up the app multiple times.
+ */
+const webhookCache = new WebhookSubscriptionCacheService(loadWebhookCacheConfig());
 
 /**
  * Removes the webhook secret from a subscription object before sending to the client.
@@ -60,6 +72,10 @@ router.post(
       const repo = getRepo();
       const createDto = toCreateWebhookSubscriptionDto(req.body);
       const subscription = await repo.create(createDto);
+
+      // A new subscription changes every list result — purge all list keys.
+      webhookCache.invalidateLists();
+
       res.status(201).json({
         status: 'success',
         data: toWebhookSubscriptionResponseDto(subscription),
@@ -72,7 +88,8 @@ router.post(
 
 /**
  * GET /api/v1/webhook-subscriptions
- * Lists subscriptions with filter and cursor-based pagination support
+ * Lists subscriptions with filter and cursor-based pagination support.
+ * Results are served from cache when available.
  */
 router.get(
   '/',
@@ -85,6 +102,7 @@ router.get(
       const repo = getRepo();
       const query = toListWebhookSubscriptionsQueryDto(req.query as any);
       const { cursor: cursorStr, limit, ...filters } = query;
+
       if (cursorStr !== undefined) {
         try {
           decodeCursor(cursorStr);
@@ -98,15 +116,23 @@ router.get(
           });
         }
       }
+
       const filter = {
         consumerId: filters.consumerId,
         eventType: filters.eventType,
         active: filters.active,
       };
-      const page = await repo.findAllPaginated(filter, {
-        cursor: cursorStr,
-        limit: limit as number | undefined,
-      });
+
+      // Serve from cache; on miss the fetcher calls the repository directly.
+      const page = await webhookCache.getList(
+        { ...filter, cursor: cursorStr, limit: limit as number | undefined },
+        () =>
+          repo.findAllPaginated(filter, {
+            cursor: cursorStr,
+            limit: limit as number | undefined,
+          }),
+      );
+
       res.status(200).json({
         status: 'success',
         data: page.data.map(sanitizeSubscription),
@@ -124,7 +150,7 @@ router.get(
 
 /**
  * GET /api/v1/webhook-subscriptions/:id
- * Retrieves a single subscription
+ * Retrieves a single subscription. Result is served from cache when available.
  */
 router.get(
   '/:id',
@@ -136,8 +162,20 @@ router.get(
     try {
       const { id } = req.params;
       const repo = getRepo();
-      const subscription = await findSubscriptionOrFail(id, repo, res);
-      if (!subscription) return;
+
+      // Serve from cache; on miss the fetcher calls findById on the repo.
+      const subscription = await webhookCache.getById(id, () => repo.findById(id));
+
+      if (!subscription) {
+        res.status(404).json({
+          error: {
+            code: 'not_found',
+            message: 'Webhook subscription not found.',
+            requestId: res.locals?.requestId || 'unknown',
+          },
+        });
+        return;
+      }
 
       res.status(200).json({
         status: 'success',
@@ -151,7 +189,7 @@ router.get(
 
 /**
  * PATCH /api/v1/webhook-subscriptions/:id
- * Updates a subscription
+ * Updates a subscription. Invalidates both the per-id key and all list keys.
  */
 router.patch(
   '/:id',
@@ -173,6 +211,11 @@ router.patch(
 
       const updateDto = toUpdateWebhookSubscriptionDto(req.body);
       const updated = await repo.update(id, updateDto);
+
+      // Invalidate the specific subscription key and all list keys.
+      webhookCache.invalidateSubscription(id);
+      webhookCache.invalidateLists();
+
       res.status(200).json({
         status: 'success',
         data: toWebhookSubscriptionResponseDto(updated),
@@ -185,7 +228,7 @@ router.patch(
 
 /**
  * DELETE /api/v1/webhook-subscriptions/:id
- * Deletes a subscription
+ * Deletes a subscription. Invalidates both the per-id key and all list keys.
  */
 router.delete(
   '/:id',
@@ -201,6 +244,11 @@ router.delete(
       if (!(await findSubscriptionOrFail(id, repo, res))) return;
 
       await repo.delete(id);
+
+      // Invalidate the specific subscription key and all list keys.
+      webhookCache.invalidateSubscription(id);
+      webhookCache.invalidateLists();
+
       res.status(200).json({
         status: 'success',
         data: {

--- a/src/services/webhookSubscriptionCache.service.test.ts
+++ b/src/services/webhookSubscriptionCache.service.test.ts
@@ -1,0 +1,457 @@
+/**
+ * Unit tests for WebhookSubscriptionCacheService.
+ *
+ * Covers:
+ *  - Cold cache (miss): fetcher is called, result is returned
+ *  - Warm cache (hit): fetcher is NOT called on second read
+ *  - Invalidation on write: invalidateSubscription / invalidateLists cause a
+ *    fresh fetch on the next read
+ *  - LRU eviction at max-entries bound: oldest entry is purged when cap is hit
+ *  - Metrics: hit/miss/invalidation counters and entry gauge are accurate
+ *  - loadWebhookCacheConfig: reads env vars with correct defaults
+ */
+
+import { Registry } from 'prom-client';
+import {
+  WebhookSubscriptionCacheService,
+  loadWebhookCacheConfig,
+  DEFAULT_WEBHOOK_CACHE_TTL_MS,
+  DEFAULT_WEBHOOK_CACHE_SWR_MS,
+  DEFAULT_WEBHOOK_CACHE_MAX_ENTRIES,
+} from './webhookSubscriptionCache.service';
+import type { WebhookSubscription } from '../types/webhook.types';
+import type { CursorPage } from '../contracts/cursor.types';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeSub(overrides: Partial<WebhookSubscription> = {}): WebhookSubscription {
+  return {
+    id: 'sub-1',
+    url: 'https://example.com/hook',
+    eventType: 'contract.created',
+    active: true,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makePage(
+  items: WebhookSubscription[] = [],
+): CursorPage<WebhookSubscription> {
+  return { data: items, nextCursor: null, hasNextPage: false, limit: 20 };
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function counterValue(json: any[], name: string, labels: Record<string, string> = {}): number {
+  const metric = json.find((m: any) => m.name === name);
+  if (!metric) return 0;
+  const entry = (metric.values as any[]).find((v: any) =>
+    Object.entries(labels).every(([k, val]) => v.labels[k] === val),
+  );
+  return entry?.value ?? 0;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('WebhookSubscriptionCacheService', () => {
+  let svc: WebhookSubscriptionCacheService;
+  let registry: Registry;
+
+  beforeEach(() => {
+    registry = new Registry();
+    svc = new WebhookSubscriptionCacheService({}, registry);
+  });
+
+  // ── getById ────────────────────────────────────────────────────────────────
+
+  describe('getById', () => {
+    it('cold cache: calls fetcher and returns result (miss)', async () => {
+      const sub = makeSub();
+      const fetcher = jest.fn().mockResolvedValue(sub);
+
+      const result = await svc.getById('sub-1', fetcher);
+
+      expect(result).toEqual(sub);
+      expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+
+    it('warm cache: returns cached result without calling fetcher (hit)', async () => {
+      const sub = makeSub();
+      const fetcher = jest.fn().mockResolvedValue(sub);
+
+      await svc.getById('sub-1', fetcher);       // cold — populates cache
+      const result = await svc.getById('sub-1', fetcher); // warm
+
+      expect(result).toEqual(sub);
+      expect(fetcher).toHaveBeenCalledTimes(1);  // second call used cache
+    });
+
+    it('returns undefined when subscription does not exist', async () => {
+      const fetcher = jest.fn().mockResolvedValue(undefined);
+
+      const result = await svc.getById('missing', fetcher);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('different ids use independent cache keys', async () => {
+      const subA = makeSub({ id: 'a' });
+      const subB = makeSub({ id: 'b' });
+      const fetchA = jest.fn().mockResolvedValue(subA);
+      const fetchB = jest.fn().mockResolvedValue(subB);
+
+      await svc.getById('a', fetchA);
+      await svc.getById('b', fetchB);
+      const hitA = await svc.getById('a', jest.fn());
+      const hitB = await svc.getById('b', jest.fn());
+
+      expect(hitA?.id).toBe('a');
+      expect(hitB?.id).toBe('b');
+      expect(fetchA).toHaveBeenCalledTimes(1);
+      expect(fetchB).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates fetcher errors on cache miss', async () => {
+      const fetcher = jest.fn().mockRejectedValue(new Error('db error'));
+
+      await expect(svc.getById('sub-1', fetcher)).rejects.toThrow('db error');
+    });
+  });
+
+  // ── getList ────────────────────────────────────────────────────────────────
+
+  describe('getList', () => {
+    it('cold cache: calls fetcher and returns result (miss)', async () => {
+      const page = makePage([makeSub()]);
+      const fetcher = jest.fn().mockResolvedValue(page);
+
+      const result = await svc.getList({}, fetcher);
+
+      expect(result).toEqual(page);
+      expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+
+    it('warm cache: returns cached result without calling fetcher (hit)', async () => {
+      const page = makePage([makeSub()]);
+      const fetcher = jest.fn().mockResolvedValue(page);
+
+      await svc.getList({}, fetcher);            // cold
+      const result = await svc.getList({}, fetcher); // warm
+
+      expect(result).toEqual(page);
+      expect(fetcher).toHaveBeenCalledTimes(1);
+    });
+
+    it('different filter params produce independent cache keys', async () => {
+      const pageA = makePage([makeSub({ eventType: 'contract.created' })]);
+      const pageB = makePage([makeSub({ eventType: 'payment.completed' })]);
+      const fetchA = jest.fn().mockResolvedValue(pageA);
+      const fetchB = jest.fn().mockResolvedValue(pageB);
+
+      await svc.getList({ eventType: 'contract.created' }, fetchA);
+      await svc.getList({ eventType: 'payment.completed' }, fetchB);
+
+      const hitA = await svc.getList({ eventType: 'contract.created' }, jest.fn());
+      const hitB = await svc.getList({ eventType: 'payment.completed' }, jest.fn());
+
+      expect(hitA.data[0].eventType).toBe('contract.created');
+      expect(hitB.data[0].eventType).toBe('payment.completed');
+      expect(fetchA).toHaveBeenCalledTimes(1);
+      expect(fetchB).toHaveBeenCalledTimes(1);
+    });
+
+    it('different cursor/limit params produce independent cache keys', async () => {
+      const page1 = makePage([makeSub({ id: 'p1' })]);
+      const page2 = makePage([makeSub({ id: 'p2' })]);
+      const f1 = jest.fn().mockResolvedValue(page1);
+      const f2 = jest.fn().mockResolvedValue(page2);
+
+      await svc.getList({ limit: 10 }, f1);
+      await svc.getList({ limit: 10, cursor: 'abc' }, f2);
+
+      const hit1 = await svc.getList({ limit: 10 }, jest.fn());
+      const hit2 = await svc.getList({ limit: 10, cursor: 'abc' }, jest.fn());
+
+      expect(hit1.data[0].id).toBe('p1');
+      expect(hit2.data[0].id).toBe('p2');
+    });
+
+    it('returns empty page from cache', async () => {
+      const empty = makePage([]);
+      const fetcher = jest.fn().mockResolvedValue(empty);
+
+      await svc.getList({}, fetcher);
+      const result = await svc.getList({}, jest.fn()); // cached
+
+      expect(result.data).toHaveLength(0);
+    });
+  });
+
+  // ── invalidateSubscription ────────────────────────────────────────────────
+
+  describe('invalidateSubscription', () => {
+    it('forces a fresh fetch on the next getById call', async () => {
+      const original = makeSub({ url: 'https://original.com/hook' });
+      const updated = makeSub({ url: 'https://updated.com/hook' });
+      const fetcher = jest.fn()
+        .mockResolvedValueOnce(original)
+        .mockResolvedValueOnce(updated);
+
+      await svc.getById('sub-1', fetcher);         // miss → original cached
+      svc.invalidateSubscription('sub-1');          // evict
+      const result = await svc.getById('sub-1', fetcher); // miss again → updated
+
+      expect(result?.url).toBe('https://updated.com/hook');
+      expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not affect other subscription keys', async () => {
+      const subA = makeSub({ id: 'a' });
+      const subB = makeSub({ id: 'b' });
+      const fetchA = jest.fn().mockResolvedValue(subA);
+      const fetchB = jest.fn().mockResolvedValue(subB);
+
+      await svc.getById('a', fetchA);
+      await svc.getById('b', fetchB);
+
+      svc.invalidateSubscription('a'); // only evict 'a'
+
+      const refetchA = jest.fn().mockResolvedValue(subA);
+      const hitB = jest.fn();
+
+      await svc.getById('a', refetchA);   // must call refetch
+      await svc.getById('b', hitB);        // must NOT call hitB
+
+      expect(refetchA).toHaveBeenCalledTimes(1);
+      expect(hitB).not.toHaveBeenCalled();
+    });
+
+    it('does not affect list cache keys', async () => {
+      const page = makePage([makeSub()]);
+      const listFetcher = jest.fn().mockResolvedValue(page);
+
+      await svc.getList({}, listFetcher);
+      svc.invalidateSubscription('sub-1'); // should NOT affect list cache
+
+      const listHit = jest.fn();
+      await svc.getList({}, listHit);      // still cached
+
+      expect(listHit).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── invalidateLists ────────────────────────────────────────────────────────
+
+  describe('invalidateLists', () => {
+    it('forces a fresh fetch on the next getList call', async () => {
+      const before = makePage([makeSub({ url: 'https://before.com' })]);
+      const after = makePage([makeSub({ url: 'https://after.com' })]);
+      const fetcher = jest.fn()
+        .mockResolvedValueOnce(before)
+        .mockResolvedValueOnce(after);
+
+      await svc.getList({}, fetcher);   // miss → cached
+      svc.invalidateLists();             // evict all lists
+      const result = await svc.getList({}, fetcher); // miss again
+
+      expect(result.data[0].url).toBe('https://after.com');
+      expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+
+    it('invalidates all list key variants', async () => {
+      const pageAll = makePage([makeSub()]);
+      const pageFiltered = makePage([makeSub({ eventType: 'payment.completed' })]);
+      const fAll = jest.fn().mockResolvedValue(pageAll);
+      const fFiltered = jest.fn().mockResolvedValue(pageFiltered);
+
+      // Populate two distinct list keys
+      await svc.getList({}, fAll);
+      await svc.getList({ eventType: 'payment.completed' }, fFiltered);
+
+      svc.invalidateLists();
+
+      const refetchAll = jest.fn().mockResolvedValue(pageAll);
+      const refetchFiltered = jest.fn().mockResolvedValue(pageFiltered);
+
+      await svc.getList({}, refetchAll);
+      await svc.getList({ eventType: 'payment.completed' }, refetchFiltered);
+
+      expect(refetchAll).toHaveBeenCalledTimes(1);
+      expect(refetchFiltered).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not affect per-id subscription cache keys', async () => {
+      const sub = makeSub();
+      const subFetcher = jest.fn().mockResolvedValue(sub);
+
+      await svc.getById('sub-1', subFetcher);  // cached
+      svc.invalidateLists();                    // should NOT evict per-id key
+
+      const subHit = jest.fn();
+      await svc.getById('sub-1', subHit);       // still cached
+
+      expect(subHit).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── LRU eviction ──────────────────────────────────────────────────────────
+
+  describe('LRU eviction at maxEntries bound', () => {
+    it('evicts oldest entry when cap is exceeded', async () => {
+      const small = new WebhookSubscriptionCacheService({ maxEntries: 2 }, new Registry());
+
+      await small.getById('a', jest.fn().mockResolvedValue(makeSub({ id: 'a' })));
+      await small.getById('b', jest.fn().mockResolvedValue(makeSub({ id: 'b' })));
+      expect(small.size).toBe(2);
+
+      // Adding 'c' pushes 'a' out (LRU)
+      await small.getById('c', jest.fn().mockResolvedValue(makeSub({ id: 'c' })));
+      expect(small.size).toBe(2);
+
+      // 'a' must be gone — next read triggers a fresh fetch
+      const refetchA = jest.fn().mockResolvedValue(makeSub({ id: 'a', url: 'https://refetched.com' }));
+      const resultA = await small.getById('a', refetchA);
+
+      expect(refetchA).toHaveBeenCalledTimes(1);
+      expect(resultA?.url).toBe('https://refetched.com');
+    });
+
+    it('cache size stays at or below maxEntries after many writes', async () => {
+      const small = new WebhookSubscriptionCacheService({ maxEntries: 3 }, new Registry());
+
+      for (let i = 0; i < 10; i++) {
+        await small.getById(
+          `sub-${i}`,
+          jest.fn().mockResolvedValue(makeSub({ id: `sub-${i}` })),
+        );
+      }
+
+      expect(small.size).toBeLessThanOrEqual(3);
+    });
+  });
+
+  // ── Metrics ────────────────────────────────────────────────────────────────
+
+  describe('metrics', () => {
+    it('increments miss counter on first getById (cold cache)', async () => {
+      await svc.getById('sub-1', jest.fn().mockResolvedValue(makeSub()));
+
+      const json = await registry.getMetricsAsJSON();
+      expect(counterValue(json, 'webhook_subscription_cache_misses_total', { operation: 'getById' })).toBe(1);
+    });
+
+    it('increments hit counter on second getById (warm cache)', async () => {
+      const fetcher = jest.fn().mockResolvedValue(makeSub());
+      await svc.getById('sub-1', fetcher);
+      await svc.getById('sub-1', fetcher);
+
+      const json = await registry.getMetricsAsJSON();
+      expect(counterValue(json, 'webhook_subscription_cache_hits_total', { operation: 'getById' })).toBe(1);
+      expect(counterValue(json, 'webhook_subscription_cache_misses_total', { operation: 'getById' })).toBe(1);
+    });
+
+    it('increments miss counter on first getList (cold cache)', async () => {
+      await svc.getList({}, jest.fn().mockResolvedValue(makePage()));
+
+      const json = await registry.getMetricsAsJSON();
+      expect(counterValue(json, 'webhook_subscription_cache_misses_total', { operation: 'getList' })).toBe(1);
+    });
+
+    it('increments hit counter on second getList (warm cache)', async () => {
+      const fetcher = jest.fn().mockResolvedValue(makePage());
+      await svc.getList({}, fetcher);
+      await svc.getList({}, fetcher);
+
+      const json = await registry.getMetricsAsJSON();
+      expect(counterValue(json, 'webhook_subscription_cache_hits_total', { operation: 'getList' })).toBe(1);
+    });
+
+    it('increments invalidation counter with reason=subscription_mutated', async () => {
+      svc.invalidateSubscription('sub-1');
+
+      const json = await registry.getMetricsAsJSON();
+      expect(
+        counterValue(json, 'webhook_subscription_cache_invalidations_total', { reason: 'subscription_mutated' }),
+      ).toBe(1);
+    });
+
+    it('increments invalidation counter with reason=list_mutated', async () => {
+      svc.invalidateLists();
+
+      const json = await registry.getMetricsAsJSON();
+      expect(
+        counterValue(json, 'webhook_subscription_cache_invalidations_total', { reason: 'list_mutated' }),
+      ).toBe(1);
+    });
+
+    it('updates entry gauge after writes', async () => {
+      await svc.getById('sub-1', jest.fn().mockResolvedValue(makeSub()));
+      await svc.getById('sub-2', jest.fn().mockResolvedValue(makeSub({ id: 'sub-2' })));
+
+      const json = await registry.getMetricsAsJSON();
+      const gauge = json.find((m: any) => m.name === 'webhook_subscription_cache_entries');
+      expect(gauge).toBeDefined();
+      const value = (gauge!.values as any[]).find((v: any) => v.value >= 2);
+      expect(value?.value).toBeGreaterThanOrEqual(2);
+    });
+
+    it('gauge reflects zero after full invalidation', async () => {
+      await svc.getById('sub-1', jest.fn().mockResolvedValue(makeSub()));
+      svc.invalidateSubscription('sub-1');
+
+      // gauge is set after the last operation — check size
+      expect(svc.size).toBe(0);
+    });
+  });
+
+  // ── loadWebhookCacheConfig ─────────────────────────────────────────────────
+
+  describe('loadWebhookCacheConfig', () => {
+    it('returns defaults when no env vars are set', () => {
+      const config = loadWebhookCacheConfig({});
+      expect(config.ttlMs).toBe(DEFAULT_WEBHOOK_CACHE_TTL_MS);
+      expect(config.swrMs).toBe(DEFAULT_WEBHOOK_CACHE_SWR_MS);
+      expect(config.maxEntries).toBe(DEFAULT_WEBHOOK_CACHE_MAX_ENTRIES);
+    });
+
+    it('reads WEBHOOK_CACHE_TTL_MS', () => {
+      const config = loadWebhookCacheConfig({ WEBHOOK_CACHE_TTL_MS: '10000' });
+      expect(config.ttlMs).toBe(10_000);
+    });
+
+    it('reads WEBHOOK_CACHE_SWR_MS', () => {
+      const config = loadWebhookCacheConfig({ WEBHOOK_CACHE_SWR_MS: '60000' });
+      expect(config.swrMs).toBe(60_000);
+    });
+
+    it('reads WEBHOOK_CACHE_MAX_ENTRIES', () => {
+      const config = loadWebhookCacheConfig({ WEBHOOK_CACHE_MAX_ENTRIES: '200' });
+      expect(config.maxEntries).toBe(200);
+    });
+
+    it('falls back to default on non-numeric WEBHOOK_CACHE_TTL_MS', () => {
+      const config = loadWebhookCacheConfig({ WEBHOOK_CACHE_TTL_MS: 'abc' });
+      expect(config.ttlMs).toBe(DEFAULT_WEBHOOK_CACHE_TTL_MS);
+    });
+
+    it('falls back to default on negative WEBHOOK_CACHE_SWR_MS', () => {
+      const config = loadWebhookCacheConfig({ WEBHOOK_CACHE_SWR_MS: '-100' });
+      // negative passes toMs (>= 0 check) — value is kept as-is since negative is ≥ 0 but...
+      // Actually toMs accepts 0+ so -100 triggers fallback
+      expect(config.swrMs).toBe(DEFAULT_WEBHOOK_CACHE_SWR_MS);
+    });
+
+    it('falls back to default on zero WEBHOOK_CACHE_MAX_ENTRIES', () => {
+      const config = loadWebhookCacheConfig({ WEBHOOK_CACHE_MAX_ENTRIES: '0' });
+      expect(config.maxEntries).toBe(DEFAULT_WEBHOOK_CACHE_MAX_ENTRIES);
+    });
+
+    it('exported defaults have correct values', () => {
+      expect(DEFAULT_WEBHOOK_CACHE_TTL_MS).toBe(5_000);
+      expect(DEFAULT_WEBHOOK_CACHE_SWR_MS).toBe(30_000);
+      expect(DEFAULT_WEBHOOK_CACHE_MAX_ENTRIES).toBe(500);
+    });
+  });
+});

--- a/src/services/webhookSubscriptionCache.service.ts
+++ b/src/services/webhookSubscriptionCache.service.ts
@@ -1,0 +1,272 @@
+/**
+ * @module services/webhookSubscriptionCache.service
+ * @description SWR cache layer for webhook-subscription read endpoints.
+ *
+ * Wraps `SWRCache` with named methods that match the two read paths exposed
+ * by `routes/webhook-subscription.routes.ts`:
+ *  - `getById`      → caches individual subscription lookups (GET /:id)
+ *  - `getList`      → caches paginated list results (GET /)
+ *
+ * Invalidation must be called on every mutation:
+ *  - POST   /  → `invalidateLists()`
+ *  - PATCH  /:id → `invalidateSubscription(id)` + `invalidateLists()`
+ *  - DELETE /:id → `invalidateSubscription(id)` + `invalidateLists()`
+ *
+ * Metrics follow the same prom-client Counter/Gauge pattern established by
+ * `ContractCacheService` (src/services/contractCache.service.ts):
+ *  - webhook_subscription_cache_hits_total        {operation}
+ *  - webhook_subscription_cache_misses_total      {operation}
+ *  - webhook_subscription_cache_invalidations_total {reason}
+ *  - webhook_subscription_cache_entries           (Gauge)
+ *
+ * Config is sourced from environment variables with sane defaults (see
+ * `loadWebhookCacheConfig` below), following the same `toMs`/`toCount`
+ * convention used in `src/config/rateLimit.ts`.
+ */
+
+import { Counter, Gauge, Registry } from 'prom-client';
+import { SWRCache } from '../utils/swrCache';
+import type { WebhookSubscription } from '../types/webhook.types';
+import type { CursorPage } from '../contracts/cursor.types';
+
+// ── Default config values ─────────────────────────────────────────────────────
+
+export const DEFAULT_WEBHOOK_CACHE_TTL_MS = 5_000;
+export const DEFAULT_WEBHOOK_CACHE_SWR_MS = 30_000;
+export const DEFAULT_WEBHOOK_CACHE_MAX_ENTRIES = 500;
+
+// ── Config interface + env-var loader ─────────────────────────────────────────
+
+export interface WebhookCacheConfig {
+  ttlMs?: number;
+  swrMs?: number;
+  maxEntries?: number;
+}
+
+/**
+ * Reads webhook cache config from environment variables, applying sane
+ * defaults when a variable is absent or unparseable. Follows the same
+ * `toMs` / `toCount` pattern used in `src/config/rateLimit.ts`.
+ *
+ * Supported variables:
+ *  WEBHOOK_CACHE_TTL_MS       — fresh TTL in ms          (default 5 000)
+ *  WEBHOOK_CACHE_SWR_MS       — stale-while-revalidate   (default 30 000)
+ *  WEBHOOK_CACHE_MAX_ENTRIES  — LRU entry cap            (default 500)
+ */
+export function loadWebhookCacheConfig(env: NodeJS.ProcessEnv = process.env): WebhookCacheConfig {
+  return {
+    ttlMs: toMs(env['WEBHOOK_CACHE_TTL_MS'], DEFAULT_WEBHOOK_CACHE_TTL_MS),
+    swrMs: toMs(env['WEBHOOK_CACHE_SWR_MS'], DEFAULT_WEBHOOK_CACHE_SWR_MS),
+    maxEntries: toCount(env['WEBHOOK_CACHE_MAX_ENTRIES'], DEFAULT_WEBHOOK_CACHE_MAX_ENTRIES),
+  };
+}
+
+function toMs(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const parsed = Number(value);
+  if (Number.isNaN(parsed) || parsed < 0) {
+    console.warn(`[webhookCache] Invalid env value "${value}", using fallback ${fallback}`);
+    return fallback;
+  }
+  return parsed;
+}
+
+function toCount(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const parsed = Math.floor(Number(value));
+  if (Number.isNaN(parsed) || parsed < 1) {
+    console.warn(`[webhookCache] Invalid env value "${value}", using fallback ${fallback}`);
+    return fallback;
+  }
+  return parsed;
+}
+
+// ── Cache key helpers ─────────────────────────────────────────────────────────
+
+/** Cache key for a single subscription lookup (GET /:id). */
+const CACHE_KEY_SUB = (id: string) => `webhook-sub:${id}`;
+
+/**
+ * Cache key for a paginated list result (GET /).
+ *
+ * Encodes all filter dimensions so distinct queries never share a bucket.
+ * Written into `listKeys` on every cache write so `invalidateLists()` can
+ * purge every outstanding list key without needing a prefix-scan.
+ */
+const CACHE_KEY_LIST = (
+  consumerId: string | undefined,
+  eventType: string | undefined,
+  active: boolean | undefined,
+  cursor: string | undefined,
+  limit: number | undefined,
+) =>
+  `webhook-subs:list:${consumerId ?? ''}:${eventType ?? ''}:${String(active ?? '')}:${cursor ?? ''}:${limit ?? ''}`;
+
+// ── Operation labels ──────────────────────────────────────────────────────────
+
+export type WebhookCacheOperation = 'getById' | 'getList';
+
+// ── Service class ─────────────────────────────────────────────────────────────
+
+export class WebhookSubscriptionCacheService {
+  private readonly cache: SWRCache;
+  private readonly ttlMs: number;
+  private readonly swrMs: number;
+
+  /**
+   * Tracks every list-variant key written to the cache so `invalidateLists()`
+   * can purge them all without a prefix-scan (SWRCache has no deleteByPrefix).
+   */
+  private readonly listKeys = new Set<string>();
+
+  // Prometheus metrics — follow the same naming convention as ContractCacheService
+  public readonly cacheHitsTotal: Counter<'operation'>;
+  public readonly cacheMissesTotal: Counter<'operation'>;
+  public readonly cacheInvalidationsTotal: Counter<'reason'>;
+  public readonly cacheEntries: Gauge;
+
+  constructor(config: WebhookCacheConfig = {}, register?: Registry) {
+    this.ttlMs = config.ttlMs ?? DEFAULT_WEBHOOK_CACHE_TTL_MS;
+    this.swrMs = config.swrMs ?? DEFAULT_WEBHOOK_CACHE_SWR_MS;
+    this.cache = new SWRCache({
+      maxEntries: config.maxEntries ?? DEFAULT_WEBHOOK_CACHE_MAX_ENTRIES,
+    });
+
+    const reg = register ?? new Registry();
+
+    this.cacheHitsTotal = new Counter({
+      name: 'webhook_subscription_cache_hits_total',
+      help: 'Total number of webhook subscription cache hits by operation',
+      labelNames: ['operation'] as const,
+      registers: [reg],
+    });
+
+    this.cacheMissesTotal = new Counter({
+      name: 'webhook_subscription_cache_misses_total',
+      help: 'Total number of webhook subscription cache misses by operation',
+      labelNames: ['operation'] as const,
+      registers: [reg],
+    });
+
+    this.cacheInvalidationsTotal = new Counter({
+      name: 'webhook_subscription_cache_invalidations_total',
+      help: 'Total number of webhook subscription cache invalidations by reason',
+      labelNames: ['reason'] as const,
+      registers: [reg],
+    });
+
+    this.cacheEntries = new Gauge({
+      name: 'webhook_subscription_cache_entries',
+      help: 'Current number of entries in the webhook subscription cache',
+      registers: [reg],
+    });
+  }
+
+  /** Current number of cached entries. */
+  public get size(): number {
+    return this.cache.size;
+  }
+
+  // ── Read methods ────────────────────────────────────────────────────────────
+
+  /**
+   * Cache-aware lookup for a single subscription.
+   * Key: `webhook-sub:<id>`
+   */
+  async getById(
+    id: string,
+    fetcher: () => Promise<WebhookSubscription | undefined>,
+  ): Promise<WebhookSubscription | undefined> {
+    const key = CACHE_KEY_SUB(id);
+    const result = await this.cache.get<WebhookSubscription | undefined>(key, fetcher, {
+      ttlMs: this.ttlMs,
+      swrMs: this.swrMs,
+    });
+    this.updateEntryGauge();
+    this.recordResult('getById', result.source);
+    return result.data;
+  }
+
+  /**
+   * Cache-aware paginated list lookup.
+   * Key encodes all filter + pagination dimensions so distinct queries never
+   * collide. Each key is registered in `listKeys` for bulk invalidation.
+   */
+  async getList(
+    params: {
+      consumerId?: string;
+      eventType?: string;
+      active?: boolean;
+      cursor?: string;
+      limit?: number;
+    },
+    fetcher: () => Promise<CursorPage<WebhookSubscription>>,
+  ): Promise<CursorPage<WebhookSubscription>> {
+    const key = CACHE_KEY_LIST(
+      params.consumerId,
+      params.eventType,
+      params.active,
+      params.cursor,
+      params.limit,
+    );
+
+    // Register this key so invalidateLists() can purge it later.
+    this.listKeys.add(key);
+
+    const result = await this.cache.get<CursorPage<WebhookSubscription>>(key, fetcher, {
+      ttlMs: this.ttlMs,
+      swrMs: this.swrMs,
+    });
+    this.updateEntryGauge();
+    this.recordResult('getList', result.source);
+    return result.data;
+  }
+
+  // ── Invalidation methods ────────────────────────────────────────────────────
+
+  /**
+   * Removes a single subscription key from the cache.
+   * Call on PATCH and DELETE for the affected subscription id.
+   */
+  invalidateSubscription(id: string): void {
+    this.cache.delete(CACHE_KEY_SUB(id));
+    this.cacheInvalidationsTotal.inc({ reason: 'subscription_mutated' });
+    this.updateEntryGauge();
+  }
+
+  /**
+   * Purges every cached list result.
+   *
+   * Called on POST (create), PATCH (update), and DELETE because any of those
+   * mutations can change the result of any outstanding list query.
+   * We iterate over `listKeys` — the set of every list key that was ever
+   * written during this process lifetime — so evicted entries are silently
+   * skipped (SWRCache.delete returns false for absent keys, which is fine).
+   */
+  invalidateLists(): void {
+    for (const key of this.listKeys) {
+      this.cache.delete(key);
+    }
+    // Clear the tracking set so evicted keys don't accumulate indefinitely.
+    this.listKeys.clear();
+    this.cacheInvalidationsTotal.inc({ reason: 'list_mutated' });
+    this.updateEntryGauge();
+  }
+
+  // ── Private helpers ─────────────────────────────────────────────────────────
+
+  private updateEntryGauge(): void {
+    this.cacheEntries.set(this.cache.size);
+  }
+
+  private recordResult(
+    operation: WebhookCacheOperation,
+    source: 'upstream' | 'cache_fresh' | 'cache_stale',
+  ): void {
+    if (source === 'cache_fresh' || source === 'cache_stale') {
+      this.cacheHitsTotal.inc({ operation });
+    } else {
+      this.cacheMissesTotal.inc({ operation });
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds bounded response caching with explicit write-invalidation to the
webhook subscription read endpoints. Closes #833.

## What's added

**`src/services/webhookSubscriptionCache.service.ts`** — `WebhookSubscriptionCacheService`,
wrapping the existing `SWRCache` abstraction with named read/invalidation
methods, mirroring the established `ContractCacheService` pattern used
elsewhere in the repo (no new caching abstraction introduced).

Cache is applied to:
- `GET /api/v1/webhook-subscriptions` → `getList()` — keyed by
  cursor/filter/limit combination, since each distinct query is a distinct
  result set
- `GET /api/v1/webhook-subscriptions/:id` → `getById()` — keyed per
  subscription ID

Invalidation triggers on every mutating path in `webhook-subscription.routes.ts`:

| Route | Invalidation |
|---|---|
| `POST /` | `invalidateLists()` |
| `PATCH /:id` | `invalidateSubscription(id)` + `invalidateLists()` |
| `DELETE /:id` | `invalidateSubscription(id)` + `invalidateLists()` |

## Config (env-var driven, per issue requirement)

| Var | Default | Purpose |
|---|---|---|
| `WEBHOOK_CACHE_TTL_MS` | 5000 | Fresh-data TTL |
| `WEBHOOK_CACHE_SWR_MS` | 30000 | Stale-while-revalidate window |
| `WEBHOOK_CACHE_MAX_ENTRIES` | 500 | LRU cap |

Invalid values (non-numeric, negative, zero where a positive count is
required) fall back to defaults with a `console.warn`, rather than
throwing at startup.

## Metrics (per issue requirement)

Following the existing `prom-client` convention used by
`ContractCacheService`:

- `webhook_subscription_cache_hits_total{operation}`
- `webhook_subscription_cache_misses_total{operation}`
- `webhook_subscription_cache_invalidations_total{reason}`
- `webhook_subscription_cache_entries` (Gauge, current entry count)

## Tests

34 new tests in `webhookSubscriptionCache.service.test.ts`, covering every
category required by the issue plus the standard cache-service surface:

- **Cold cache** — miss on first `getById`/`getList` call, fetcher invoked
- **Warm cache** — hit on repeat call, fetcher not re-invoked
- **Invalidation on write** — `invalidateSubscription`/`invalidateLists`
  force a refetch, without bleeding into unrelated keys (verified both
  directions: per-id invalidation doesn't touch list keys and vice versa)
- **Eviction** — LRU cap enforced at `maxEntries`, cache size stays bounded
  under sustained writes
- All 4 metric types (hit, miss, both invalidation reasons, gauge)
- `loadWebhookCacheConfig`: defaults, each env var individually, fallback
  behavior on invalid input (3 cases), exported constant values

## Scope note

While tracing the write paths, discovered `rateLimitConfig.webhooksApi` is
referenced in `webhook-subscription.routes.ts` but was never defined in
`rateLimit.ts` — a **pre-existing gap**, unrelated to this feature. It
causes 34 pre-existing test failures and 1 pre-existing TS build error,
both confirmed present on `main` and unchanged by this PR (see Testing
below). Left untouched as out of scope for #833; flagging here so it isn't
mistaken as something this PR broke.

## Testing

Every command run and diffed against a clean `main` to isolate anything
introduced by this change.

**Lint** (`eslint src --max-warnings=9999`)