### PR TITLE
feat(contracts): add idempotency-key support for POST /api/v1/contracts

### DIFF
--- a/src/auth/authCache.test.ts
+++ b/src/auth/authCache.test.ts
@@ -61,19 +61,24 @@ describe('AuthCache', () => {
     });
 
     it('does not increment hit counter on expired entry', () => {
-      const shortTtlCache = new AuthCache({ ttlMs: 10, maxEntries: 100 });
-      shortTtlCache.set('selector-1', mockApiKeyInfo);
-      
-      // Wait for expiration
-      jest.advanceTimersByTime(20);
-      
-      const statsBefore = shortTtlCache.getStats();
-      const result = shortTtlCache.get('selector-1');
-      const statsAfter = shortTtlCache.getStats();
-      
-      expect(result).toBeNull();
-      expect(statsAfter.misses).toBe(statsBefore.misses + 1);
-      expect(statsAfter.hits).toBe(statsBefore.hits);
+      jest.useFakeTimers();
+      try {
+        const shortTtlCache = new AuthCache({ ttlMs: 10, maxEntries: 100 });
+        shortTtlCache.set('selector-1', mockApiKeyInfo);
+
+        // Wait for expiration
+        jest.advanceTimersByTime(20);
+
+        const statsBefore = shortTtlCache.getStats();
+        const result = shortTtlCache.get('selector-1');
+        const statsAfter = shortTtlCache.getStats();
+
+        expect(result).toBeNull();
+        expect(statsAfter.misses).toBe(statsBefore.misses + 1);
+        expect(statsAfter.hits).toBe(statsBefore.hits);
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 

--- a/src/middleware/contractIdempotency.test.ts
+++ b/src/middleware/contractIdempotency.test.ts
@@ -1,0 +1,290 @@
+import express from 'express';
+import request from 'supertest';
+
+import {
+  createContractIdempotencyMiddleware,
+  IDEMPOTENCY_KEY_MAX_LENGTH,
+} from './contractIdempotency';
+import { InMemoryContractIdempotencyStore } from './contractIdempotencyStore';
+
+/**
+ * Builds an isolated Express app that mimics POST /api/v1/contracts with a
+ * mock "milestone release" handler. The handler counts executions so tests
+ * can prove the side effect ran exactly once.
+ */
+function buildApp(
+  store: InMemoryContractIdempotencyStore,
+  options: { ttlMs?: number } = {},
+): { app: express.Express; releases: () => number } {
+  let releases = 0;
+  const app = express();
+  app.use(express.json());
+  app.use((req, res, next) => {
+    (req as express.Request & { user?: { id: string } }).user = {
+      id: req.header('X-Test-User') ?? 'user-a',
+    };
+    res.locals.requestId = 'contract-idempotency-test';
+    next();
+  });
+  app.post(
+    '/api/v1/contracts',
+    createContractIdempotencyMiddleware({
+      store,
+      ttlMs: options.ttlMs,
+    }),
+    (req, res) => {
+      releases += 1;
+      res.status(201).json({
+        status: 'success',
+        data: { id: 'contract-1', title: req.body.title },
+        requestId: 'contract-idempotency-test',
+      });
+    },
+  );
+  return { app, releases: () => releases };
+}
+
+describe('contract idempotency middleware', () => {
+  it('passes through unchanged when Idempotency-Key is absent', async () => {
+    const store = new InMemoryContractIdempotencyStore();
+    const { app, releases } = buildApp(store);
+    const body = { title: 'Milestone' };
+
+    await request(app).post('/api/v1/contracts').send(body).expect(201);
+    await request(app).post('/api/v1/contracts').send(body).expect(201);
+
+    expect(releases()).toBe(2);
+    expect(store.size()).toBe(0);
+  });
+
+  it('replays the identical response and executes the release only once', async () => {
+    const store = new InMemoryContractIdempotencyStore();
+    const { app, releases } = buildApp(store);
+
+    const first = await request(app)
+      .post('/api/v1/contracts')
+      .set('Idempotency-Key', 'key-1')
+      .send({ title: 'Milestone', budget: 100 })
+      .expect(201);
+
+    // Same logical body with reordered keys must fingerprint identically.
+    const replay = await request(app)
+      .post('/api/v1/contracts')
+      .set('Idempotency-Key', 'key-1')
+      .send({ budget: 100, title: 'Milestone' })
+      .expect(201);
+
+    expect(releases()).toBe(1);
+    expect(replay.body).toEqual(first.body);
+    expect(replay.headers['idempotency-replayed']).toBe('true');
+    expect(store.size()).toBe(1);
+  });
+
+  it('returns 409 idempotency_conflict when the key is reused with a different body', async () => {
+    const store = new InMemoryContractIdempotencyStore();
+    const { app, releases } = buildApp(store);
+
+    await request(app)
+      .post('/api/v1/contracts')
+      .set('Idempotency-Key', 'key-2')
+      .send({ title: 'First' })
+      .expect(201);
+
+    const conflict = await request(app)
+      .post('/api/v1/contracts')
+      .set('Idempotency-Key', 'key-2')
+      .send({ title: 'Different' })
+      .expect(409);
+
+    expect(conflict.body.error.code).toBe('idempotency_conflict');
+    expect(releases()).toBe(1);
+  });
+
+  it('releases the reservation on a failed first attempt so a retry re-executes', async () => {
+    const store = new InMemoryContractIdempotencyStore();
+    let releases = 0;
+
+    const app = express();
+    app.use(express.json());
+    app.use((req, res, next) => {
+      (req as express.Request & { user?: { id: string } }).user = { id: 'user-a' };
+      res.locals.requestId = 'contract-idempotency-test';
+      next();
+    });
+    app.post(
+      '/api/v1/contracts',
+      createContractIdempotencyMiddleware({ store }),
+      (req, res) => {
+        releases += 1;
+        if (releases === 1) {
+          res.status(500).json({
+            status: 'error',
+            error: {
+              code: 'internal_error',
+              message: 'transient failure',
+              requestId: 'contract-idempotency-test',
+            },
+          });
+          return;
+        }
+        res.status(201).json({
+          status: 'success',
+          data: { id: 'contract-1', title: req.body.title },
+          requestId: 'contract-idempotency-test',
+        });
+      },
+    );
+
+    const body = { title: 'Retryable' };
+    await request(app)
+      .post('/api/v1/contracts')
+      .set('Idempotency-Key', 'retry')
+      .send(body)
+      .expect(500);
+    await request(app)
+      .post('/api/v1/contracts')
+      .set('Idempotency-Key', 'retry')
+      .send(body)
+      .expect(201);
+
+    expect(releases).toBe(2);
+  });
+
+  it('allows exactly one concurrent request and rejects the other with request_in_progress', async () => {
+    const store = new InMemoryContractIdempotencyStore();
+
+    let enterResolve!: () => void;
+    const entered = new Promise<void>((resolve) => {
+      enterResolve = resolve;
+    });
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    let releases = 0;
+
+    const app = express();
+    app.use(express.json());
+    app.use((req, res, next) => {
+      (req as express.Request & { user?: { id: string } }).user = { id: 'user-a' };
+      res.locals.requestId = 'contract-idempotency-test';
+      next();
+    });
+    app.post(
+      '/api/v1/contracts',
+      createContractIdempotencyMiddleware({ store }),
+      async (req, res) => {
+        releases += 1;
+        enterResolve();
+        await gate;
+        res.status(201).json({
+          status: 'success',
+          data: { id: 'contract-1', title: req.body.title },
+          requestId: 'contract-idempotency-test',
+        });
+      },
+    );
+
+    const body = { title: 'Concurrent' };
+    // `.then` eagerly dispatches the (otherwise lazy) supertest request, so
+    // request #1 actually reaches the middleware before we wait on `entered`.
+    const firstPromise = request(app)
+      .post('/api/v1/contracts')
+      .set('Idempotency-Key', 'concurrent')
+      .send(body)
+      .then((res) => res);
+
+    // Wait until the first request has reserved the key and is blocked on the
+    // gate, then fire the overlapping second request.
+    await entered;
+    const second = await request(app)
+      .post('/api/v1/contracts')
+      .set('Idempotency-Key', 'concurrent')
+      .send(body);
+
+    releaseGate();
+    const first = await firstPromise;
+
+    expect(releases).toBe(1);
+    expect(first.status).toBe(201);
+    expect(second.status).toBe(409);
+    expect(second.body.error.code).toBe('request_in_progress');
+  });
+
+  it('treats the same key as a new request after TTL expiry', async () => {
+    let now = 1_000_000;
+    const store = new InMemoryContractIdempotencyStore({ clock: () => now });
+    const { app, releases } = buildApp(store, { ttlMs: 100 });
+    const body = { title: 'Expiring' };
+
+    await request(app)
+      .post('/api/v1/contracts')
+      .set('Idempotency-Key', 'expiring')
+      .send(body)
+      .expect(201);
+
+    now += 101;
+
+    await request(app)
+      .post('/api/v1/contracts')
+      .set('Idempotency-Key', 'expiring')
+      .send(body)
+      .expect(201);
+
+    expect(releases()).toBe(2);
+  });
+
+  it('isolates the same key across tenants', async () => {
+    const store = new InMemoryContractIdempotencyStore();
+    const { app, releases } = buildApp(store);
+    const body = { title: 'Shared' };
+
+    await request(app)
+      .post('/api/v1/contracts')
+      .set('Idempotency-Key', 'shared')
+      .set('X-Test-User', 'user-a')
+      .send(body)
+      .expect(201);
+    await request(app)
+      .post('/api/v1/contracts')
+      .set('Idempotency-Key', 'shared')
+      .set('X-Test-User', 'user-b')
+      .send(body)
+      .expect(201);
+
+    expect(releases()).toBe(2);
+    expect(store.size()).toBe(2);
+  });
+
+  it('rejects a malformed (empty/whitespace) key with 400', async () => {
+    const store = new InMemoryContractIdempotencyStore();
+    const { app, releases } = buildApp(store);
+
+    for (const key of ['', '   ']) {
+      const res = await request(app)
+        .post('/api/v1/contracts')
+        .set('Idempotency-Key', key)
+        .send({ title: 'x' })
+        .expect(400);
+      expect(res.body.error.code).toBe('invalid_idempotency_key');
+    }
+
+    expect(releases()).toBe(0);
+    expect(store.size()).toBe(0);
+  });
+
+  it('rejects an oversized key with 400', async () => {
+    const store = new InMemoryContractIdempotencyStore();
+    const { app, releases } = buildApp(store);
+
+    const res = await request(app)
+      .post('/api/v1/contracts')
+      .set('Idempotency-Key', 'x'.repeat(IDEMPOTENCY_KEY_MAX_LENGTH + 1))
+      .send({ title: 'x' })
+      .expect(400);
+
+    expect(res.body.error.code).toBe('invalid_idempotency_key');
+    expect(releases()).toBe(0);
+    expect(store.size()).toBe(0);
+  });
+});

--- a/src/middleware/contractIdempotency.ts
+++ b/src/middleware/contractIdempotency.ts
@@ -1,143 +1,238 @@
-import type { Request, Response, NextFunction } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 import { createHash } from 'crypto';
-import { defaultIdempotencyStore } from '../db/idempotencyStore';
+import { computeIdempotencyFingerprint } from '../utils/idempotencyFingerprint';
+import {
+  ContractIdempotencyStore,
+  InMemoryContractIdempotencyStore,
+  CONTRACT_IDEMPOTENCY_DEFAULT_TTL_MS,
+} from './contractIdempotencyStore';
 
 /**
- * Contract creation idempotency middleware.
+ * @module middleware/contractIdempotency
+ * @description Optional Idempotency-Key support for `POST /api/v1/contracts`.
  *
- * Enforces HTTP idempotency for:
- *   POST /api/v1/contracts
+ * Why idempotency exists
+ * ----------------------
+ * `POST /api/v1/contracts` triggers the "milestone release" side effect
+ * (persisting a contract and preparing the Soroban escrow). A network retry
+ * must not release that milestone twice, so clients may attach an
+ * `Idempotency-Key` header and safely retry.
  *
- * Behavior:
- * - Requires Idempotency-Key header
- * - Idempotency keys are scoped to the authenticated user (req.user.id)
- * - Same key + same body returns the original response
- * - Same key + different body returns 409 Conflict
+ * Concurrency
+ * -----------
+ * A request reservation is made atomically via
+ * {@link ContractIdempotencyStore.reserve} — a single synchronous
+ * check-and-insert with no `await` in between. Exactly one concurrent request
+ * may execute; overlapping requests with the same key + fingerprint receive
+ * `409 request_in_progress`.
+ *
+ * Behaviour
+ * ---------
+ * - No header → pass through unchanged (idempotency is optional).
+ * - First request → execute, then persist `{ fingerprint, statusCode, body }`.
+ * - Same key + same fingerprint → replay the stored status and body verbatim.
+ * - Same key + different fingerprint → `409 idempotency_conflict`.
+ * - Concurrent same key + same fingerprint → `409 request_in_progress`.
+ * - Records expire after 24 hours (TTL), after which the key is treated as new.
  */
 
-type StoredResponse = {
-  statusCode: number;
-  body: unknown;
-};
+/** Maximum accepted Idempotency-Key length (rejected keys are never truncated). */
+export const IDEMPOTENCY_KEY_MAX_LENGTH = 255;
 
-type StoredIdempotency = {
-  payloadHash: string;
-  result: StoredResponse;
-};
+/** Contract idempotency record lifetime: exactly 24 hours. */
+export const CONTRACT_IDEMPOTENCY_TTL_MS = CONTRACT_IDEMPOTENCY_DEFAULT_TTL_MS;
 
-function stableJsonStringify(value: unknown): string {
-  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+export interface ContractIdempotencyMiddlewareOptions {
+  store?: ContractIdempotencyStore;
+  /**
+   * Record lifetime override. Production always uses 24h; exposed so tests can
+   * exercise expiry deterministically without real wall-clock time.
+   */
+  ttlMs?: number;
+}
 
-  if (Array.isArray(value)) {
-    return `[${value.map((v) => stableJsonStringify(v)).join(',')}]`;
+/**
+ * Shared in-memory store for contract idempotency records.
+ *
+ * Intentionally in-memory only (issue #1189). The {@link ContractIdempotencyStore}
+ * interface keeps the design replaceable with a distributed implementation
+ * (e.g. Redis `SET NX`) later without changing the middleware.
+ */
+export const contractIdempotencyStore: ContractIdempotencyStore =
+  new InMemoryContractIdempotencyStore({ ttlMs: CONTRACT_IDEMPOTENCY_TTL_MS });
+
+function requestIdFrom(res: Response): string {
+  return typeof res.locals.requestId === 'string'
+    ? res.locals.requestId
+    : 'unknown';
+}
+
+function sendError(
+  res: Response,
+  status: number,
+  code: string,
+  message: string,
+): Response {
+  return res.status(status).json({
+    error: {
+      code,
+      message,
+      requestId: requestIdFrom(res),
+    },
+  });
+}
+
+function resolveTenantId(req: Request): string | undefined {
+  const user = (
+    req as Request & {
+      user?: { id?: string; userId?: string; sub?: string };
+    }
+  ).user;
+  return user?.id ?? user?.userId ?? user?.sub;
+}
+
+function resolvePath(req: Request): string {
+  const raw = req.originalUrl || req.url || '';
+  return raw.split('?')[0] || '/';
+}
+
+/**
+ * Builds the store key from the tenant scope + method + path + idempotency key.
+ * The idempotency key is never used as the sole store key: two tenants (users)
+ * can independently use the same key.
+ */
+function buildScopeKey(
+  method: string,
+  path: string,
+  tenantId: string,
+  idempotencyKey: string,
+): string {
+  return createHash('sha256')
+    .update(`${tenantId}:${method}:${path}:${idempotencyKey}`)
+    .digest('hex');
+}
+
+/** Normalizes a `res.send` body (which may be a JSON string) for storage. */
+function normalizeSendBody(body: unknown): unknown {
+  if (typeof body !== 'string') {
+    return body;
   }
-
-  const obj = value as Record<string, unknown>;
-  const keys = Object.keys(obj).sort();
-  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableJsonStringify(obj[k])}`).join(',')}}`;
+  try {
+    return JSON.parse(body);
+  } catch {
+    return body;
+  }
 }
 
-function sha256Hex(input: string): string {
-  return createHash('sha256').update(input).digest('hex');
-}
+export function createContractIdempotencyMiddleware(
+  options: ContractIdempotencyMiddlewareOptions = {},
+): (req: Request, res: Response, next: NextFunction) => void {
+  const store = options.store ?? contractIdempotencyStore;
+  const ttlMs = options.ttlMs ?? CONTRACT_IDEMPOTENCY_TTL_MS;
 
-function getUserScopeId(req: Request): string | null {
-  const anyReq = req as any;
-  // Prefer user.id from this repo's JWT middleware (req.user.id == decoded.sub)
-  // Never fall back to a shared scope - return null if no authenticated user exists
-  return anyReq?.user?.id ?? anyReq?.user?.userId ?? anyReq?.user?.sub ?? null;
-}
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const header = req.headers['idempotency-key'];
 
-function buildScopedKey(userScopeId: string, idempotencyKey: string): string {
-  return sha256Hex(`${userScopeId}:${idempotencyKey.trim()}`);
-}
-
-function computePayloadHash(body: unknown): string {
-  return sha256Hex(stableJsonStringify(body));
-}
-
-export function contractCreateIdempotencyMiddleware(): (req: Request, res: Response, next: NextFunction) => Promise<void> {
-  const store = defaultIdempotencyStore;
-
-  return async (req: Request, res: Response, next: NextFunction) => {
-    const idempotencyKeyHeader = req.headers['idempotency-key'];
-    const requestId = typeof (res.locals as any)?.requestId === 'string' ? (res.locals as any).requestId : 'unknown';
-
-    if (typeof idempotencyKeyHeader !== 'string' || idempotencyKeyHeader.trim().length === 0) {
-      res.status(400).json({
-        error: {
-          code: 'bad_request',
-          message: 'Idempotency-Key header is required',
-          requestId,
-        },
-      });
+    // No header → idempotency is optional: do not touch the store and do not
+    // compute a fingerprint. The existing request flow is preserved exactly.
+    if (header === undefined) {
+      next();
       return;
     }
 
-    const userScopeId = getUserScopeId(req);
-    
-    // Fail closed: reject unauthenticated requests to prevent shared-scope collisions
-    if (userScopeId === null) {
-      res.status(401).json({
-        error: {
-          code: 'unauthorized',
-          message: 'Authentication required for idempotent contract creation',
-          requestId,
-        },
-      });
+    if (
+      typeof header !== 'string' ||
+      header.trim().length === 0 ||
+      header.length > IDEMPOTENCY_KEY_MAX_LENGTH
+    ) {
+      sendError(
+        res,
+        400,
+        'invalid_idempotency_key',
+        `Idempotency-Key must be a non-empty string of at most ${IDEMPOTENCY_KEY_MAX_LENGTH} characters.`,
+      );
       return;
     }
-    
-    const scopedKey = buildScopedKey(userScopeId, idempotencyKeyHeader);
-    const currentPayloadHash = computePayloadHash(req.body);
 
-    const existing = store.get<StoredIdempotency>(scopedKey);
-    if (existing) {
-      if (existing.payloadHash !== currentPayloadHash) {
-        res.status(409).json({
-          error: {
-            code: 'conflict',
-            message: 'Idempotency-Key was reused with a different request body',
-            requestId,
-          },
-        });
+    const tenantId = resolveTenantId(req);
+    if (tenantId === undefined) {
+      sendError(res, 401, 'unauthorized', 'Authentication required.');
+      return;
+    }
+
+    const idempotencyKey = header.trim();
+    const method = req.method;
+    const path = resolvePath(req);
+    const scopeKey = buildScopeKey(method, path, tenantId, idempotencyKey);
+    const fingerprint = computeIdempotencyFingerprint({
+      method,
+      path,
+      tenantId,
+      body: req.body,
+    });
+
+    const result = store.reserve(scopeKey, fingerprint, ttlMs);
+
+    switch (result.kind) {
+      case 'replay': {
+        res.setHeader('Idempotency-Replayed', 'true');
+        res.status(result.record.statusCode);
+        res.json(result.record.body);
         return;
       }
-
-      const cached = existing.result;
-      // Return the original response verbatim so a replay is byte-for-byte
-      // identical to the first response. The replay is signalled via a header
-      // rather than by mutating the cached body.
-      res.setHeader('Idempotency-Replayed', 'true');
-      res.status(cached.result.statusCode);
-      res.json(cached.result.body);
-      return;
+      case 'conflict':
+        sendError(
+          res,
+          409,
+          'idempotency_conflict',
+          'Idempotency-Key was already used with a different request body.',
+        );
+        return;
+      case 'in_progress':
+        sendError(
+          res,
+          409,
+          'request_in_progress',
+          'A request with this Idempotency-Key is already being processed.',
+        );
+        return;
+      case 'reserved':
+        break;
     }
 
-    // Capture response and store it with payload hash.
+    // Capture the terminal response exactly once. Successful (2xx) responses
+    // are persisted for replay; non-2xx responses release the reservation so a
+    // retry can re-attempt rather than replaying a transient failure.
+    let finished = false;
+    const finish = (body: unknown): void => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      if (res.statusCode >= 200 && res.statusCode < 300) {
+        store.complete(scopeKey, fingerprint, res.statusCode, body, ttlMs);
+      } else {
+        store.release(scopeKey, fingerprint);
+      }
+    };
+
     const originalJson = res.json.bind(res);
+    const originalSend = res.send.bind(res);
 
-    res.json = ((body: any) => {
-      // Store once the response is ready.
-      const stored: StoredIdempotency = {
-        payloadHash: currentPayloadHash,
-        result: {
-          statusCode: res.statusCode,
-          body,
-        },
-      };
-
-      store.set({
-        key: scopedKey,
-        payloadHash: currentPayloadHash,
-        result: stored,
-        createdAt: new Date(),
-      });
-
+    res.json = ((body: unknown) => {
+      finish(body);
       return originalJson(body);
-    }) as any;
+    }) as Response['json'];
+
+    res.send = ((body: unknown) => {
+      finish(normalizeSendBody(body));
+      return originalSend(body);
+    }) as Response['send'];
 
     next();
   };
 }
 
+/** Backwards-compatible no-arg factory used by the contracts router. */
+export const contractCreateIdempotencyMiddleware =
+  createContractIdempotencyMiddleware;

--- a/src/middleware/contractIdempotencyStore.test.ts
+++ b/src/middleware/contractIdempotencyStore.test.ts
@@ -1,0 +1,168 @@
+import { InMemoryContractIdempotencyStore } from './contractIdempotencyStore';
+
+describe('InMemoryContractIdempotencyStore', () => {
+  function makeStore(options: { ttlMs?: number; maxSize?: number; start?: number } = {}) {
+    let now = options.start ?? 1_000_000;
+    const store = new InMemoryContractIdempotencyStore({
+      ttlMs: options.ttlMs,
+      maxSize: options.maxSize,
+      clock: () => now,
+    });
+    return {
+      store,
+      now: () => now,
+      advance: (ms: number) => {
+        now += ms;
+      },
+    };
+  }
+
+  const TTL = 1_000;
+
+  describe('atomic reservation', () => {
+    it('reserves an absent key exactly once', () => {
+      const { store } = makeStore();
+      expect(store.reserve('key', 'fp-1', TTL)).toEqual({ kind: 'reserved' });
+      expect(store.reserve('key', 'fp-1', TTL)).toEqual({ kind: 'in_progress' });
+    });
+
+    it('returns conflict for the same key with a different fingerprint while in progress', () => {
+      const { store } = makeStore();
+      store.reserve('key', 'fp-1', TTL);
+      expect(store.reserve('key', 'fp-2', TTL)).toEqual({ kind: 'conflict' });
+    });
+  });
+
+  describe('completion and replay', () => {
+    it('replays the stored status and body after completion', () => {
+      const { store } = makeStore();
+      store.reserve('key', 'fp-1', TTL);
+      store.complete('key', 'fp-1', 201, { ok: true }, TTL);
+
+      const result = store.reserve('key', 'fp-1', TTL);
+      expect(result.kind).toBe('replay');
+      if (result.kind === 'replay') {
+        expect(result.record.statusCode).toBe(201);
+        expect(result.record.body).toEqual({ ok: true });
+      }
+    });
+
+    it('returns conflict for a different fingerprint after completion', () => {
+      const { store } = makeStore();
+      store.reserve('key', 'fp-1', TTL);
+      store.complete('key', 'fp-1', 201, { ok: true }, TTL);
+      expect(store.reserve('key', 'fp-2', TTL)).toEqual({ kind: 'conflict' });
+    });
+
+    it('preserves the original reservation expiry on completion', () => {
+      const { store, advance } = makeStore({ ttlMs: TTL });
+      store.reserve('key', 'fp-1', TTL);
+      const reservedEntry = store.get('key');
+      advance(50);
+      store.complete('key', 'fp-1', 201, {}, TTL);
+
+      const completedEntry = store.get('key');
+      expect(completedEntry?.expiresAt).toBe(reservedEntry?.expiresAt);
+    });
+  });
+
+  describe('release', () => {
+    it('frees a reservation so the key can be reserved again', () => {
+      const { store } = makeStore();
+      store.reserve('key', 'fp-1', TTL);
+      store.release('key', 'fp-1');
+      expect(store.reserve('key', 'fp-1', TTL)).toEqual({ kind: 'reserved' });
+    });
+
+    it('does not release a completed entry', () => {
+      const { store } = makeStore();
+      store.reserve('key', 'fp-1', TTL);
+      store.complete('key', 'fp-1', 201, {}, TTL);
+      store.release('key', 'fp-1');
+      expect(store.reserve('key', 'fp-1', TTL).kind).toBe('replay');
+    });
+  });
+
+  describe('expiration', () => {
+    it('defaults records to a 24-hour TTL when none is supplied', () => {
+      const { store } = makeStore(); // no ttlMs → constructor default (24h)
+      store.reserve('key', 'fp'); // no explicit ttl → store default
+      const entry = store.get('key');
+      expect(entry?.expiresAt).toBe(1_000_000 + 24 * 60 * 60 * 1000);
+    });
+
+    it('treats an expired record as absent on reserve', () => {
+      const { store, advance } = makeStore({ ttlMs: 100 });
+      store.reserve('key', 'fp-1', 100);
+      store.complete('key', 'fp-1', 201, {}, 100);
+
+      advance(101);
+      expect(store.reserve('key', 'fp-1', 100)).toEqual({ kind: 'reserved' });
+    });
+
+    it('lazy-expires on get()', () => {
+      const { store, advance } = makeStore({ ttlMs: 100 });
+      store.reserve('key', 'fp-1', 100);
+      store.complete('key', 'fp-1', 201, {}, 100);
+
+      advance(101);
+      expect(store.get('key')).toBeUndefined();
+      expect(store.size()).toBe(0);
+    });
+
+    it('purgeExpired removes expired entries and returns the count', () => {
+      const { store, advance } = makeStore({ ttlMs: 100 });
+      store.reserve('a', 'fp', 100);
+      store.complete('a', 'fp', 201, {}, 100);
+      store.reserve('b', 'fp', 100); // left in_progress
+
+      advance(101);
+      expect(store.purgeExpired()).toBe(2);
+      expect(store.size()).toBe(0);
+    });
+
+    it('bounds memory via maxSize eviction of the oldest entry', () => {
+      const { store } = makeStore({ maxSize: 2, ttlMs: 100 });
+      store.reserve('a', 'fp', 100);
+      store.reserve('b', 'fp', 100);
+      store.reserve('c', 'fp', 100);
+      expect(store.size()).toBe(2);
+    });
+  });
+
+  describe('tenant isolation', () => {
+    it('keeps the same fingerprint independent across scope keys', () => {
+      const { store } = makeStore();
+      expect(store.reserve('scope-a', 'fp', TTL)).toEqual({ kind: 'reserved' });
+      expect(store.reserve('scope-b', 'fp', TTL)).toEqual({ kind: 'reserved' });
+    });
+  });
+
+  describe('response immutability', () => {
+    it('never shares the stored body reference with the caller', () => {
+      const { store } = makeStore();
+      store.reserve('key', 'fp-1', TTL);
+      store.complete(
+        'key',
+        'fp-1',
+        200,
+        { nested: { value: 1 } },
+        TTL,
+      );
+
+      const first = store.reserve('key', 'fp-1', TTL);
+      if (first.kind !== 'replay') {
+        throw new Error('expected replay');
+      }
+      (first.record.body as { nested: { value: number } }).nested.value = 999;
+
+      const second = store.reserve('key', 'fp-1', TTL);
+      if (second.kind !== 'replay') {
+        throw new Error('expected replay');
+      }
+      expect(
+        (second.record.body as { nested: { value: number } }).nested.value,
+      ).toBe(1);
+    });
+  });
+});

--- a/src/middleware/contractIdempotencyStore.ts
+++ b/src/middleware/contractIdempotencyStore.ts
@@ -1,0 +1,240 @@
+/**
+ * @module middleware/contractIdempotencyStore
+ * @description Idempotency store for `POST /api/v1/contracts`.
+ *
+ * The store models the three conceptual states the endpoint needs:
+ *
+ *   - absent        → no record for this scope + key
+ *   - in_progress   → a request has reserved the key and is still executing
+ *   - completed     → the request finished; its response is replayable
+ *
+ * {@link reserve} performs the check-and-insert **atomically**. Because it is
+ * a single synchronous operation on a `Map` with no `await` between the check
+ * and the write, two overlapping Node requests can never both win a
+ * reservation (Node runs JavaScript on a single thread). A distributed
+ * implementation would replace this with an atomic `INSERT ... ON CONFLICT
+ * DO NOTHING` (or an equivalent CAS), which is why the shape is an interface
+ * rather than a concrete `Map`.
+ */
+
+/** A finished request whose response can be replayed. */
+export interface CompletedIdempotencyRecord {
+  fingerprint: string;
+  statusCode: number;
+  body: unknown;
+  createdAt: number;
+  expiresAt: number;
+}
+
+/** Internal state for a single scope + idempotency key. */
+export interface IdempotencyEntry {
+  state: 'in_progress' | 'completed';
+  fingerprint: string;
+  createdAt: number;
+  expiresAt: number;
+  /** Present only when {@link state} is `completed`. */
+  record?: CompletedIdempotencyRecord;
+}
+
+/** Result of an atomic {@link ContractIdempotencyStore.reserve} call. */
+export type ReserveResult =
+  | { kind: 'reserved' } // this request owns the key; execute the side effect
+  | { kind: 'replay'; record: CompletedIdempotencyRecord } // completed + same fingerprint
+  | { kind: 'conflict' } // same key, different fingerprint (any state)
+  | { kind: 'in_progress' }; // in_progress + same fingerprint
+
+export interface ContractIdempotencyStore {
+  /** Atomically reserve `scopeKey` for `fingerprint`, or report the existing state. */
+  reserve(scopeKey: string, fingerprint: string, ttlMs: number): ReserveResult;
+  /** Transition a reserved key to `completed`, capturing the response for replay. */
+  complete(
+    scopeKey: string,
+    fingerprint: string,
+    statusCode: number,
+    body: unknown,
+    ttlMs: number,
+  ): void;
+  /** Free an in-progress reservation (error path) so a retry can re-attempt. */
+  release(scopeKey: string, fingerprint: string): void;
+  /** Inspect a non-expired entry (lazy-expires on access). Primarily for tests. */
+  get(scopeKey: string): IdempotencyEntry | undefined;
+  delete(scopeKey: string): void;
+  size(): number;
+  clear(): void;
+  /** Remove expired entries and return the count removed. */
+  purgeExpired(now?: number): number;
+}
+
+export interface ContractIdempotencyStoreConfig {
+  ttlMs?: number;
+  clock?: () => number;
+  maxSize?: number;
+}
+
+/** Default record lifetime for contract idempotency: exactly 24 hours. */
+export const CONTRACT_IDEMPOTENCY_DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+
+const DEFAULT_MAX_SIZE = 10_000;
+
+/**
+ * Deep-copies a JSON response body so later mutation of either the stored
+ * record or the replayed object can never affect the other.
+ */
+function snapshot<T>(value: T): T {
+  if (value === undefined || value === null) {
+    return value;
+  }
+  try {
+    return JSON.parse(JSON.stringify(value)) as T;
+  } catch {
+    // Not JSON-serializable (should not happen for our JSON endpoints) —
+    // fall back to the original reference rather than throwing mid-response.
+    return value;
+  }
+}
+
+function cloneRecord(
+  record: CompletedIdempotencyRecord,
+): CompletedIdempotencyRecord {
+  return { ...record, body: snapshot(record.body) };
+}
+
+export class InMemoryContractIdempotencyStore
+  implements ContractIdempotencyStore
+{
+  private readonly entries = new Map<string, IdempotencyEntry>();
+  private readonly ttlMs: number;
+  private readonly clock: () => number;
+  private readonly maxSize: number;
+
+  constructor(config: ContractIdempotencyStoreConfig = {}) {
+    this.ttlMs = config.ttlMs ?? CONTRACT_IDEMPOTENCY_DEFAULT_TTL_MS;
+    this.clock = config.clock ?? (() => Date.now());
+    this.maxSize = config.maxSize ?? DEFAULT_MAX_SIZE;
+  }
+
+  reserve(
+    scopeKey: string,
+    fingerprint: string,
+    ttlMs: number = this.ttlMs,
+  ): ReserveResult {
+    const now = this.clock();
+    const existing = this.entries.get(scopeKey);
+
+    if (existing && existing.expiresAt > now) {
+      if (existing.state === 'completed' && existing.record) {
+        // Fingerprints are non-secret SHA-256 digests; plain equality is
+        // correct here (no timing side-channel to protect).
+        return existing.fingerprint === fingerprint
+          ? { kind: 'replay', record: cloneRecord(existing.record) }
+          : { kind: 'conflict' };
+      }
+
+      // in_progress
+      return existing.fingerprint === fingerprint
+        ? { kind: 'in_progress' }
+        : { kind: 'conflict' };
+    }
+
+    // Absent or expired → a fresh reservation.
+    if (existing) {
+      this.entries.delete(scopeKey);
+    }
+    this.evictOldestIfNeeded();
+    this.entries.set(scopeKey, {
+      state: 'in_progress',
+      fingerprint,
+      createdAt: now,
+      expiresAt: now + ttlMs,
+    });
+    return { kind: 'reserved' };
+  }
+
+  complete(
+    scopeKey: string,
+    fingerprint: string,
+    statusCode: number,
+    body: unknown,
+    ttlMs: number = this.ttlMs,
+  ): void {
+    const now = this.clock();
+    const existing = this.entries.get(scopeKey);
+
+    // Preserve the original reservation's timestamps so the total lifetime
+    // stays exactly TTL from first reservation (not extended by processing).
+    const base =
+      existing && existing.state === 'in_progress'
+        ? { createdAt: existing.createdAt, expiresAt: existing.expiresAt }
+        : { createdAt: now, expiresAt: now + ttlMs };
+
+    this.entries.set(scopeKey, {
+      state: 'completed',
+      fingerprint,
+      createdAt: base.createdAt,
+      expiresAt: base.expiresAt,
+      record: {
+        fingerprint,
+        statusCode,
+        body: snapshot(body),
+        createdAt: base.createdAt,
+        expiresAt: base.expiresAt,
+      },
+    });
+  }
+
+  release(scopeKey: string, fingerprint: string): void {
+    const existing = this.entries.get(scopeKey);
+    if (
+      existing &&
+      existing.state === 'in_progress' &&
+      existing.fingerprint === fingerprint
+    ) {
+      this.entries.delete(scopeKey);
+    }
+  }
+
+  get(scopeKey: string): IdempotencyEntry | undefined {
+    const entry = this.entries.get(scopeKey);
+    if (!entry) {
+      return undefined;
+    }
+    if (entry.expiresAt <= this.clock()) {
+      this.entries.delete(scopeKey);
+      return undefined;
+    }
+    return entry;
+  }
+
+  delete(scopeKey: string): void {
+    this.entries.delete(scopeKey);
+  }
+
+  size(): number {
+    return this.entries.size;
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  purgeExpired(now: number = this.clock()): number {
+    let purged = 0;
+    for (const [key, entry] of this.entries) {
+      if (entry.expiresAt <= now) {
+        this.entries.delete(key);
+        purged += 1;
+      }
+    }
+    return purged;
+  }
+
+  private evictOldestIfNeeded(): void {
+    if (this.entries.size < this.maxSize) {
+      return;
+    }
+    const oldest = this.entries.keys().next().value;
+    if (oldest !== undefined) {
+      this.entries.delete(oldest);
+    }
+  }
+}

--- a/src/routes/contracts.routes.ts
+++ b/src/routes/contracts.routes.ts
@@ -251,7 +251,6 @@ function createContractsRouter(
     validateContractId,
     validateRequest(createMilestoneSchema),
     requireAuth,
-    contractCreateIdempotencyMiddleware(),
     requirePermission("contracts", "update", getContractOwnerId),
     milestonesSoftDelete.create.bind(milestonesSoftDelete),
   );
@@ -263,7 +262,6 @@ function createContractsRouter(
     validateContractId,
     validateParams(milestoneIdParamSchema),
     requireAuth,
-    contractCreateIdempotencyMiddleware(),
     requirePermission("contracts", "update", getContractOwnerId),
     milestonesSoftDelete.restore.bind(milestonesSoftDelete),
   );
@@ -275,7 +273,6 @@ function createContractsRouter(
     validateContractId,
     validateParams(milestoneIdParamSchema),
     requireAuth,
-    contractCreateIdempotencyMiddleware(),
     requirePermission("contracts", "update", getContractOwnerId),
     milestonesSoftDelete.softDelete.bind(milestonesSoftDelete),
   );
@@ -295,7 +292,9 @@ function createContractsRouter(
 
   /**
    * POST /api/v1/contracts
-   * Supports Idempotency-Key to safely retry contract creation without creating duplicates.
+   *
+   * Optionally supports an `Idempotency-Key` header to safely retry contract
+   * creation (the "milestone release" side effect) without executing it twice.
    */
   router.post(
     "/",
@@ -322,21 +321,18 @@ function createContractsRouter(
     "/bulk",
     requireAuth,
     requirePermission("contracts", "create"),
-    contractCreateIdempotencyMiddleware(),
     validateSchema(bulkCreateContractsSchema),
     bulkController.bulkCreateContracts,
   );
 
   // PATCH /:id — update an existing contract (owner or admin only)
   // validateContractId runs before auth to reject clearly invalid :id params early.
-  // Idempotency-Key support added for milestones write safety.
   /** @permission contracts:update (ownOnly for client/freelancer) — admin, client, freelancer */
   router.patch(
     "/:id",
     validateContractId,
     requireAuth,
     requirePermission("contracts", "update", getContractOwnerId),
-    contractCreateIdempotencyMiddleware(),
     validateUpdateContract,
     controller.updateContract,
   );
@@ -359,7 +355,6 @@ function createContractsRouter(
     validateContractId,
     requireAuth,
     requirePermission("contracts", "delete", getContractOwnerId),
-    contractCreateIdempotencyMiddleware(),
     controller.deleteContract,
   );
 

--- a/src/utils/idempotencyFingerprint.test.ts
+++ b/src/utils/idempotencyFingerprint.test.ts
@@ -1,0 +1,76 @@
+import {
+  canonicalizeJson,
+  computeIdempotencyFingerprint,
+} from './idempotencyFingerprint';
+
+describe('canonicalizeJson', () => {
+  it('is order-insensitive for object keys', () => {
+    expect(canonicalizeJson({ a: 1, b: 2 })).toBe(
+      canonicalizeJson({ b: 2, a: 1 }),
+    );
+  });
+
+  it('handles nested objects and arrays deterministically', () => {
+    const value = { a: [1, { b: 2, c: [3, 4] }], d: null };
+    expect(canonicalizeJson(value)).toBe(canonicalizeJson(value));
+  });
+
+  it('preserves array order (arrays are not sorted)', () => {
+    expect(canonicalizeJson([1, 2])).not.toBe(canonicalizeJson([2, 1]));
+  });
+
+  it('canonicalizes undefined to null', () => {
+    expect(canonicalizeJson(undefined)).toBe('null');
+  });
+
+  it('canonicalizes primitives', () => {
+    expect(canonicalizeJson('x')).toBe('"x"');
+    expect(canonicalizeJson(5)).toBe('5');
+    expect(canonicalizeJson(null)).toBe('null');
+  });
+});
+
+describe('computeIdempotencyFingerprint', () => {
+  const base = {
+    method: 'POST',
+    path: '/api/v1/contracts',
+    tenantId: 'user-1',
+    body: { title: 'Milestone', budget: 100 },
+  };
+
+  it('is deterministic for identical input', () => {
+    expect(computeIdempotencyFingerprint(base)).toBe(
+      computeIdempotencyFingerprint(base),
+    );
+  });
+
+  it('is body-order-insensitive', () => {
+    expect(
+      computeIdempotencyFingerprint({
+        ...base,
+        body: { budget: 100, title: 'Milestone' },
+      }),
+    ).toBe(computeIdempotencyFingerprint(base));
+  });
+
+  it('differs when the body changes', () => {
+    expect(
+      computeIdempotencyFingerprint({ ...base, body: { title: 'Other' } }),
+    ).not.toBe(computeIdempotencyFingerprint(base));
+  });
+
+  it('differs when the tenant changes', () => {
+    expect(
+      computeIdempotencyFingerprint({ ...base, tenantId: 'user-2' }),
+    ).not.toBe(computeIdempotencyFingerprint(base));
+  });
+
+  it('differs when the method or path changes', () => {
+    expect(computeIdempotencyFingerprint({ ...base, method: 'PATCH' })).not.toBe(
+      computeIdempotencyFingerprint(base),
+    );
+    expect(
+      computeIdempotencyFingerprint({ ...base, path: '/api/v1/other' }),
+    ).not.toBe(computeIdempotencyFingerprint(base));
+  });
+});

--- a/src/utils/idempotencyFingerprint.ts
+++ b/src/utils/idempotencyFingerprint.ts
@@ -1,0 +1,57 @@
+import { createHash } from 'crypto';
+
+/**
+ * Recursively canonicalizes a JSON-serializable value into a deterministic
+ * string so semantically-equal bodies produce the same fingerprint regardless
+ * of object key insertion order.
+ *
+ * @remarks
+ * This is intentionally self-contained (no Prometheus/axios import side
+ * effects) so the idempotency middleware stays dependency-light. Object keys
+ * are sorted at every nesting level; arrays preserve order (order is
+ * semantically significant for arrays); `undefined` is canonicalized as
+ * `null` so a missing body is distinguishable from an empty object.
+ */
+export function canonicalizeJson(value: unknown): string {
+  if (value === undefined) {
+    return 'null';
+  }
+
+  if (value === null || typeof value !== 'object') {
+    // JSON.stringify returns `string | undefined`, but for every JSON-legal
+    // primitive here (string/number/boolean/null) it is always a string.
+    return JSON.stringify(value) as string;
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalizeJson(item)).join(',')}]`;
+  }
+
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys
+    .map((key) => `${JSON.stringify(key)}:${canonicalizeJson(obj[key])}`)
+    .join(',')}}`;
+}
+
+export interface IdempotencyFingerprintInput {
+  method: string;
+  path: string;
+  tenantId: string;
+  body: unknown;
+}
+
+/**
+ * Computes the idempotency fingerprint for a request.
+ *
+ * Includes method, path, tenant scope, and the canonicalized body. No
+ * secrets or request headers are included — only the fields that define the
+ * logical operation being deduplicated.
+ */
+export function computeIdempotencyFingerprint(
+  input: IdempotencyFingerprintInput,
+): string {
+  const { method, path, tenantId, body } = input;
+  const payload = `${method}\n${path}\n${tenantId}\n${canonicalizeJson(body)}`;
+  return createHash('sha256').update(payload, 'utf8').digest('hex');
+}


### PR DESCRIPTION
## Summary

Implements optional `Idempotency-Key` support for `POST /api/v1/contracts` so a client retry can never execute the contract-creation (milestone-release) side effect twice.

Closes #1189

## Behavior

- **No header** → request flows through unchanged (idempotency is optional).
- **First request** → executes, then persists fingerprint + statusCode + body for replay.
- **Replay** (same tenant + key + fingerprint) → returns the stored status/body verbatim; does not re-execute.
- **Conflict** (same tenant + key, different body) → `409 idempotency_conflict`.
- **Concurrent** (same tenant + key + fingerprint while in flight) → exactly one executes; the loser gets `409 request_in_progress`.
- **Malformed / oversized key** (empty or > 255 chars) → `400 invalid_idempotency_key`.
- **TTL** → 24 hours; expired records are treated as absent, lazily purged, and memory-bounded.

## Architecture

- `ContractIdempotencyStore` interface + `InMemoryContractIdempotencyStore` (in-memory only per issue scope; replaceable with a distributed store later).
- Atomic `reserve()` — a single synchronous check-and-insert (no read-then-write), so overlapping Node requests can't both win.
- Fingerprint = `sha256(method + path + tenantId + canonicalized body)` via `src/utils/idempotencyFingerprint.ts`.
- Tenant isolation: store key scoped to the authenticated user id (`req.user.id`); the raw idempotency key is never the sole store key.
- Scoped to `POST /` only — removed the previously broken required-header middleware from `/bulk`, `PATCH /:id`, `DELETE /:id`, and milestone routes.

## Testing

Added unit + integration coverage for every mandatory edge case: replay, conflict, barrier-gated concurrency, 24h TTL, no-header, malformed/oversized key, cross-tenant isolation, response immutability, and release-on-error.

## Verification

- `npm run lint` — 0 errors
- `npm test` — 197 suites / 4241 tests passing
- `npm run build` — passing

## Files

- `src/middleware/contractIdempotency.ts` (rewritten)
- `src/middleware/contractIdempotencyStore.ts` (new)
- `src/utils/idempotencyFingerprint.ts` (new)
- `src/routes/contracts.routes.ts` (scoped to POST /)
- `src/middleware/contractIdempotency.test.ts`, `contractIdempotencyStore.test.ts`, `utils/idempotencyFingerprint.test.ts` (new)
- `src/auth/authCache.test.ts` (fix a flaky fake-timer test so `npm test` is deterministic)