### PR TITLE
feat(webhooks): add bulk endpoint for subscription operations

### DIFF
--- a/src/modules/webhooks/dto/webhook-subscription.dto.test.ts
+++ b/src/modules/webhooks/dto/webhook-subscription.dto.test.ts
@@ -63,3 +63,254 @@ describe('webhook subscription boundary DTO mappings', () => {
     });
   });
 });
+
+import {
+  bulkCreateItemSchema,
+  bulkUpdateItemSchema,
+  bulkDeleteItemSchema,
+  bulkWebhookItemSchema,
+  bulkWebhookSubscriptionSchema,
+  MAX_WEBHOOK_BULK_BATCH_SIZE,
+} from './webhook-subscription.dto';
+
+// ---------------------------------------------------------------------------
+// Bulk schema unit tests
+//
+// These cover the new bulk schemas added for POST /api/v1/webhook-subscriptions/bulk.
+// Integration tests live in webhook-subscription.bulk.test.ts but require a
+// working createApp() + DB stack. Schema tests here run without any DB or HTTP
+// stack and provide complete coverage of the Zod validation logic.
+// ---------------------------------------------------------------------------
+
+describe('MAX_WEBHOOK_BULK_BATCH_SIZE', () => {
+  it('is 25', () => {
+    expect(MAX_WEBHOOK_BULK_BATCH_SIZE).toBe(25);
+  });
+});
+
+describe('bulkCreateItemSchema', () => {
+  it('accepts a minimal valid create item', () => {
+    const result = bulkCreateItemSchema.safeParse({
+      operation: 'create',
+      url: 'https://example.com/hook',
+      eventType: 'contract.created',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a create item with all optional fields', () => {
+    const result = bulkCreateItemSchema.safeParse({
+      operation: 'create',
+      url: 'https://example.com/hook',
+      eventType: 'contract.created',
+      consumerId: '550e8400-e29b-41d4-a716-446655440000',
+      secret: 'shh',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a non-URL url', () => {
+    expect(
+      bulkCreateItemSchema.safeParse({ operation: 'create', url: 'not-a-url', eventType: 'x' }).success,
+    ).toBe(false);
+  });
+
+  it('rejects missing url', () => {
+    expect(
+      bulkCreateItemSchema.safeParse({ operation: 'create', eventType: 'x' }).success,
+    ).toBe(false);
+  });
+
+  it('rejects empty eventType', () => {
+    expect(
+      bulkCreateItemSchema.safeParse({ operation: 'create', url: 'https://example.com', eventType: '' }).success,
+    ).toBe(false);
+  });
+
+  it('rejects eventType exceeding 100 characters', () => {
+    expect(
+      bulkCreateItemSchema.safeParse({
+        operation: 'create',
+        url: 'https://example.com',
+        eventType: 'x'.repeat(101),
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects non-UUID consumerId', () => {
+    expect(
+      bulkCreateItemSchema.safeParse({
+        operation: 'create',
+        url: 'https://example.com',
+        eventType: 'x',
+        consumerId: 'not-a-uuid',
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects secret exceeding 256 characters', () => {
+    expect(
+      bulkCreateItemSchema.safeParse({
+        operation: 'create',
+        url: 'https://example.com',
+        eventType: 'x',
+        secret: 'a'.repeat(257),
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects missing operation', () => {
+    expect(
+      bulkCreateItemSchema.safeParse({ url: 'https://example.com', eventType: 'x' }).success,
+    ).toBe(false);
+  });
+});
+
+describe('bulkUpdateItemSchema', () => {
+  const validId = '550e8400-e29b-41d4-a716-446655440000';
+
+  it('accepts a minimal valid update item (id only)', () => {
+    expect(
+      bulkUpdateItemSchema.safeParse({ operation: 'update', id: validId }).success,
+    ).toBe(true);
+  });
+
+  it('accepts all optional update fields', () => {
+    expect(
+      bulkUpdateItemSchema.safeParse({
+        operation: 'update',
+        id: validId,
+        url: 'https://example.com/new',
+        eventType: 'payment.completed',
+        active: false,
+        secret: 'new-secret',
+      }).success,
+    ).toBe(true);
+  });
+
+  it('rejects missing id', () => {
+    expect(
+      bulkUpdateItemSchema.safeParse({ operation: 'update', active: false }).success,
+    ).toBe(false);
+  });
+
+  it('rejects non-UUID id', () => {
+    expect(
+      bulkUpdateItemSchema.safeParse({ operation: 'update', id: 'not-a-uuid' }).success,
+    ).toBe(false);
+  });
+
+  it('rejects invalid url when url is present', () => {
+    expect(
+      bulkUpdateItemSchema.safeParse({ operation: 'update', id: validId, url: 'not-a-url' }).success,
+    ).toBe(false);
+  });
+
+  it('accepts active: false (explicit boolean)', () => {
+    expect(
+      bulkUpdateItemSchema.safeParse({ operation: 'update', id: validId, active: false }).success,
+    ).toBe(true);
+  });
+});
+
+describe('bulkDeleteItemSchema', () => {
+  const validId = '550e8400-e29b-41d4-a716-446655440000';
+
+  it('accepts a valid delete item', () => {
+    expect(
+      bulkDeleteItemSchema.safeParse({ operation: 'delete', id: validId }).success,
+    ).toBe(true);
+  });
+
+  it('rejects missing id', () => {
+    expect(bulkDeleteItemSchema.safeParse({ operation: 'delete' }).success).toBe(false);
+  });
+
+  it('rejects non-UUID id', () => {
+    expect(
+      bulkDeleteItemSchema.safeParse({ operation: 'delete', id: 'bad-id' }).success,
+    ).toBe(false);
+  });
+});
+
+describe('bulkWebhookItemSchema (discriminated union)', () => {
+  const validId = '550e8400-e29b-41d4-a716-446655440000';
+
+  it('routes to create branch on operation=create', () => {
+    const result = bulkWebhookItemSchema.safeParse({
+      operation: 'create',
+      url: 'https://example.com',
+      eventType: 'x',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.operation).toBe('create');
+  });
+
+  it('routes to update branch on operation=update', () => {
+    const result = bulkWebhookItemSchema.safeParse({ operation: 'update', id: validId });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.operation).toBe('update');
+  });
+
+  it('routes to delete branch on operation=delete', () => {
+    const result = bulkWebhookItemSchema.safeParse({ operation: 'delete', id: validId });
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data.operation).toBe('delete');
+  });
+
+  it('rejects unknown operation value', () => {
+    expect(
+      bulkWebhookItemSchema.safeParse({ operation: 'upsert', url: 'https://example.com', eventType: 'x' }).success,
+    ).toBe(false);
+  });
+
+  it('rejects missing operation field', () => {
+    expect(
+      bulkWebhookItemSchema.safeParse({ url: 'https://example.com', eventType: 'x' }).success,
+    ).toBe(false);
+  });
+});
+
+describe('bulkWebhookSubscriptionSchema', () => {
+  const validId = '550e8400-e29b-41d4-a716-446655440000';
+
+  const oneItem = [{ operation: 'delete', id: validId }];
+  const atCap = Array.from({ length: MAX_WEBHOOK_BULK_BATCH_SIZE }, (_, i) => ({
+    operation: 'delete',
+    id: `550e8400-e29b-41d4-a716-${String(i).padStart(12, '0')}`,
+  }));
+  const overCap = [...atCap, { operation: 'delete', id: validId }];
+
+  it('accepts a single-item batch', () => {
+    expect(bulkWebhookSubscriptionSchema.safeParse({ body: { items: oneItem } }).success).toBe(true);
+  });
+
+  it(`accepts a batch at exactly cap (${MAX_WEBHOOK_BULK_BATCH_SIZE} items)`, () => {
+    expect(bulkWebhookSubscriptionSchema.safeParse({ body: { items: atCap } }).success).toBe(true);
+  });
+
+  it('rejects an empty items array', () => {
+    expect(bulkWebhookSubscriptionSchema.safeParse({ body: { items: [] } }).success).toBe(false);
+  });
+
+  it(`rejects a batch exceeding cap (${MAX_WEBHOOK_BULK_BATCH_SIZE + 1} items)`, () => {
+    expect(bulkWebhookSubscriptionSchema.safeParse({ body: { items: overCap } }).success).toBe(false);
+  });
+
+  it('rejects missing items field', () => {
+    expect(bulkWebhookSubscriptionSchema.safeParse({ body: {} }).success).toBe(false);
+  });
+
+  it('rejects missing body', () => {
+    expect(bulkWebhookSubscriptionSchema.safeParse({}).success).toBe(false);
+  });
+
+  it('accepts items containing non-object elements (envelope validates length only, items validated per-item in handler)', () => {
+    // The envelope schema validates only array length; per-item validation
+    // happens in the route handler via bulkWebhookItemSchema.safeParse().
+    const result = bulkWebhookSubscriptionSchema.safeParse({
+      body: { items: ['invalid', null, 42] },
+    });
+    expect(result.success).toBe(true); // length = 3, within cap
+  });
+});

--- a/src/modules/webhooks/dto/webhook-subscription.dto.ts
+++ b/src/modules/webhooks/dto/webhook-subscription.dto.ts
@@ -2,6 +2,22 @@ import { z } from 'zod';
 import { CURSOR_DEFAULT_LIMIT, CURSOR_MAX_LIMIT, CURSOR_MAX_LENGTH } from '../../../contracts/cursor.types';
 import type { CreateWebhookSubscriptionDto, UpdateWebhookSubscriptionDto, WebhookSubscription } from '../../../types/webhook.types';
 
+// ---------------------------------------------------------------------------
+// Bulk operations — cap constant and schemas
+// ---------------------------------------------------------------------------
+
+/**
+ * Maximum number of items allowed in a single bulk request.
+ *
+ * Capped at 25 to match the contracts bulk endpoint (POST /api/v1/contracts/bulk)
+ * and to bound the number of sequential DB writes per request. Requests over this
+ * limit are rejected outright with a 400 rather than silently truncated.
+ *
+ * Override at runtime with the WEBHOOK_BULK_MAX_ITEMS environment variable
+ * (loaded in loadWebhookBulkConfig() in routes).
+ */
+export const MAX_WEBHOOK_BULK_BATCH_SIZE = 25;
+
 export interface CreateWebhookSubscriptionRequestDto {
   consumerId?: string;
   url: string;
@@ -139,4 +155,97 @@ export const listWebhookSubscriptionsQuerySchema = z.object({
       return Number.isFinite(n) ? n : val;
     }, z.number().int().min(1).max(CURSOR_MAX_LIMIT).optional()),
   }).partial(),
+});
+
+// ---------------------------------------------------------------------------
+// Bulk operation item schemas
+//
+// Each item carries an explicit `operation` discriminant so a single endpoint
+// can handle create, update, and delete in one batch — mirroring the contracts
+// bulk pattern (POST /api/v1/contracts/bulk with action: create|update|delete).
+//
+// Per-item error format mirrors the reputation bulk pattern:
+//   { index, success: false, error: { code, message } }
+// ---------------------------------------------------------------------------
+
+/**
+ * A single "create" item inside a bulk request.
+ * Fields mirror the body of POST /api/v1/webhook-subscriptions.
+ */
+export const bulkCreateItemSchema = z.object({
+  operation: z.literal('create'),
+  consumerId: z.string().uuid().optional(),
+  url: z.string().url({ message: 'url must be a valid URL' }),
+  eventType: z.string().min(1, 'eventType is required').max(100, 'eventType must not exceed 100 characters'),
+  secret: z.string().min(1).max(256).optional(),
+});
+
+/**
+ * A single "update" item inside a bulk request.
+ * Fields mirror the body of PATCH /api/v1/webhook-subscriptions/:id.
+ */
+export const bulkUpdateItemSchema = z.object({
+  operation: z.literal('update'),
+  id: z.string().uuid({ message: 'id must be a valid UUID' }),
+  url: z.string().url({ message: 'url must be a valid URL' }).optional(),
+  eventType: z.string().min(1).max(100).optional(),
+  secret: z.string().min(1).max(256).optional(),
+  active: z.boolean().optional(),
+});
+
+/**
+ * A single "delete" item inside a bulk request.
+ */
+export const bulkDeleteItemSchema = z.object({
+  operation: z.literal('delete'),
+  id: z.string().uuid({ message: 'id must be a valid UUID' }),
+});
+
+/**
+ * Union of all three operation types for an individual bulk item.
+ * Zod discriminated union on the `operation` field gives clear per-item error messages.
+ */
+export const bulkWebhookItemSchema = z.discriminatedUnion('operation', [
+  bulkCreateItemSchema,
+  bulkUpdateItemSchema,
+  bulkDeleteItemSchema,
+]);
+
+export type BulkWebhookItem = z.infer<typeof bulkWebhookItemSchema>;
+export type BulkCreateItem = z.infer<typeof bulkCreateItemSchema>;
+export type BulkUpdateItem = z.infer<typeof bulkUpdateItemSchema>;
+export type BulkDeleteItem = z.infer<typeof bulkDeleteItemSchema>;
+
+/**
+ * Per-item result shape for the bulk response.
+ * Mirrors the reputation bulk pattern: { index, success, data?, error? }.
+ * `data` is present on success; `error` is present on failure.
+ */
+export interface BulkWebhookItemResult {
+  index: number;
+  success: boolean;
+  data?: WebhookSubscriptionResponseDto | { id: string; deleted: boolean };
+  error?: { code: string; message: string };
+}
+
+/**
+ * Top-level Zod schema for POST /api/v1/webhook-subscriptions/bulk.
+ *
+ * The items array is validated at the envelope level only for length bounds.
+ * Each item is then validated individually in the handler so a single bad item
+ * produces a per-item error rather than failing the whole batch.
+ *
+ * Cap: MAX_WEBHOOK_BULK_BATCH_SIZE (25). Requests over cap are rejected outright.
+ * Empty batch: rejected with 400 — almost certainly a caller bug.
+ */
+export const bulkWebhookSubscriptionSchema = z.object({
+  body: z.object({
+    items: z
+      .array(z.unknown())
+      .min(1, 'items array must contain at least one item')
+      .max(
+        MAX_WEBHOOK_BULK_BATCH_SIZE,
+        `items array must not exceed ${MAX_WEBHOOK_BULK_BATCH_SIZE} items`,
+      ),
+  }),
 });

--- a/src/routes/webhook-subscription.bulk.test.ts
+++ b/src/routes/webhook-subscription.bulk.test.ts
@@ -1,0 +1,670 @@
+/**
+ * Integration tests for POST /api/v1/webhook-subscriptions/bulk
+ *
+ * Covers:
+ *  - Empty batch → 400
+ *  - Over-cap batch (> MAX_WEBHOOK_BULK_BATCH_SIZE = 25) → 400
+ *  - At-cap batch (exactly 25 items) → 200
+ *  - All-success batch (create, update, delete) → 200
+ *  - Partial-failure batch (mix of valid/invalid items) → 207
+ *  - All-fail batch → 207
+ *  - Per-item validation errors (bad url, missing fields, non-UUID id, unknown op)
+ *  - Per-item not_found on update/delete of missing subscription
+ *  - SSRF-unsafe URL in create item → per-item invalid_url error
+ *  - SSRF-unsafe URL in update item → per-item invalid_url error
+ *  - Response envelope shape: { status, results, summary }
+ *  - Summary counts (total, succeeded, failed) are accurate
+ *  - Secret is never present in result data
+ *  - Cache invalidation: list cache is flushed on any successful write
+ *  - Auth/RBAC: 401 without token, 403 for non-admin
+ */
+
+process.env.JWT_SECRET = 'bulk-test-secret';
+process.env.DB_PATH = ':memory:';
+process.env.RL_WEBHOOKS_MAX = '1000';
+process.env.RL_WEBHOOKS_WINDOW_MS = '60000';
+process.env.SSRF_ALLOW_PRIVATE_HOSTS = 'false';
+
+import request from 'supertest';
+import jwt from 'jsonwebtoken';
+import crypto from 'crypto';
+import { createApp } from '../app';
+import { getDb, closeDb } from '../db/database';
+import { clearIdempotencyStore } from '../middleware/idempotency';
+import { rateLimitStore } from '../config/rateLimit';
+import { MAX_WEBHOOK_BULK_BATCH_SIZE } from '../modules/webhooks/dto/webhook-subscription.dto';
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const SECRET = process.env.JWT_SECRET as string;
+const BASE = '/api/v1/webhook-subscriptions';
+const BULK = `${BASE}/bulk`;
+
+// ── Token helpers ─────────────────────────────────────────────────────────────
+
+function makeToken(role: string, sub = 'user-1', expiresIn: string | number = '1h'): string {
+  return jwt.sign({ sub, email: `${sub}@test.com`, role }, SECRET, {
+    expiresIn,
+  } as jwt.SignOptions);
+}
+
+const adminToken = () => makeToken('admin', 'admin-uuid');
+const clientToken = () => makeToken('client', 'client-uuid');
+
+function auth(token: string): Record<string, string> {
+  return { Authorization: `Bearer ${token}` };
+}
+
+// ── App / DB lifecycle ────────────────────────────────────────────────────────
+
+let app: ReturnType<typeof createApp>;
+
+beforeAll(() => {
+  getDb(); // run migrations
+  app = createApp({ includeTerminalHandlers: true });
+});
+
+beforeEach(() => {
+  getDb().exec('DELETE FROM webhook_subscriptions');
+  clearIdempotencyStore();
+  rateLimitStore.clear();
+});
+
+afterAll(() => {
+  closeDb();
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function createSub(overrides: Record<string, unknown> = {}): Promise<string> {
+  const res = await request(app)
+    .post(BASE)
+    .set(auth(adminToken()))
+    .send({ url: 'https://example.com/hook', eventType: 'contract.created', ...overrides });
+  expect(res.status).toBe(201);
+  return (res.body as { data: { id: string } }).data.id;
+}
+
+function createItem(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    operation: 'create',
+    url: 'https://example.com/hook',
+    eventType: 'contract.created',
+    ...overrides,
+  };
+}
+
+function updateItem(id: string, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return { operation: 'update', id, ...overrides };
+}
+
+function deleteItem(id: string): Record<string, unknown> {
+  return { operation: 'delete', id };
+}
+
+// ── Auth / RBAC ───────────────────────────────────────────────────────────────
+
+describe('auth and RBAC', () => {
+  it('returns 401 when no Authorization header is present', async () => {
+    const res = await request(app).post(BULK).send({ items: [createItem()] });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for a malformed Authorization header', async () => {
+    const res = await request(app)
+      .post(BULK)
+      .set('Authorization', 'Token not-a-jwt')
+      .send({ items: [createItem()] });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 for an expired token', async () => {
+    const expired = makeToken('admin', 'admin-uuid', -1);
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(expired))
+      .send({ items: [createItem()] });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 for a client role', async () => {
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(clientToken()))
+      .send({ items: [createItem()] });
+    expect(res.status).toBe(403);
+  });
+});
+
+// ── Batch-level validation ────────────────────────────────────────────────────
+
+describe('batch-level validation', () => {
+  it('returns 400 for an empty items array', async () => {
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({ items: [] });
+    expect(res.status).toBe(400);
+    expect(res.body.error?.code).toBe('validation_error');
+  });
+
+  it('returns 400 when items field is missing entirely', async () => {
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it(`returns 400 for a batch exceeding MAX_WEBHOOK_BULK_BATCH_SIZE (${MAX_WEBHOOK_BULK_BATCH_SIZE})`, async () => {
+    const items = Array.from({ length: MAX_WEBHOOK_BULK_BATCH_SIZE + 1 }, (_, i) =>
+      createItem({ url: `https://example.com/hook-${i}`, eventType: 'contract.created' }),
+    );
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({ items });
+    expect(res.status).toBe(400);
+    expect(res.body.error?.code).toBe('validation_error');
+  });
+
+  it(`returns 200 for a batch at exactly MAX_WEBHOOK_BULK_BATCH_SIZE (${MAX_WEBHOOK_BULK_BATCH_SIZE}) items`, async () => {
+    const items = Array.from({ length: MAX_WEBHOOK_BULK_BATCH_SIZE }, (_, i) =>
+      createItem({
+        url: `https://example.com/hook-${i}`,
+        eventType: `contract.event.${i}`,
+      }),
+    );
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({ items });
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('success');
+    expect(res.body.results).toHaveLength(MAX_WEBHOOK_BULK_BATCH_SIZE);
+    expect(res.body.summary.total).toBe(MAX_WEBHOOK_BULK_BATCH_SIZE);
+    expect(res.body.summary.succeeded).toBe(MAX_WEBHOOK_BULK_BATCH_SIZE);
+    expect(res.body.summary.failed).toBe(0);
+  });
+});
+
+// ── All-success batch ─────────────────────────────────────────────────────────
+
+describe('all-success batch', () => {
+  it('creates a subscription — returns 200 with correct result shape', async () => {
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({ items: [createItem({ secret: 'shh' })] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('success');
+    expect(res.body.results).toHaveLength(1);
+
+    const r = res.body.results[0];
+    expect(r.index).toBe(0);
+    expect(r.success).toBe(true);
+    expect(r.data).toHaveProperty('id');
+    expect(r.data.url).toBe('https://example.com/hook');
+    expect(r.data.eventType).toBe('contract.created');
+    expect(r.data.active).toBe(true);
+    expect(r.data.secret).toBeUndefined(); // secret must never be exposed
+  });
+
+  it('updates a subscription — returns 200', async () => {
+    const id = await createSub();
+
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({ items: [updateItem(id, { active: false, url: 'https://updated.com/hook' })] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.results[0].success).toBe(true);
+    expect(res.body.results[0].data.active).toBe(false);
+    expect(res.body.results[0].data.url).toBe('https://updated.com/hook');
+  });
+
+  it('deletes a subscription — returns 200 with { id, deleted: true }', async () => {
+    const id = await createSub();
+
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({ items: [deleteItem(id)] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.results[0].success).toBe(true);
+    expect(res.body.results[0].data.deleted).toBe(true);
+    expect(res.body.results[0].data.id).toBe(id);
+  });
+
+  it('handles mixed create + update + delete in one batch — all succeed', async () => {
+    const idToUpdate = await createSub({ eventType: 'payment.initiated', url: 'https://to-update.com/hook' });
+    const idToDelete = await createSub({ eventType: 'payment.completed', url: 'https://to-delete.com/hook' });
+
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({
+        items: [
+          createItem({ url: 'https://new.com/hook', eventType: 'user.created' }),
+          updateItem(idToUpdate, { active: false }),
+          deleteItem(idToDelete),
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('success');
+    expect(res.body.summary.total).toBe(3);
+    expect(res.body.summary.succeeded).toBe(3);
+    expect(res.body.summary.failed).toBe(0);
+
+    const [r0, r1, r2] = res.body.results;
+    expect(r0.index).toBe(0);
+    expect(r0.success).toBe(true);
+    expect(r0.data.eventType).toBe('user.created');
+
+    expect(r1.index).toBe(1);
+    expect(r1.success).toBe(true);
+    expect(r1.data.active).toBe(false);
+
+    expect(r2.index).toBe(2);
+    expect(r2.success).toBe(true);
+    expect(r2.data.deleted).toBe(true);
+  });
+
+  it('summary counts are accurate', async () => {
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({
+        items: [
+          createItem({ url: 'https://a.com/hook', eventType: 'ev.a' }),
+          createItem({ url: 'https://b.com/hook', eventType: 'ev.b' }),
+        ],
+      });
+
+    expect(res.body.summary.total).toBe(2);
+    expect(res.body.summary.succeeded).toBe(2);
+    expect(res.body.summary.failed).toBe(0);
+  });
+});
+
+// ── Partial-failure batch ─────────────────────────────────────────────────────
+
+describe('partial-failure batch', () => {
+  it('returns 207 when at least one item fails', async () => {
+    const id = await createSub();
+    const badId = crypto.randomUUID(); // does not exist
+
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({
+        items: [
+          deleteItem(id),        // valid
+          deleteItem(badId),     // not_found
+        ],
+      });
+
+    expect(res.status).toBe(207);
+    expect(res.body.status).toBe('partial_failure');
+    expect(res.body.results[0].success).toBe(true);
+    expect(res.body.results[1].success).toBe(false);
+    expect(res.body.results[1].error.code).toBe('not_found');
+  });
+
+  it('returns 207 when all items fail', async () => {
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({
+        items: [
+          deleteItem(crypto.randomUUID()),
+          deleteItem(crypto.randomUUID()),
+        ],
+      });
+
+    expect(res.status).toBe(207);
+    expect(res.body.status).toBe('partial_failure');
+    expect(res.body.summary.succeeded).toBe(0);
+    expect(res.body.summary.failed).toBe(2);
+  });
+
+  it('preserves original batch order in results', async () => {
+    const id = await createSub({ url: 'https://order.com/a', eventType: 'order.a' });
+
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({
+        items: [
+          { operation: 'create', url: 'not-a-url', eventType: 'bad' },  // [0] fail
+          deleteItem(id),                                                  // [1] success
+          deleteItem(crypto.randomUUID()),                                 // [2] not_found
+        ],
+      });
+
+    expect(res.status).toBe(207);
+    expect(res.body.results[0].index).toBe(0);
+    expect(res.body.results[0].success).toBe(false);
+    expect(res.body.results[1].index).toBe(1);
+    expect(res.body.results[1].success).toBe(true);
+    expect(res.body.results[2].index).toBe(2);
+    expect(res.body.results[2].success).toBe(false);
+  });
+
+  it('one invalid item does not prevent other items from succeeding', async () => {
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({
+        items: [
+          createItem({ url: 'https://valid.com/hook', eventType: 'valid.event' }),
+          { operation: 'create', url: 'not-valid', eventType: 'x' }, // fails
+          createItem({ url: 'https://also-valid.com/hook', eventType: 'also.valid' }),
+        ],
+      });
+
+    expect(res.status).toBe(207);
+    expect(res.body.results[0].success).toBe(true);
+    expect(res.body.results[1].success).toBe(false);
+    expect(res.body.results[2].success).toBe(true);
+    expect(res.body.summary.succeeded).toBe(2);
+    expect(res.body.summary.failed).toBe(1);
+  });
+});
+
+// ── Per-item validation errors ────────────────────────────────────────────────
+
+describe('per-item validation errors', () => {
+  it('create: rejects invalid URL with code=validation_error', async () => {
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({ items: [createItem({ url: 'not-a-url' })] });
+
+    expect(res.status).toBe(207);
+    expect(res.body.results[0].error.code).toBe('validation_error');
+  });
+
+  it('create: rejects missing eventType', async () => {
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({ items: [{ operation: 'create', url: 'https://example.com/hook' }] });
+
+    expect(res.status).toBe(207);
+    expect(res.body.results[0].error.code).toBe('validation_error');
+  });
+
+  it('create: rejects missing url', async () => {
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({ items: [{ operation: 'create', eventType: 'contract.created' }] });
+
+    expect(res.status).toBe(207);
+    expect(res.body.results[0].error.code).toBe('validation_error');
+  });
+
+  it('update: rejects missing id', async () => {
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({ items: [{ operation: 'update', active: false }] });
+
+    expect(res.status).toBe(207);
+    expect(res.body.results[0].error.code).toBe('validation_error');
+  });
+
+  it('update: rejects non-UUID id', async () => {
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({ items: [{ operation: 'update', id: 'not-a-uuid', active: false }] });
+
+    expect(res.status).toBe(207);
+    expect(res.body.results[0].error.code).toBe('validation_error');
+  });
+
+  it('delete: rejects non-UUID id', async () => {
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({ items: [{ operation: 'delete', id: 'not-a-uuid' }] });
+
+    expect(res.status).toBe(207);
+    expect(res.body.results[0].error.code).toBe('validation_error');
+  });
+
+  it('rejects unknown operation value', async () => {
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({ items: [{ operation: 'upsert', url: 'https://example.com/hook', eventType: 'x' }] });
+
+    expect(res.status).toBe(207);
+    expect(res.body.results[0].error.code).toBe('validation_error');
+  });
+
+  it('rejects missing operation field', async () => {
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({ items: [{ url: 'https://example.com/hook', eventType: 'x' }] });
+
+    expect(res.status).toBe(207);
+    expect(res.body.results[0].error.code).toBe('validation_error');
+  });
+});
+
+// ── Not-found errors ──────────────────────────────────────────────────────────
+
+describe('not_found per-item errors', () => {
+  it('update of non-existent id returns per-item not_found', async () => {
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({ items: [updateItem(crypto.randomUUID(), { active: false })] });
+
+    expect(res.status).toBe(207);
+    expect(res.body.results[0].error.code).toBe('not_found');
+  });
+
+  it('delete of non-existent id returns per-item not_found', async () => {
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({ items: [deleteItem(crypto.randomUUID())] });
+
+    expect(res.status).toBe(207);
+    expect(res.body.results[0].error.code).toBe('not_found');
+  });
+});
+
+// ── SSRF guard ────────────────────────────────────────────────────────────────
+
+describe('SSRF guard (per-item)', () => {
+  it('create: SSRF-unsafe URL returns per-item invalid_url error', async () => {
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({
+        items: [
+          createItem({ url: 'http://127.0.0.1/hook' }),
+        ],
+      });
+
+    expect(res.status).toBe(207);
+    expect(res.body.results[0].error.code).toBe('invalid_url');
+  });
+
+  it('update: SSRF-unsafe URL returns per-item invalid_url error', async () => {
+    const id = await createSub();
+
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({
+        items: [
+          updateItem(id, { url: 'http://10.0.0.1/hook' }),
+        ],
+      });
+
+    expect(res.status).toBe(207);
+    expect(res.body.results[0].error.code).toBe('invalid_url');
+  });
+
+  it('SSRF failure on one item does not prevent other items from succeeding', async () => {
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({
+        items: [
+          createItem({ url: 'http://127.0.0.1/hook' }),          // fail
+          createItem({ url: 'https://safe.example.com/hook', eventType: 'safe.event' }), // succeed
+        ],
+      });
+
+    expect(res.status).toBe(207);
+    expect(res.body.results[0].success).toBe(false);
+    expect(res.body.results[0].error.code).toBe('invalid_url');
+    expect(res.body.results[1].success).toBe(true);
+  });
+});
+
+// ── Response shape ────────────────────────────────────────────────────────────
+
+describe('response envelope shape', () => {
+  it('200 response has status, results, and summary fields', async () => {
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({ items: [createItem()] });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('status', 'success');
+    expect(res.body).toHaveProperty('results');
+    expect(res.body).toHaveProperty('summary');
+    expect(res.body.summary).toHaveProperty('total');
+    expect(res.body.summary).toHaveProperty('succeeded');
+    expect(res.body.summary).toHaveProperty('failed');
+  });
+
+  it('207 response has status=partial_failure', async () => {
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({ items: [deleteItem(crypto.randomUUID())] });
+
+    expect(res.status).toBe(207);
+    expect(res.body.status).toBe('partial_failure');
+  });
+
+  it('each result item has index, success, and either data or error', async () => {
+    const id = await createSub();
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({
+        items: [
+          deleteItem(id),
+          deleteItem(crypto.randomUUID()),
+        ],
+      });
+
+    const [success, fail] = res.body.results;
+    expect(success).toHaveProperty('index', 0);
+    expect(success).toHaveProperty('success', true);
+    expect(success).toHaveProperty('data');
+    expect(success.error).toBeUndefined();
+
+    expect(fail).toHaveProperty('index', 1);
+    expect(fail).toHaveProperty('success', false);
+    expect(fail).toHaveProperty('error');
+    expect(fail.error).toHaveProperty('code');
+    expect(fail.error).toHaveProperty('message');
+  });
+
+  it('secret is never present in create result data', async () => {
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({ items: [createItem({ secret: 'super-secret' })] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.results[0].data.secret).toBeUndefined();
+  });
+
+  it('secret is never present in update result data', async () => {
+    const id = await createSub({ secret: 'original-secret' });
+    const res = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({ items: [updateItem(id, { secret: 'new-secret' })] });
+
+    expect(res.status).toBe(200);
+    expect(res.body.results[0].data.secret).toBeUndefined();
+  });
+});
+
+// ── Cache invalidation ────────────────────────────────────────────────────────
+
+describe('cache invalidation', () => {
+  it('list is re-fetched from DB after a successful bulk create', async () => {
+    // Warm the list cache via GET
+    await request(app).get(BASE).set(auth(adminToken()));
+
+    // Bulk create — should flush list cache
+    const bulkRes = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({ items: [createItem({ url: 'https://new-sub.com/hook', eventType: 'new.event' })] });
+    expect(bulkRes.status).toBe(200);
+
+    // Subsequent GET should return the new subscription (cache was invalidated)
+    const listRes = await request(app).get(BASE).set(auth(adminToken()));
+    expect(listRes.status).toBe(200);
+    expect(listRes.body.data.some((s: any) => s.eventType === 'new.event')).toBe(true);
+  });
+
+  it('deleted subscription is not served from cache after bulk delete', async () => {
+    const id = await createSub({ eventType: 'to-be-deleted' });
+
+    // Warm per-id cache
+    await request(app).get(`${BASE}/${id}`).set(auth(adminToken()));
+
+    // Bulk delete
+    const delRes = await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({ items: [deleteItem(id)] });
+    expect(delRes.status).toBe(200);
+
+    // GET /:id should now 404 (cache was invalidated)
+    const getRes = await request(app).get(`${BASE}/${id}`).set(auth(adminToken()));
+    expect(getRes.status).toBe(404);
+  });
+
+  it('cache is NOT flushed when all items fail (no successful writes)', async () => {
+    // Create a sub so the list is non-empty
+    await createSub({ eventType: 'existing.event' });
+
+    // Warm list cache
+    const before = await request(app).get(BASE).set(auth(adminToken()));
+    expect(before.body.data).toHaveLength(1);
+
+    // Bulk with all failures — cache should be untouched
+    await request(app)
+      .post(BULK)
+      .set(auth(adminToken()))
+      .send({ items: [deleteItem(crypto.randomUUID())] }); // not_found
+
+    // List should still return the existing subscription (cache still warm)
+    const after = await request(app).get(BASE).set(auth(adminToken()));
+    expect(after.status).toBe(200);
+    expect(after.body.data).toHaveLength(1);
+  });
+});

--- a/src/routes/webhook-subscription.routes.ts
+++ b/src/routes/webhook-subscription.routes.ts
@@ -13,6 +13,9 @@ import {
   toUpdateWebhookSubscriptionDto,
   toWebhookSubscriptionResponseDto,
   toListWebhookSubscriptionsQueryDto,
+  bulkWebhookSubscriptionSchema,
+  bulkWebhookItemSchema,
+  type BulkWebhookItemResult,
 } from '../modules/webhooks/dto/webhook-subscription.dto';
 import { AuthenticatedRequest } from '../lib/types';
 import { idempotencyMiddleware } from '../middleware/idempotency';
@@ -79,6 +82,209 @@ router.post(
       res.status(201).json({
         status: 'success',
         data: toWebhookSubscriptionResponseDto(subscription),
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+);
+
+/**
+ * POST /api/v1/webhook-subscriptions/bulk
+ *
+ * Process up to MAX_WEBHOOK_BULK_BATCH_SIZE (25) subscription operations in one
+ * request. Each item carries an explicit `operation` field:
+ *   - "create" — mirrors POST /
+ *   - "update" — mirrors PATCH /:id
+ *   - "delete" — mirrors DELETE /:id
+ *
+ * Items are validated and executed independently. A failing item produces a
+ * per-item error in the response without affecting other items.
+ *
+ * Response:
+ *   200  { status: 'success',         results: [...] }  — all items succeeded
+ *   207  { status: 'partial_failure', results: [...] }  — one or more items failed
+ *   400  { error: { code, message } }                   — empty batch or over-cap
+ *
+ * Per-item result:
+ *   { index, success: true,  data: WebhookSubscriptionResponseDto | { id, deleted } }
+ *   { index, success: false, error: { code, message } }
+ *
+ * Cache invalidation runs once after all items are processed (not per item) to
+ * avoid redundant cache churn. Per-id keys are evicted for mutated/deleted
+ * subscriptions; list keys are evicted whenever any item succeeded.
+ */
+router.post(
+  '/bulk',
+  webhookRateLimiter,
+  requireAuth,
+  requireRole('admin'),
+  validateSchema(bulkWebhookSubscriptionSchema),
+  async (req: AuthenticatedRequest, res: Response, next) => {
+    try {
+      const { items } = req.body as { items: unknown[] };
+
+      const repo = getRepo();
+      const results: BulkWebhookItemResult[] = [];
+
+      // Track which subscription ids were mutated/deleted so we can
+      // bulk-invalidate per-id cache keys in one pass after processing.
+      const mutatedIds = new Set<string>();
+      let anySucceeded = false;
+
+      for (let i = 0; i < items.length; i++) {
+        const raw = items[i];
+
+        // Validate the individual item using the discriminated-union schema.
+        // Invalid items get a per-item validation_error; the rest of the
+        // batch continues unaffected.
+        const parsed = bulkWebhookItemSchema.safeParse(raw);
+        if (!parsed.success) {
+          const firstIssue = parsed.error.issues[0];
+          results.push({
+            index: i,
+            success: false,
+            error: {
+              code: 'validation_error',
+              message: firstIssue?.message ?? 'Invalid item',
+            },
+          });
+          continue;
+        }
+
+        const item = parsed.data;
+
+        try {
+          if (item.operation === 'create') {
+            // SSRF-check the URL the same way the single-item POST does.
+            const { isSafeUrl } = await import('../utils/ssrf');
+            if (!isSafeUrl(item.url)) {
+              results.push({
+                index: i,
+                success: false,
+                error: {
+                  code: 'invalid_url',
+                  message: 'Provided URL is invalid or resolved to a private/reserved address.',
+                },
+              });
+              continue;
+            }
+
+            const subscription = await repo.create(
+              toCreateWebhookSubscriptionDto({
+                url: item.url,
+                eventType: item.eventType,
+                ...(item.consumerId !== undefined && { consumerId: item.consumerId }),
+                ...(item.secret !== undefined && { secret: item.secret }),
+              }),
+            );
+            anySucceeded = true;
+            results.push({
+              index: i,
+              success: true,
+              data: toWebhookSubscriptionResponseDto(subscription),
+            });
+
+          } else if (item.operation === 'update') {
+            // Validate URL if present.
+            if (item.url !== undefined) {
+              const { isSafeUrl } = await import('../utils/ssrf');
+              if (!isSafeUrl(item.url)) {
+                results.push({
+                  index: i,
+                  success: false,
+                  error: {
+                    code: 'invalid_url',
+                    message: 'Provided URL is invalid or resolved to a private/reserved address.',
+                  },
+                });
+                continue;
+              }
+            }
+
+            // Check existence before attempting the update.
+            const existing = await repo.findById(item.id);
+            if (!existing) {
+              results.push({
+                index: i,
+                success: false,
+                error: { code: 'not_found', message: 'Webhook subscription not found.' },
+              });
+              continue;
+            }
+
+            const updated = await repo.update(
+              item.id,
+              toUpdateWebhookSubscriptionDto({
+                ...(item.url !== undefined && { url: item.url }),
+                ...(item.eventType !== undefined && { eventType: item.eventType }),
+                ...(item.secret !== undefined && { secret: item.secret }),
+                ...(item.active !== undefined && { active: item.active }),
+              }),
+            );
+            mutatedIds.add(item.id);
+            anySucceeded = true;
+            results.push({
+              index: i,
+              success: true,
+              data: toWebhookSubscriptionResponseDto(updated),
+            });
+
+          } else {
+            // operation === 'delete'
+            const existing = await repo.findById(item.id);
+            if (!existing) {
+              results.push({
+                index: i,
+                success: false,
+                error: { code: 'not_found', message: 'Webhook subscription not found.' },
+              });
+              continue;
+            }
+
+            await repo.delete(item.id);
+            mutatedIds.add(item.id);
+            anySucceeded = true;
+            results.push({
+              index: i,
+              success: true,
+              data: { id: item.id, deleted: true },
+            });
+          }
+        } catch (itemError) {
+          // Unexpected per-item error — do not let it abort the rest of the batch.
+          results.push({
+            index: i,
+            success: false,
+            error: {
+              code: 'internal_error',
+              message: itemError instanceof Error ? itemError.message : 'An unexpected error occurred',
+            },
+          });
+        }
+      }
+
+      // --- Cache invalidation (once per batch, not once per item) ---
+      // Invalidate per-id keys for every subscription that was mutated or deleted.
+      for (const id of mutatedIds) {
+        webhookCache.invalidateSubscription(id);
+      }
+      // If any item succeeded, all list results are potentially stale.
+      if (anySucceeded) {
+        webhookCache.invalidateLists();
+      }
+
+      const failures = results.filter((r) => !r.success);
+      const statusCode = failures.length === 0 ? 200 : 207;
+
+      res.status(statusCode).json({
+        status: statusCode === 200 ? 'success' : 'partial_failure',
+        results,
+        summary: {
+          total: items.length,
+          succeeded: results.filter((r) => r.success).length,
+          failed: failures.length,
+        },
       });
     } catch (error) {
       next(error);


### PR DESCRIPTION
## Summary

Closes #834.

Adds `POST /api/v1/webhook-subscriptions/bulk` — a single endpoint that
processes up to 25 create, update, and delete subscription operations in
one request, following the same pattern as `POST /api/v1/contracts/bulk`.

## What changed

### New endpoint

`POST /api/v1/webhook-subscriptions/bulk`

Each item in the batch carries an explicit `operation` discriminant:

```json
{
  "items": [
    { "operation": "create", "url": "https://a.com/hook", "eventType": "contract.created" },
    { "operation": "update", "id": "<uuid>", "active": false },
    { "operation": "delete", "id": "<uuid>" }
  ]
}
