### PR TITLE
feat(health): add idempotency-key support to health write endpoints

### DIFF
--- a/src/routes/disputes.routes.ts
+++ b/src/routes/disputes.routes.ts
@@ -251,9 +251,6 @@ export function createDisputesObservabilityMiddleware(options: DisputesRouterOpt
   };
 }
 
-  return router;
-}
-
 function formatExpressPath(path: unknown): string | null {
   if (typeof path === 'string') {
     return normalizeRoutePart(path);

--- a/src/routes/health.test.ts
+++ b/src/routes/health.test.ts
@@ -7,59 +7,82 @@
  */
 
 import express from 'express';
-import http from 'http';
+import request from 'supertest';
 import { healthRouter } from './health';
 
-interface SimpleResponse {
-  statusCode: number;
-  headers: http.IncomingHttpHeaders;
-  body: string;
-}
-
-function request(server: http.Server, method: string, path: string): Promise<SimpleResponse> {
-  return new Promise((resolve, reject) => {
-    const addr = server.address() as { port: number };
-    const req = http.request(
-      { hostname: '127.0.0.1', port: addr.port, path, method },
-      (res) => {
-        let data = '';
-        res.on('data', (c) => (data += c));
-        res.on('end', () =>
-          resolve({ statusCode: res.statusCode ?? 0, headers: res.headers, body: data }),
-        );
-      },
-    );
-    req.on('error', reject);
-    req.end();
-  });
-}
-
 describe('healthRouter', () => {
-  let server: http.Server;
+  let app: express.Application;
 
-  beforeAll((done: jest.DoneCallback) => {
-    const a = express();
-    a.use('/', healthRouter);
-    const s = a.listen(0, '127.0.0.1', done);
-    void (server = s);
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/', healthRouter);
   });
 
-  afterAll((done) => {
-    void server.close(done);
+  describe('GET /', () => {
+    it('returns 200 and { status: "ok", service: "talenttrust-backend" }', async () => {
+      const res = await request(app).get('/');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ status: 'ok', service: 'talenttrust-backend' });
+      expect(res.headers['content-type']).toMatch(/application\/json/);
+    });
   });
 
-  it('GET / → 200', async () => {
-    const res = await request(server, 'GET', '/');
-    expect(res.statusCode).toBe(200);
-  });
+  describe('POST /', () => {
+    it('first write: returns 200 and healthy payload', async () => {
+      const res = await request(app)
+        .post('/')
+        .set('idempotency-key', 'test-key-1')
+        .send({ service: 'test-svc-1', status: 'ok', uptimeSeconds: 100 });
+      
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('healthy');
+      expect(res.body.timestamp).toBeDefined();
+      expect(res.body.version).toBeDefined();
+    });
 
-  it('returns { status: "ok", service: "talenttrust-backend" }', async () => {
-    const res = await request(server, 'GET', '/');
-    expect(JSON.parse(res.body)).toEqual({ status: 'ok', service: 'talenttrust-backend' });
-  });
+    it('exact replay: returns original response', async () => {
+      // First request
+      const firstRes = await request(app)
+        .post('/')
+        .set('idempotency-key', 'test-key-2')
+        .send({ service: 'test-svc-2', status: 'ok', uptimeSeconds: 200 });
+      
+      expect(firstRes.status).toBe(200);
+      
+      // Wait a bit to ensure timestamp would be different if not cached
+      await new Promise(r => setTimeout(r, 10));
 
-  it('content-type is application/json', async () => {
-    const res = await request(server, 'GET', '/');
-    expect(res.headers['content-type']).toMatch(/application\/json/);
+      // Second request (exact replay)
+      const secondRes = await request(app)
+        .post('/')
+        .set('idempotency-key', 'test-key-2')
+        .send({ service: 'test-svc-2', status: 'ok', uptimeSeconds: 200 });
+
+      expect(secondRes.status).toBe(200);
+      expect(secondRes.body).toEqual(firstRes.body);
+    });
+
+    it('key reuse with different body: returns 409 conflict', async () => {
+      // First request
+      await request(app)
+        .post('/')
+        .set('idempotency-key', 'test-key-3')
+        .send({ service: 'test-svc-3', status: 'ok', uptimeSeconds: 300 });
+
+      // Second request (different body, same key)
+      const conflictRes = await request(app)
+        .post('/')
+        .set('idempotency-key', 'test-key-3')
+        .send({ service: 'test-svc-different', status: 'ok', uptimeSeconds: 400 });
+
+      expect(conflictRes.status).toBe(409);
+      expect(conflictRes.body).toEqual({
+        error: {
+          code: 'conflict',
+          message: 'Idempotency key already used for a different request',
+        },
+      });
+    });
   });
 });

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -25,12 +25,19 @@
  */
 
 import { Router, Request, Response } from 'express';
+import { createHash } from 'crypto';
+import { LRUCache } from 'lru-cache';
 import { registry } from '../docs/openapi-registry';
 import { validateRequest, validateQuery } from '../middleware/validation';
 import { HealthWriteBodySchema, HealthQuerySchema } from '../health/validation';
 import { createRateLimiter } from '../middleware/rateLimiter';
 import { rateLimitConfig } from '../config/rateLimit';
 import { healthRateLimitKeyFn } from '../health/rateLimitKey';
+
+const idempotencyStore = new LRUCache<string, { bodyHash: string; response: any }>({
+  max: 1000,
+  ttl: 1000 * 60 * 60 * 24, // 24 hours
+});
 
 export const healthRouter = Router();
 
@@ -103,7 +110,35 @@ healthRouter.get('/', validateQuery(HealthQuerySchema), (_req: Request, res: Res
   });
 });
 
-healthRouter.post('/', validateRequest(HealthWriteBodySchema), (_req: Request, res: Response) => {
+healthRouter.post('/', validateRequest(HealthWriteBodySchema), (req: Request, res: Response) => {
+  const idempotencyKey = req.header('idempotency-key');
+
+  if (idempotencyKey) {
+    const bodyHash = createHash('sha256').update(JSON.stringify(req.body)).digest('hex');
+    const cached = idempotencyStore.get(idempotencyKey);
+
+    if (cached) {
+      if (cached.bodyHash !== bodyHash) {
+        return res.status(409).json({
+          error: {
+            code: 'conflict',
+            message: 'Idempotency key already used for a different request',
+          },
+        });
+      }
+      return res.status(200).json(cached.response);
+    }
+
+    const response = {
+      status: 'healthy',
+      timestamp: new Date().toISOString(),
+      version: process.env.npm_package_version ?? '0.1.0',
+    };
+
+    idempotencyStore.set(idempotencyKey, { bodyHash, response });
+    return res.status(200).json(response);
+  }
+
   res.status(200).json({
     status: 'healthy',
     timestamp: new Date().toISOString(),


### PR DESCRIPTION
## Description
Retried health write requests could previously double-apply. This PR adds `Idempotency-Key` header handling so that repeats safely return the original result.

## Requirements and context
- Adds an `Idempotency-Key` header check on health writes (`POST /health`).
- Uses `LRUCache` to store and replay the original responses for repeats.
- The cache is bounded to 1000 items and expires old keys after 24 hours.
- A cryptographic hash of the request body is stored to detect key reuse with different bodies.

## Edge cases covered
- **First write**: Handled correctly, caches the exact original generated payload.
- **Exact replay**: Handled correctly, returns the original cached response.
- **Key reuse with different body**: Handled correctly, returns HTTP `409 Conflict`.

## Test Output

> talenttrust-backend@0.1.0 test
> jest src/routes/health.test.ts
PASS src/routes/health.test.ts
  healthRouter
    GET /
      ✓ returns 200 and { status: "ok", service: "talenttrust-backend" } (48 ms)
    POST /
      ✓ first write: returns 200 and healthy payload (27 ms)
      ✓ exact replay: returns original response (17 ms)
      ✓ key reuse with different body: returns 409 conflict (6 ms)
Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        3.632 s, estimated 4 s
Ran all test suites matching /src\/routes\/health.test.ts/i.


closes #772 