### PR TITLE
feat(transaction-poller): lease token fencing to prevent stale cross-instance writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Transaction Poller Lease Fencing (Issue #1210)
+
+- **Lease tokens on transactions**: `Transaction` rows now carry `lease_owner` and
+  `lease_expires_at` (SQLite migration v14), so only the poller instance that
+  currently owns a transaction may update it.
+- **Fenced writes**: every poller write is a compare-and-swap
+  (`setIfLeaseOwner`) that only applies while the caller still owns the lease.
+  An old worker that completes late after losing its lease can no longer
+  clobber the new owner's state.
+- **Abandonment reporting**: polls abandoned because the lease was lost are
+  logged (structured `warn`), counted (`abandonedPolls`), and reported through
+  an optional `onPollAbandoned` callback for retry.
+- **Clock-skew tolerance**: `leaseSkewMs` prevents leases from being stolen
+  early by nodes with fast clocks.
+- **Restart-safe recovery**: `recoverPendingTransactions()` resumes only
+  transactions whose lease has expired or is unowned, skipping live foreign
+  leases.
+- **Coverage**: unit + integration tests for lease acquisition, expiry during
+  RPC, old-worker late completion, process restart, and clock skew.
+
 #### Deployment Automation Pipeline (Issue #45)
 
 - **Environment Configuration Module** (`src/config/environment.ts`)

--- a/docs/transaction-polling.md
+++ b/docs/transaction-polling.md
@@ -37,3 +37,19 @@ During application boot, the system calls `TransactionPoller.recoverPendingTrans
 3. Background polling resumes transparently.
 
 Because of the exponential backoff, transactions that had already accumulated a high `retryCount` before the restart will resume with a long delay, rather than hitting the network immediately.
+
+## Lease Fencing (multi-instance safety)
+
+Each transaction row carries a poll lease (`lease_owner` + `lease_expires_at`). A lease prevents two poller instances from updating the same transaction after the lease owner has changed:
+
+- **Acquisition**: `poll()` and `recoverPendingTransactions()` acquire the lease before polling. A transaction whose lease is held by a *live* owner is skipped/deferred — only one instance polls it at a time.
+- **Renewal**: the lease is renewed immediately before every RPC call, so a long-running poll keeps its lease fresh without abandoning.
+- **Fencing**: every state write is a compare-and-swap (`setIfLeaseOwner`) that only applies while the stored `lease_owner` still matches the writer's token. If the lease expired while an RPC call was in flight and another instance took over, the old worker's late write is rejected and the poll is **abandoned and reported** (structured `warn` log + optional `onPollAbandoned` callback + `abandonedPolls` counter) so the work can be retried by the new owner.
+- **Recovery after restart**: only transactions whose lease has expired (the previous process is dead) or is unowned are resumed; transactions with a live foreign lease are skipped.
+
+Operational tuning (see `TransactionPollerOptions`):
+- `leaseDurationMs` (default 30s) bounds how long an in-flight RPC may outlive its owner before the transaction becomes stealable. Keep it comfortably above the expected RPC latency.
+- `leaseSkewMs` (default 5s) is a clock-skew tolerance: a lease is only considered expired when `expiresAt + skewMs < now`. This prevents a node with a slightly fast clock from stealing a lease that the owner still considers valid.
+- `leaseToken` defaults to a per-instance UUID, so every poller in a process group has a distinct fencing identity.
+
+On the SQLite store, lease acquisition runs inside an exclusive transaction (`BEGIN IMMEDIATE` where available) so concurrent processes sharing the database file cannot both acquire the same lease; the fenced write is a single atomic `UPDATE … WHERE lease_owner = ?` statement.

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -614,3 +614,37 @@ MIGRATIONS.push({
     `);
   },
 });
+
+// Version 14: poll lease columns on the transactions table.
+//
+// Lease fencing prevents two poller instances from updating the same
+// transaction after a lease owner has changed: `lease_owner` names the poller
+// instance that currently owns the transaction and `lease_expires_at` bounds
+// that ownership. Writes are only applied while the stored owner matches the
+// writer's token, so a poller whose lease expired (or was taken over) while an
+// RPC call was in flight abandons its poll instead of clobbering the new
+// owner's state.
+MIGRATIONS.push({
+  version: 14,
+  name: "add_transaction_lease_columns",
+  checksumSource: [
+    "ALTER TABLE transactions ADD COLUMN lease_owner TEXT",
+    "ALTER TABLE transactions ADD COLUMN lease_expires_at TEXT",
+  ].join("\n"),
+  up: (db) => {
+    const columns = db.pragma("table_info(transactions)") as Array<{
+      name: string;
+    }>;
+    const hasLeaseOwner = columns.some((column) => column.name === "lease_owner");
+    const hasLeaseExpiresAt = columns.some(
+      (column) => column.name === "lease_expires_at",
+    );
+
+    if (!hasLeaseOwner) {
+      db.exec("ALTER TABLE transactions ADD COLUMN lease_owner TEXT");
+    }
+    if (!hasLeaseExpiresAt) {
+      db.exec("ALTER TABLE transactions ADD COLUMN lease_expires_at TEXT");
+    }
+  },
+});

--- a/src/models/Transaction.lease.test.ts
+++ b/src/models/Transaction.lease.test.ts
@@ -1,0 +1,188 @@
+import {
+  InMemoryTransactionStore,
+  SqliteTransactionStore,
+  TransactionStatus,
+  TransactionsDbInterface,
+} from './Transaction';
+import { closeDb } from '../db/database';
+
+process.env.DB_PATH = ':memory:';
+
+/**
+ * Unit tests for the lease-fencing primitives shared by the transaction stores.
+ *
+ * These cover the storage contract used by {@link TransactionPoller} to prevent
+ * two poller instances from updating the same transaction after a lease owner
+ * has changed: lease acquisition/renewal, expiry with clock-skew tolerance, and
+ * compare-and-swap (fenced) writes.
+ */
+describe('Transaction store lease fencing', () => {
+  const OWNER_A = 'instance-a';
+  const OWNER_B = 'instance-b';
+
+  const runFor = (getStore: () => TransactionsDbInterface): void => {
+    const store = (): TransactionsDbInterface => getStore();
+
+    describe('acquireLease', () => {
+      it('creates a PENDING transaction and grants the lease for an unknown hash', () => {
+        const acquired = store().acquireLease('0xnew', OWNER_A, new Date(1000), 0, 0);
+        expect(acquired).toBe(true);
+
+        const tx = store().get('0xnew');
+        expect(tx).toBeDefined();
+        expect(tx!.status).toBe(TransactionStatus.PENDING);
+        expect(tx!.retryCount).toBe(0);
+        expect(tx!.leaseOwner).toBe(OWNER_A);
+        expect(tx!.leaseExpiresAt?.getTime()).toBe(1000);
+      });
+
+      it('renews the lease for the same owner, preserving transaction state', () => {
+        store().acquireLease('0xrenew', OWNER_A, new Date(1000), 0, 0);
+
+        const renewed = store().acquireLease('0xrenew', OWNER_A, new Date(5000), 4000, 0);
+        expect(renewed).toBe(true);
+
+        const tx = store().get('0xrenew');
+        expect(tx!.leaseOwner).toBe(OWNER_A);
+        expect(tx!.leaseExpiresAt?.getTime()).toBe(5000);
+        expect(tx!.status).toBe(TransactionStatus.PENDING);
+      });
+
+      it('refuses to grant a live lease held by another owner', () => {
+        store().acquireLease('0xheld', OWNER_A, new Date(10_000), 0, 0);
+
+        const acquired = store().acquireLease('0xheld', OWNER_B, new Date(20_000), 0, 0);
+        expect(acquired).toBe(false);
+
+        const tx = store().get('0xheld');
+        expect(tx!.leaseOwner).toBe(OWNER_A);
+      });
+
+      it('grants the lease to a new owner once the previous lease expires', () => {
+        store().acquireLease('0xexpires', OWNER_A, new Date(1000), 0, 0);
+
+        // now=1000, skew=0: the lease is no longer active.
+        const acquired = store().acquireLease('0xexpires', OWNER_B, new Date(2000), 1000, 0);
+        expect(acquired).toBe(true);
+        expect(store().get('0xexpires')!.leaseOwner).toBe(OWNER_B);
+      });
+
+      it('applies clock-skew tolerance before a lease may be stolen', () => {
+        store().acquireLease('0xskew', OWNER_A, new Date(1000), 0, 0);
+        const skewMs = 500;
+
+        // now=1000 is past the nominal expiry but within the skew window
+        // (1000 + 500 > 1000) — the lease must still be considered live.
+        expect(store().acquireLease('0xskew', OWNER_B, new Date(2000), 1000, skewMs)).toBe(false);
+
+        // At now=1500 (expiry + skew) the lease becomes stealable.
+        expect(store().acquireLease('0xskew', OWNER_B, new Date(2500), 1500, skewMs)).toBe(true);
+        expect(store().get('0xskew')!.leaseOwner).toBe(OWNER_B);
+      });
+
+      it('acquires legacy rows that predate lease tracking', () => {
+        store().set('0xlegacy', {
+          hash: '0xlegacy',
+          status: TransactionStatus.PENDING,
+          retryCount: 3,
+        });
+
+        const acquired = store().acquireLease('0xlegacy', OWNER_A, new Date(1000), 0, 0);
+        expect(acquired).toBe(true);
+
+        const tx = store().get('0xlegacy');
+        expect(tx!.leaseOwner).toBe(OWNER_A);
+        expect(tx!.retryCount).toBe(3);
+      });
+    });
+
+    describe('isLeaseOwner', () => {
+      it('is true for the current owner and false for everyone else', () => {
+        store().acquireLease('0xowner', OWNER_A, new Date(10_000), 0, 0);
+        expect(store().isLeaseOwner('0xowner', OWNER_A)).toBe(true);
+        expect(store().isLeaseOwner('0xowner', OWNER_B)).toBe(false);
+      });
+
+      it('is false for unknown hashes', () => {
+        expect(store().isLeaseOwner('0xmissing', OWNER_A)).toBe(false);
+      });
+
+      it('is false once a terminal write has cleared the lease', () => {
+        store().acquireLease('0xterminal', OWNER_A, new Date(10_000), 0, 0);
+        store().setIfLeaseOwner('0xterminal', {
+          hash: '0xterminal',
+          status: TransactionStatus.SUCCESS,
+          retryCount: 0,
+        }, OWNER_A);
+
+        expect(store().isLeaseOwner('0xterminal', OWNER_A)).toBe(false);
+      });
+    });
+
+    describe('setIfLeaseOwner (fenced writes)', () => {
+      it('applies the write while the caller owns the lease', () => {
+        store().acquireLease('0xwrite', OWNER_A, new Date(10_000), 0, 0);
+
+        const written = store().setIfLeaseOwner('0xwrite', {
+          hash: '0xwrite',
+          status: TransactionStatus.SUCCESS,
+          retryCount: 0,
+          receipt: { status: 1 },
+        }, OWNER_A);
+
+        expect(written).toBe(true);
+        expect(store().get('0xwrite')!.status).toBe(TransactionStatus.SUCCESS);
+      });
+
+      it('rejects the write and leaves state untouched when the lease was lost', () => {
+        store().acquireLease('0xstale', OWNER_A, new Date(10_000), 0, 0);
+
+        // Owner B takes over after A's lease expires mid-poll.
+        store().acquireLease('0xstale', OWNER_B, new Date(20_000), 10_000, 0);
+        store().setIfLeaseOwner('0xstale', {
+          hash: '0xstale',
+          status: TransactionStatus.SUCCESS,
+          retryCount: 0,
+          receipt: { status: 1, finalizedBy: 'B' },
+        }, OWNER_B);
+
+        // A completes late and attempts to write its stale result.
+        const staleWrite = store().setIfLeaseOwner('0xstale', {
+          hash: '0xstale',
+          status: TransactionStatus.SUCCESS,
+          retryCount: 0,
+          receipt: { status: 1, finalizedBy: 'A' },
+        }, OWNER_A);
+
+        expect(staleWrite).toBe(false);
+        expect(store().get('0xstale')!.receipt).toEqual({ status: 1, finalizedBy: 'B' });
+      });
+    });
+  };
+
+  describe('InMemoryTransactionStore', () => {
+    let store: InMemoryTransactionStore;
+
+    beforeEach(() => {
+      store = new InMemoryTransactionStore();
+    });
+
+    runFor(() => store);
+  });
+
+  describe('SqliteTransactionStore', () => {
+    let store: SqliteTransactionStore;
+
+    beforeEach(() => {
+      process.env.DB_PATH = ':memory:';
+      closeDb();
+      store = new SqliteTransactionStore();
+    });
+
+    afterEach(() => {
+      closeDb();
+    });
+
+    runFor(() => store);
+  });
+});

--- a/src/models/Transaction.ts
+++ b/src/models/Transaction.ts
@@ -20,6 +20,18 @@ export interface Transaction {
   lastCheckedAt?: Date;
   retryCount: number;
   startedAt?: Date;
+  /**
+   * Token of the poller instance that currently holds the poll lease for this
+   * transaction. Absent when no instance owns the transaction.
+   *
+   * Lease fencing guarantees that only the current owner may mutate the
+   * transaction: a poller that loses its lease (e.g. because it expired while
+   * an RPC call was in flight and another instance took over) must abandon its
+   * poll instead of writing stale state.
+   */
+  leaseOwner?: string;
+  /** When the current lease expires. Absent when no lease is held. */
+  leaseExpiresAt?: Date;
 }
 
 /**
@@ -37,6 +49,38 @@ export interface TransactionsDbInterface {
   clear(): void;
   /** Returns an iterator over all stored transactions. */
   values(): IterableIterator<Transaction>;
+
+  /**
+   * Atomically acquires (or renews) the poll lease for a transaction on behalf
+   * of `owner`.
+   *
+   * A lease is granted when:
+   *  - no lease is recorded (including legacy rows that predate leases), or
+   *  - the recorded lease has expired, judged with a clock-skew tolerance
+   *    (`expiresAt + skewMs < now`), or
+   *  - the recorded lease is already held by `owner` (renewal).
+   *
+   * A transaction row is created as `PENDING` when the hash is not yet known.
+   * When a live lease is held by a different owner the acquisition fails and
+   * the caller must not poll or write the transaction.
+   *
+   * @param hash      - Transaction hash.
+   * @param owner     - Unique token of the polling instance requesting the lease.
+   * @param expiresAt - Absolute time the lease expires.
+   * @param now       - Current time (injectable clock) used for expiry checks.
+   * @param skewMs    - Clock-skew tolerance applied when judging expiry.
+   * @returns true when `owner` now holds the lease, false when a live lease is
+   *          held by another instance.
+   */
+  acquireLease(hash: string, owner: string, expiresAt: Date, now: number, skewMs: number): boolean;
+  /** Returns true when the stored lease for the transaction is held by `owner`. */
+  isLeaseOwner(hash: string, owner: string): boolean;
+  /**
+   * Fenced write: persists `tx` only when the stored lease is still held by
+   * `owner`. Returns true when the write was applied, false when the lease was
+   * lost (the caller must abandon the poll and retry later).
+   */
+  setIfLeaseOwner(hash: string, tx: Transaction, owner: string): boolean;
 }
 
 /**
@@ -60,6 +104,8 @@ function rowToTransaction(row: any): Transaction {
     lastCheckedAt: row.last_checked_at ? new Date(row.last_checked_at) : undefined,
     retryCount: row.retry_count,
     startedAt: row.started_at ? new Date(row.started_at) : undefined,
+    leaseOwner: row.lease_owner ?? undefined,
+    leaseExpiresAt: row.lease_expires_at ? new Date(row.lease_expires_at) : undefined,
   };
 }
 
@@ -90,6 +136,49 @@ export class InMemoryTransactionStore implements TransactionsDbInterface {
 
   values(): IterableIterator<Transaction> {
     return this.store.values();
+  }
+
+  acquireLease(hash: string, owner: string, expiresAt: Date, now: number, skewMs: number): boolean {
+    const existing = this.store.get(hash);
+
+    if (!existing) {
+      this.store.set(hash, {
+        hash,
+        status: TransactionStatus.PENDING,
+        retryCount: 0,
+        startedAt: new Date(now),
+        leaseOwner: owner,
+        leaseExpiresAt: expiresAt,
+      });
+      return true;
+    }
+
+    const leaseActive =
+      existing.leaseOwner !== undefined &&
+      existing.leaseExpiresAt !== undefined &&
+      existing.leaseExpiresAt.getTime() + skewMs > now;
+
+    if (!leaseActive || existing.leaseOwner === owner) {
+      existing.leaseOwner = owner;
+      existing.leaseExpiresAt = expiresAt;
+      this.store.set(hash, existing);
+      return true;
+    }
+
+    return false;
+  }
+
+  isLeaseOwner(hash: string, owner: string): boolean {
+    return this.store.get(hash)?.leaseOwner === owner;
+  }
+
+  setIfLeaseOwner(hash: string, tx: Transaction, owner: string): boolean {
+    const existing = this.store.get(hash);
+    if (existing?.leaseOwner !== owner) {
+      return false;
+    }
+    this.store.set(hash, tx);
+    return true;
   }
 }
 
@@ -173,6 +262,89 @@ export class SqliteTransactionStore implements TransactionsDbInterface {
   }
 
   /**
+   * Acquires (or renews) the poll lease for a transaction.
+   *
+   * The read-decision-write sequence runs inside an exclusive transaction so
+   * that two processes sharing the same SQLite file cannot both acquire the
+   * lease for the same transaction. Rows are created as `PENDING` when the
+   * hash is not yet known.
+   */
+  acquireLease(hash: string, owner: string, expiresAt: Date, now: number, skewMs: number): boolean {
+    const db = getDb();
+    let acquired = false;
+
+    const decide = (): void => {
+      const existing = db
+        .prepare('SELECT lease_owner, lease_expires_at FROM transactions WHERE hash = ?')
+        .get(hash) as { lease_owner: string | null; lease_expires_at: string | null } | undefined;
+
+      if (!existing) {
+        db.prepare(`
+          INSERT INTO transactions (hash, status, retry_count, started_at, lease_owner, lease_expires_at)
+          VALUES (?, 'PENDING', 0, ?, ?, ?)
+        `).run(hash, new Date(now).toISOString(), owner, expiresAt.toISOString());
+        acquired = true;
+        return;
+      }
+
+      const expiryMs = existing.lease_expires_at ? Date.parse(existing.lease_expires_at) : NaN;
+      const leaseActive =
+        existing.lease_owner !== null &&
+        !isNaN(expiryMs) &&
+        expiryMs + skewMs > now;
+
+      if (!leaseActive || existing.lease_owner === owner) {
+        db.prepare('UPDATE transactions SET lease_owner = ?, lease_expires_at = ? WHERE hash = ?')
+          .run(owner, expiresAt.toISOString(), hash);
+        acquired = true;
+      }
+    };
+
+    runExclusive(db, decide);
+    return acquired;
+  }
+
+  /**
+   * Returns true when the stored lease for the transaction is held by `owner`.
+   */
+  isLeaseOwner(hash: string, owner: string): boolean {
+    try {
+      const row = getDb()
+        .prepare('SELECT lease_owner FROM transactions WHERE hash = ?')
+        .get(hash) as { lease_owner: string | null } | undefined;
+      return row?.lease_owner === owner;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Fenced write: updates the transaction row only while the stored lease is
+   * still held by `owner`. The single `UPDATE … WHERE lease_owner = ?`
+   * statement is atomic in SQLite, so a poller whose lease was taken over can
+   * never clobber the new owner's state.
+   */
+  setIfLeaseOwner(hash: string, tx: Transaction, owner: string): boolean {
+    const info = getDb().prepare(`
+      UPDATE transactions
+      SET status = ?, receipt = ?, last_checked_at = ?, retry_count = ?, started_at = ?,
+          lease_owner = ?, lease_expires_at = ?
+      WHERE hash = ? AND lease_owner = ?
+    `).run(
+      tx.status,
+      tx.receipt ? JSON.stringify(tx.receipt) : null,
+      tx.lastCheckedAt ? tx.lastCheckedAt.toISOString() : null,
+      tx.retryCount,
+      tx.startedAt ? tx.startedAt.toISOString() : null,
+      tx.leaseOwner ?? null,
+      tx.leaseExpiresAt ? tx.leaseExpiresAt.toISOString() : null,
+      hash,
+      owner,
+    );
+    return info.changes > 0;
+  }
+
+  /**
    * Returns an iterator over all stored transactions.
    *
    * ⚠️ Loads the entire table into memory. For large datasets,
@@ -181,6 +353,25 @@ export class SqliteTransactionStore implements TransactionsDbInterface {
   values(): IterableIterator<Transaction> {
     const rows = getDb().prepare('SELECT * FROM transactions').all() as any[];
     return rows.map(rowToTransaction).values();
+  }
+}
+
+/**
+ * Runs `work` inside an exclusive SQLite transaction so a read-decision-write
+ * sequence (lease acquisition) is atomic across processes sharing one database
+ * file.
+ *
+ * Real better-sqlite3 exposes `.immediate()` (`BEGIN IMMEDIATE`), which takes
+ * the write lock up front; the in-memory test double returns the function
+ * unchanged, where single-threaded execution already provides atomicity.
+ */
+function runExclusive(db: ReturnType<typeof getDb>, work: () => void): void {
+  const tx = db.transaction(work);
+  const immediate = (tx as { immediate?: () => void }).immediate;
+  if (typeof immediate === 'function') {
+    immediate();
+  } else {
+    tx();
   }
 }
 

--- a/src/services/TransactionPoller.fencing.integration.test.ts
+++ b/src/services/TransactionPoller.fencing.integration.test.ts
@@ -1,0 +1,193 @@
+import {
+  AbandonedPollInfo,
+  IBlockchainProvider,
+  SystemClock,
+  TransactionPoller,
+} from './TransactionPoller';
+import {
+  InMemoryTransactionStore,
+  SqliteTransactionStore,
+  TransactionStatus,
+} from '../models/Transaction';
+import { closeDb } from '../db/database';
+
+process.env.DB_PATH = ':memory:';
+
+/**
+ * Integration tests for TransactionPoller lease fencing.
+ *
+ * These exercise two poller instances sharing one store — the scenario behind
+ * the issue — including the SQLite-backed fence (real `UPDATE … WHERE
+ * lease_owner = ?` compare-and-swap) and restart recovery across instances.
+ */
+describe('TransactionPoller lease fencing (integration)', () => {
+  let sqliteStore: SqliteTransactionStore;
+
+  function createMockProvider(): jest.Mocked<IBlockchainProvider> {
+    return { getTransactionReceipt: jest.fn() };
+  }
+
+  async function flushMicrotasks(): Promise<void> {
+    await new Promise<void>((resolve) => {
+      jest.requireActual<typeof import('timers')>('timers').setImmediate(resolve);
+    });
+  }
+
+  async function advanceTimersAndFlush(ms: number): Promise<void> {
+    jest.advanceTimersByTime(ms);
+    await flushMicrotasks();
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(0);
+    jest.spyOn(Math, 'random').mockReturnValue(0.5);
+    process.env.DB_PATH = ':memory:';
+    closeDb();
+    sqliteStore = new SqliteTransactionStore();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+    closeDb();
+  });
+
+  describe('two poller instances sharing one store', () => {
+    it('exactly one instance wins the lease on a concurrent start; the other defers', async () => {
+      const store = new InMemoryTransactionStore();
+      const providerA = createMockProvider();
+      const providerB = createMockProvider();
+      providerA.getTransactionReceipt.mockResolvedValue({ status: 1, transactionHash: '0xrace', finalizedBy: 'A' });
+      providerB.getTransactionReceipt.mockResolvedValue({ status: 1, transactionHash: '0xrace', finalizedBy: 'B' });
+
+      const reports: AbandonedPollInfo[] = [];
+      const pollerA = new TransactionPoller(
+        providerA, 3, 100, undefined, SystemClock, store,
+        { leaseToken: 'instance-a', onPollAbandoned: (info) => reports.push(info) },
+      );
+      const pollerB = new TransactionPoller(
+        providerB, 3, 100, undefined, SystemClock, store,
+        { leaseToken: 'instance-b', onPollAbandoned: (info) => reports.push(info) },
+      );
+
+      await Promise.all([pollerA.poll('0xrace'), pollerB.poll('0xrace')]);
+      await flushMicrotasks();
+
+      const stored = store.get('0xrace');
+      expect(stored?.status).toBe(TransactionStatus.SUCCESS);
+
+      // Exactly one instance polled; the loser deferred without writing.
+      const totalProviderCalls =
+        providerA.getTransactionReceipt.mock.calls.length +
+        providerB.getTransactionReceipt.mock.calls.length;
+      expect(totalProviderCalls).toBe(1);
+
+      const winner = providerA.getTransactionReceipt.mock.calls.length === 1 ? 'A' : 'B';
+      expect(stored?.receipt.finalizedBy).toBe(winner);
+      expect(reports).toHaveLength(0);
+      expect(pollerA.abandonedPolls).toBe(0);
+      expect(pollerB.abandonedPolls).toBe(0);
+    });
+
+    it('fences out the old worker late write through the SQLite store', async () => {
+      const txHash = '0xsql-takeover';
+      let resolveLateRpc!: (receipt: any) => void;
+      const providerA = createMockProvider();
+      const providerB = createMockProvider();
+      providerA.getTransactionReceipt.mockImplementation(
+        () => new Promise((resolve) => { resolveLateRpc = resolve; }),
+      );
+      providerB.getTransactionReceipt.mockResolvedValue({ status: 0, transactionHash: txHash, finalizedBy: 'B' });
+
+      const reports: AbandonedPollInfo[] = [];
+      const pollerA = new TransactionPoller(
+        providerA, 3, 100, undefined, SystemClock, sqliteStore,
+        { leaseToken: 'instance-a', leaseDurationMs: 100, leaseSkewMs: 0, onPollAbandoned: (info) => reports.push(info) },
+      );
+      const pollerB = new TransactionPoller(
+        providerB, 3, 100, undefined, SystemClock, sqliteStore,
+        { leaseToken: 'instance-b', leaseDurationMs: 100, leaseSkewMs: 0 },
+      );
+
+      const pollPromiseA = pollerA.poll(txHash);
+      await flushMicrotasks();
+      expect(sqliteStore.get(txHash)?.leaseOwner).toBe('instance-a');
+
+      // A's 100ms lease expires while its RPC is in flight; B takes over.
+      await advanceTimersAndFlush(100);
+      const pollPromiseB = pollerB.poll(txHash);
+      await flushMicrotasks();
+      expect(sqliteStore.get(txHash)?.status).toBe(TransactionStatus.FAILED);
+
+      // A completes late; its SUCCESS write must be rejected by the SQL fence.
+      resolveLateRpc({ status: 1, transactionHash: txHash, finalizedBy: 'A' });
+      await flushMicrotasks();
+      await Promise.all([pollPromiseA, pollPromiseB]);
+
+      const stored = sqliteStore.get(txHash);
+      expect(stored?.status).toBe(TransactionStatus.FAILED);
+      expect(stored?.receipt).toEqual({ status: 0, transactionHash: txHash, finalizedBy: 'B' });
+      expect(reports).toEqual([
+        expect.objectContaining({ txHash, reason: 'lease-lost-during-rpc', leaseOwner: 'instance-a' }),
+      ]);
+      expect(pollerA.abandonedPolls).toBe(1);
+    });
+
+    it('renews the lease across backoff iterations through the SQLite store', async () => {
+      const provider = createMockProvider();
+      provider.getTransactionReceipt.mockResolvedValue(null);
+
+      const poller = new TransactionPoller(
+        provider, 3, 100, undefined, SystemClock, sqliteStore,
+        { leaseToken: 'instance-a', leaseDurationMs: 100, leaseSkewMs: 0 },
+      );
+
+      const pollPromise = poller.poll('0xsql-renew');
+      await flushMicrotasks();
+      expect(sqliteStore.get('0xsql-renew')?.leaseOwner).toBe('instance-a');
+      expect(sqliteStore.get('0xsql-renew')?.retryCount).toBe(1);
+
+      // Step through the backoff schedule (75/150/300ms with jitter 0.5): the
+      // lease is renewed on every iteration, so the poll is never abandoned
+      // even though each individual 100ms lease is shorter than the total time
+      // the poll stays alive.
+      await advanceTimersAndFlush(75);
+      expect(sqliteStore.get('0xsql-renew')?.retryCount).toBe(2);
+
+      await advanceTimersAndFlush(150);
+      expect(sqliteStore.get('0xsql-renew')?.retryCount).toBe(3);
+
+      await advanceTimersAndFlush(300);
+      expect(poller.abandonedPolls).toBe(0);
+      expect(sqliteStore.get('0xsql-renew')?.status).toBe(TransactionStatus.TIMEOUT);
+      await pollPromise;
+    });
+  });
+
+  describe('restart recovery across instances', () => {
+    it('resumes only transactions whose lease has expired, skipping live leases (SQLite)', async () => {
+      // A dead instance's lease expired long ago.
+      sqliteStore.acquireLease('0xrestart-expired', 'dead-instance', new Date(-10_000), -10_000, 0);
+      // Another live instance still holds a lease.
+      sqliteStore.acquireLease('0xrestart-live', 'live-instance', new Date(10_000), 0, 0);
+
+      const provider = createMockProvider();
+      provider.getTransactionReceipt.mockResolvedValue({ status: 1, transactionHash: '0xrestart-expired' });
+
+      const restarted = new TransactionPoller(
+        provider, 3, 100, undefined, SystemClock, sqliteStore,
+        { leaseToken: 'fresh-instance', leaseSkewMs: 0 },
+      );
+
+      await restarted.recoverPendingTransactions();
+      await flushMicrotasks();
+
+      expect(provider.getTransactionReceipt).toHaveBeenCalledTimes(1);
+      expect(provider.getTransactionReceipt).toHaveBeenCalledWith('0xrestart-expired');
+      expect(sqliteStore.get('0xrestart-expired')?.status).toBe(TransactionStatus.SUCCESS);
+      expect(sqliteStore.get('0xrestart-live')?.leaseOwner).toBe('live-instance');
+      expect(sqliteStore.get('0xrestart-live')?.status).toBe(TransactionStatus.PENDING);
+    });
+  });
+});

--- a/src/services/TransactionPoller.fencing.test.ts
+++ b/src/services/TransactionPoller.fencing.test.ts
@@ -1,0 +1,379 @@
+import {
+  AbandonedPollInfo,
+  IBlockchainProvider,
+  SystemClock,
+  TransactionPoller,
+} from './TransactionPoller';
+import {
+  InMemoryTransactionStore,
+  TransactionStatus,
+} from '../models/Transaction';
+
+/**
+ * Unit tests for TransactionPoller lease fencing.
+ *
+ * These cover the poller behaviour that prevents two poller instances from
+ * updating the same transaction after a lease owner has changed: lease
+ * acquisition, lease expiry mid-RPC, late writes by an old worker, process
+ * restart recovery, clock-skew tolerance, and abandonment reporting.
+ */
+describe('TransactionPoller lease fencing', () => {
+  let mockProvider: jest.Mocked<IBlockchainProvider>;
+  let store: InMemoryTransactionStore;
+  const initialDelay = 100;
+  const maxRetries = 3;
+
+  function createMockProvider(): jest.Mocked<IBlockchainProvider> {
+    return { getTransactionReceipt: jest.fn() };
+  }
+
+  async function flushMicrotasks(): Promise<void> {
+    await new Promise<void>((resolve) => {
+      jest.requireActual<typeof import('timers')>('timers').setImmediate(resolve);
+    });
+  }
+
+  async function advanceTimersAndFlush(ms: number): Promise<void> {
+    jest.advanceTimersByTime(ms);
+    await flushMicrotasks();
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    // Pin the fake clock to a known instant so absolute lease-expiry timestamps
+    // in tests are relative to t=0 rather than the real wall clock.
+    jest.setSystemTime(0);
+    jest.spyOn(Math, 'random').mockReturnValue(0.5);
+    store = new InMemoryTransactionStore();
+    mockProvider = createMockProvider();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  describe('lease acquisition', () => {
+    it('holds the lease while polling and releases it on a terminal write', async () => {
+      const txHash = '0xacquired';
+      mockProvider.getTransactionReceipt.mockImplementation((hash) => {
+        // While the RPC is in flight the lease must be held by this instance.
+        expect(store.get(hash)?.leaseOwner).toBe('poller-a');
+        return Promise.resolve({ status: 1, transactionHash: hash });
+      });
+
+      const poller = new TransactionPoller(
+        mockProvider, maxRetries, initialDelay, undefined, SystemClock, store,
+        { leaseToken: 'poller-a', leaseDurationMs: 1000, leaseSkewMs: 0 },
+      );
+
+      await poller.poll(txHash);
+
+      const tx = store.get(txHash);
+      expect(tx?.status).toBe(TransactionStatus.SUCCESS);
+      // Terminal state releases the lease.
+      expect(tx?.leaseOwner).toBeUndefined();
+      expect(tx?.leaseExpiresAt).toBeUndefined();
+    });
+
+    it('defers to another instance holding a live lease without polling or reporting', async () => {
+      const txHash = '0xdeferred';
+      store.set(txHash, {
+        hash: txHash,
+        status: TransactionStatus.PENDING,
+        retryCount: 0,
+        leaseOwner: 'poller-a',
+        leaseExpiresAt: new Date(10_000),
+      });
+
+      const reports: AbandonedPollInfo[] = [];
+      const pollerB = new TransactionPoller(
+        mockProvider, maxRetries, initialDelay, undefined, SystemClock, store,
+        { leaseToken: 'poller-b', leaseDurationMs: 1000, leaseSkewMs: 0, onPollAbandoned: (info) => reports.push(info) },
+      );
+
+      await pollerB.poll(txHash);
+
+      expect(mockProvider.getTransactionReceipt).not.toHaveBeenCalled();
+      expect(store.get(txHash)?.leaseOwner).toBe('poller-a');
+      expect(reports).toHaveLength(0);
+      expect(pollerB.abandonedPolls).toBe(0);
+    });
+  });
+
+  describe('lease expiry during RPC call', () => {
+    it('abandons the poll when the lease expires while the RPC is in flight', async () => {
+      const txHash = '0xexpire-during-rpc';
+      let resolveLateRpc!: (receipt: any) => void;
+      const providerA = createMockProvider();
+      const providerB = createMockProvider();
+      providerA.getTransactionReceipt.mockImplementation(
+        () => new Promise((resolve) => { resolveLateRpc = resolve; }),
+      );
+      providerB.getTransactionReceipt.mockResolvedValue({ status: 1, transactionHash: txHash });
+
+      const reports: AbandonedPollInfo[] = [];
+      const pollerA = new TransactionPoller(
+        providerA, maxRetries, initialDelay, undefined, SystemClock, store,
+        { leaseToken: 'poller-a', leaseDurationMs: 100, leaseSkewMs: 0, onPollAbandoned: (info) => reports.push(info) },
+      );
+      const pollerB = new TransactionPoller(
+        providerB, maxRetries, initialDelay, undefined, SystemClock, store,
+        { leaseToken: 'poller-b', leaseDurationMs: 100, leaseSkewMs: 0 },
+      );
+
+      const pollPromiseA = pollerA.poll(txHash);
+      await flushMicrotasks();
+      expect(store.get(txHash)?.leaseOwner).toBe('poller-a');
+
+      // The lease (100ms) expires while A's RPC is still pending; B takes over.
+      await advanceTimersAndFlush(100);
+      const pollPromiseB = pollerB.poll(txHash);
+      await flushMicrotasks();
+      expect(store.get(txHash)?.status).toBe(TransactionStatus.SUCCESS);
+
+      // A's RPC finally returns — A must abandon instead of writing.
+      resolveLateRpc({ status: 1, transactionHash: txHash });
+      await flushMicrotasks();
+      await Promise.all([pollPromiseA, pollPromiseB]);
+
+      expect(reports).toEqual([
+        expect.objectContaining({ txHash, reason: 'lease-lost-during-rpc', leaseOwner: 'poller-a' }),
+      ]);
+      expect(reports[0]!.abandonedAt).toBeInstanceOf(Date);
+      expect(pollerA.abandonedPolls).toBe(1);
+      expect(store.get(txHash)?.leaseOwner).toBeUndefined();
+    });
+
+    it('does not abandon when the lease merely lapses but no one took it over', async () => {
+      const txHash = '0xself-renew';
+      mockProvider.getTransactionReceipt.mockImplementation(() => {
+        // Simulate an RPC that outlives the lease duration but is still owned.
+        return Promise.resolve(null);
+      });
+
+      const poller = new TransactionPoller(
+        mockProvider, maxRetries, initialDelay, undefined, SystemClock, store,
+        { leaseToken: 'poller-a', leaseDurationMs: 100, leaseSkewMs: 0 },
+      );
+
+      const pollPromise = poller.poll(txHash);
+      await flushMicrotasks();
+
+      // Advance past the lease duration; the poller renews on the next
+      // iteration instead of abandoning.
+      await advanceTimersAndFlush(1000);
+      expect(poller.abandonedPolls).toBe(0);
+      expect(store.get(txHash)?.leaseOwner).toBe('poller-a');
+      expect(store.get(txHash)?.status).toBe(TransactionStatus.PENDING);
+
+      // Exhaust retries so the loop terminates.
+      if (store.get(txHash)) {
+        store.set(txHash, { ...store.get(txHash)!, status: TransactionStatus.SUCCESS });
+      }
+      jest.runAllTimers();
+      await pollPromise;
+    });
+  });
+
+  describe('old worker completes late', () => {
+    it('fences out the late write of an old worker after a takeover', async () => {
+      const txHash = '0xlate-worker';
+      let resolveLateRpc!: (receipt: any) => void;
+      const providerA = createMockProvider();
+      const providerB = createMockProvider();
+      providerA.getTransactionReceipt.mockImplementation(
+        () => new Promise((resolve) => { resolveLateRpc = resolve; }),
+      );
+      // B observes a reverted (FAILED) chain state.
+      providerB.getTransactionReceipt.mockResolvedValue({ status: 0, transactionHash: txHash, finalizedBy: 'B' });
+
+      const pollerA = new TransactionPoller(
+        providerA, maxRetries, initialDelay, undefined, SystemClock, store,
+        { leaseToken: 'poller-a', leaseDurationMs: 100, leaseSkewMs: 0 },
+      );
+      const pollerB = new TransactionPoller(
+        providerB, maxRetries, initialDelay, undefined, SystemClock, store,
+        { leaseToken: 'poller-b', leaseDurationMs: 100, leaseSkewMs: 0 },
+      );
+
+      const pollPromiseA = pollerA.poll(txHash);
+      await flushMicrotasks();
+
+      await advanceTimersAndFlush(100);
+      const pollPromiseB = pollerB.poll(txHash);
+      await flushMicrotasks();
+      expect(store.get(txHash)?.status).toBe(TransactionStatus.FAILED);
+
+      // A completes late with a conflicting SUCCESS result.
+      resolveLateRpc({ status: 1, transactionHash: txHash, finalizedBy: 'A' });
+      await flushMicrotasks();
+      await Promise.all([pollPromiseA, pollPromiseB]);
+
+      // A's stale SUCCESS must not clobber B's FAILED outcome.
+      const stored = store.get(txHash);
+      expect(stored?.status).toBe(TransactionStatus.FAILED);
+      expect(stored?.receipt).toEqual({ status: 0, transactionHash: txHash, finalizedBy: 'B' });
+      expect(pollerA.abandonedPolls).toBe(1);
+    });
+  });
+
+  describe('process restart', () => {
+    it('resumes only transactions whose previous lease has expired', async () => {
+      // A dead instance's lease has long expired.
+      store.set('0xrestart-expired', {
+        hash: '0xrestart-expired',
+        status: TransactionStatus.PENDING,
+        retryCount: 1,
+        leaseOwner: 'dead-instance',
+        leaseExpiresAt: new Date(-10_000),
+      });
+      // Another live instance still holds a lease.
+      store.set('0xrestart-live', {
+        hash: '0xrestart-live',
+        status: TransactionStatus.PENDING,
+        retryCount: 0,
+        leaseOwner: 'live-instance',
+        leaseExpiresAt: new Date(10_000),
+      });
+
+      mockProvider.getTransactionReceipt.mockResolvedValue({ status: 1, transactionHash: '0xrestart-expired' });
+
+      const restarted = new TransactionPoller(
+        mockProvider, maxRetries, initialDelay, undefined, SystemClock, store,
+        { leaseToken: 'fresh-instance', leaseSkewMs: 0 },
+      );
+
+      await restarted.recoverPendingTransactions();
+      await flushMicrotasks();
+
+      expect(mockProvider.getTransactionReceipt).toHaveBeenCalledTimes(1);
+      expect(mockProvider.getTransactionReceipt).toHaveBeenCalledWith('0xrestart-expired');
+      expect(store.get('0xrestart-expired')?.status).toBe(TransactionStatus.SUCCESS);
+      // The live lease is untouched by recovery.
+      expect(store.get('0xrestart-live')?.leaseOwner).toBe('live-instance');
+      expect(store.get('0xrestart-live')?.status).toBe(TransactionStatus.PENDING);
+    });
+
+    it('treats unleased legacy PENDING rows as recoverable', async () => {
+      store.set('0xlegacy', {
+        hash: '0xlegacy',
+        status: TransactionStatus.PENDING,
+        retryCount: 2,
+      });
+
+      mockProvider.getTransactionReceipt.mockResolvedValue({ status: 1, transactionHash: '0xlegacy' });
+
+      const restarted = new TransactionPoller(
+        mockProvider, maxRetries, initialDelay, undefined, SystemClock, store,
+        { leaseToken: 'fresh-instance', leaseSkewMs: 0 },
+      );
+
+      await restarted.recoverPendingTransactions();
+      await flushMicrotasks();
+
+      expect(mockProvider.getTransactionReceipt).toHaveBeenCalledWith('0xlegacy');
+      expect(store.get('0xlegacy')?.status).toBe(TransactionStatus.SUCCESS);
+    });
+  });
+
+  describe('clock skew', () => {
+    it('defers takeover while a lease is within the skew window and steals it afterwards', async () => {
+      const txHash = '0xskew';
+      store.set(txHash, {
+        hash: txHash,
+        status: TransactionStatus.PENDING,
+        retryCount: 0,
+        leaseOwner: 'poller-a',
+        leaseExpiresAt: new Date(1000), // nominal expiry at t=1000
+      });
+      mockProvider.getTransactionReceipt.mockResolvedValue({ status: 1, transactionHash: txHash });
+
+      const pollerB = new TransactionPoller(
+        mockProvider, maxRetries, initialDelay, undefined, SystemClock, store,
+        { leaseToken: 'poller-b', leaseDurationMs: 1000, leaseSkewMs: 500 },
+      );
+
+      // now=1100: past nominal expiry but inside the skew window (1000+500).
+      jest.advanceTimersByTime(1100);
+      await pollerB.poll(txHash);
+      await flushMicrotasks();
+
+      expect(mockProvider.getTransactionReceipt).not.toHaveBeenCalled();
+      expect(store.get(txHash)?.leaseOwner).toBe('poller-a');
+
+      // now=1600: past expiry + skew — the lease is stealable.
+      jest.advanceTimersByTime(500);
+      await pollerB.poll(txHash);
+      await flushMicrotasks();
+
+      expect(mockProvider.getTransactionReceipt).toHaveBeenCalledTimes(1);
+      expect(store.get(txHash)?.status).toBe(TransactionStatus.SUCCESS);
+    });
+  });
+
+  describe('abandonment reporting', () => {
+    it('reports abandoned polls for retry via the callback and counter', async () => {
+      const txHash = '0xreported';
+      let resolveLateRpc!: (receipt: any) => void;
+      const providerA = createMockProvider();
+      const providerB = createMockProvider();
+      providerA.getTransactionReceipt.mockImplementation(
+        () => new Promise((resolve) => { resolveLateRpc = resolve; }),
+      );
+      providerB.getTransactionReceipt.mockResolvedValue({ status: 1, transactionHash: txHash });
+
+      const reports: AbandonedPollInfo[] = [];
+      const pollerA = new TransactionPoller(
+        providerA, maxRetries, initialDelay, undefined, SystemClock, store,
+        {
+          leaseToken: 'poller-a',
+          leaseDurationMs: 100,
+          leaseSkewMs: 0,
+          onPollAbandoned: (info) => reports.push(info),
+        },
+      );
+      const pollerB = new TransactionPoller(
+        providerB, maxRetries, initialDelay, undefined, SystemClock, store,
+        { leaseToken: 'poller-b', leaseDurationMs: 100, leaseSkewMs: 0 },
+      );
+
+      const pollPromiseA = pollerA.poll(txHash);
+      await flushMicrotasks();
+      await advanceTimersAndFlush(100);
+      const pollPromiseB = pollerB.poll(txHash);
+      await flushMicrotasks();
+      resolveLateRpc({ status: 1, transactionHash: txHash });
+      await flushMicrotasks();
+      await Promise.all([pollPromiseA, pollPromiseB]);
+
+      expect(reports).toHaveLength(1);
+      expect(reports[0]).toMatchObject({
+        txHash,
+        reason: 'lease-lost-during-rpc',
+        leaseOwner: 'poller-a',
+      });
+      expect(reports[0]!.abandonedAt).toBeInstanceOf(Date);
+      expect(pollerA.abandonedPolls).toBe(1);
+      expect(pollerB.abandonedPolls).toBe(0);
+    });
+  });
+
+  describe('lease configuration', () => {
+    it('rejects non-positive lease durations', () => {
+      expect(() => new TransactionPoller(mockProvider, maxRetries, initialDelay, undefined, SystemClock, store, { leaseDurationMs: 0 }))
+        .toThrow('leaseDurationMs must be a positive finite number');
+      expect(() => new TransactionPoller(mockProvider, maxRetries, initialDelay, undefined, SystemClock, store, { leaseDurationMs: -5 }))
+        .toThrow('leaseDurationMs must be a positive finite number');
+      expect(() => new TransactionPoller(mockProvider, maxRetries, initialDelay, undefined, SystemClock, store, { leaseDurationMs: Infinity }))
+        .toThrow('leaseDurationMs must be a positive finite number');
+    });
+
+    it('rejects negative or infinite clock-skew tolerances', () => {
+      expect(() => new TransactionPoller(mockProvider, maxRetries, initialDelay, undefined, SystemClock, store, { leaseSkewMs: -1 }))
+        .toThrow('leaseSkewMs must be a non-negative finite number');
+      expect(() => new TransactionPoller(mockProvider, maxRetries, initialDelay, undefined, SystemClock, store, { leaseSkewMs: Infinity }))
+        .toThrow('leaseSkewMs must be a non-negative finite number');
+    });
+  });
+});

--- a/src/services/TransactionPoller.ts
+++ b/src/services/TransactionPoller.ts
@@ -1,5 +1,7 @@
-import { TransactionStatus, TransactionsDbInterface, transactionsDb } from '../models/Transaction';
+import { randomUUID } from 'crypto';
+import { Transaction, TransactionStatus, TransactionsDbInterface, transactionsDb } from '../models/Transaction';
 import { calculateDelay } from '../utils/retry';
+import { logger } from '../logger';
 
 /**
  * Blockchain provider abstraction to decouple polling logic from specific web3/ethers implementations.
@@ -16,9 +18,58 @@ export const SystemClock: IClock = {
   now: () => Date.now(),
 };
 
+/** Why a poll was abandoned mid-flight. */
+export type AbandonReason =
+  | 'lease-lost-before-poll'
+  | 'lease-renewal-failed'
+  | 'lease-lost-during-rpc'
+  | 'fence-rejected-write';
+
+/** Structured report emitted when a poll is abandoned because its lease was lost. */
+export interface AbandonedPollInfo {
+  txHash: string;
+  reason: AbandonReason;
+  /** Token of the instance that lost the lease. */
+  leaseOwner: string;
+  abandonedAt: Date;
+}
+
+export interface TransactionPollerOptions {
+  /**
+   * How long (ms) a poll lease is held before another instance may take over.
+   * The lease is renewed before every RPC call, so this only bounds how long an
+   * in-flight RPC may outlive its owner without the transaction being fenced.
+   * Default: 30_000.
+   */
+  leaseDurationMs?: number;
+  /**
+   * Clock-skew tolerance (ms) applied when judging whether a lease has expired.
+   * A lease is only considered expired when `expiresAt + skewMs < now`, so a
+   * node with a slightly slow clock cannot have its lease stolen early by a
+   * fast-clocked peer. Default: 5_000.
+   */
+  leaseSkewMs?: number;
+  /**
+   * Unique token identifying this poller instance. Generated per instance when
+   * omitted, so every poller in a process group has a distinct fencing token.
+   */
+  leaseToken?: string;
+  /**
+   * Invoked whenever this instance abandons a poll because the lease was lost.
+   * Enables reporting abandoned work for retry (e.g. re-enqueueing the hash).
+   */
+  onPollAbandoned?: (info: AbandonedPollInfo) => void;
+}
+
 /**
  * Monitors blockchain transaction status using an exponential backoff strategy.
  * Designed to ensure eventual consistency and respect RPC rate limits during peak network congestion.
+ *
+ * Lease fencing: each transaction carries a lease (`leaseOwner` / `leaseExpiresAt`
+ * in the store). Only the current lease owner may mutate a transaction, and every
+ * write is applied via a compare-and-swap (`setIfLeaseOwner`) so a poller whose
+ * lease expired — or was taken over by another instance — while an RPC call was
+ * in flight abandons its poll instead of clobbering the new owner's state.
  */
 export class TransactionPoller {
   public readonly name = 'transaction-poller';
@@ -28,8 +79,13 @@ export class TransactionPoller {
   private readonly maxTotalDurationMs?: number;
   private readonly clock: IClock;
   private readonly store: TransactionsDbInterface;
+  private readonly leaseToken: string;
+  private readonly leaseDurationMs: number;
+  private readonly leaseSkewMs: number;
+  private readonly onPollAbandoned?: (info: AbandonedPollInfo) => void;
   private acceptingNewPolls = true;
   private readonly activePolls = new Map<string, Promise<void>>();
+  private abandonedPollCount = 0;
 
   /**
    * @param provider The blockchain provider instance.
@@ -41,6 +97,7 @@ export class TransactionPoller {
    * @param clock Optional injectable clock for testing (default: SystemClock).
    * @param store Optional transaction store (default: global transactionsDb).
    *              Inject an InMemoryTransactionStore for test isolation.
+   * @param options Optional lease-fencing configuration; see {@link TransactionPollerOptions}.
    */
   constructor(
     provider: IBlockchainProvider,
@@ -48,23 +105,49 @@ export class TransactionPoller {
     initialDelay: number = 1000,
     maxTotalDurationMs?: number,
     clock: IClock = SystemClock,
-    store: TransactionsDbInterface = transactionsDb
+    store: TransactionsDbInterface = transactionsDb,
+    options: TransactionPollerOptions = {}
   ) {
     if (maxTotalDurationMs !== undefined && (isNaN(maxTotalDurationMs) || maxTotalDurationMs <= 0 || maxTotalDurationMs === Infinity)) {
       throw new Error('maxTotalDurationMs must be a positive finite number to prevent silently disabling timeouts');
     }
-    
+
+    const {
+      leaseDurationMs = 30_000,
+      leaseSkewMs = 5_000,
+      leaseToken = randomUUID(),
+      onPollAbandoned,
+    } = options;
+
+    if (isNaN(leaseDurationMs) || leaseDurationMs <= 0 || leaseDurationMs === Infinity) {
+      throw new Error('leaseDurationMs must be a positive finite number');
+    }
+    if (isNaN(leaseSkewMs) || leaseSkewMs < 0 || leaseSkewMs === Infinity) {
+      throw new Error('leaseSkewMs must be a non-negative finite number');
+    }
+
     this.provider = provider;
     this.maxRetries = maxRetries;
     this.initialDelay = initialDelay;
     this.maxTotalDurationMs = maxTotalDurationMs;
     this.clock = clock;
     this.store = store;
+    this.leaseToken = leaseToken;
+    this.leaseDurationMs = leaseDurationMs;
+    this.leaseSkewMs = leaseSkewMs;
+    this.onPollAbandoned = onPollAbandoned;
+  }
+
+  /** Number of polls this instance has abandoned because it lost the lease. */
+  public get abandonedPolls(): number {
+    return this.abandonedPollCount;
   }
 
   /**
    * Orchestrates the polling lifecycle for a given transaction hash.
-   * Initializes local state if necessary and triggers the recursive backoff loop.
+   * Acquires the poll lease (creating the transaction when necessary) and
+   * triggers the recursive backoff loop. When a live lease is held by another
+   * poller instance the call defers to that owner and returns without polling.
    */
   public async poll(txHash: string): Promise<void> {
     if (!this.acceptingNewPolls) {
@@ -77,19 +160,40 @@ export class TransactionPoller {
       return;
     }
 
-    let transaction = this.store.get(txHash);
+    const current = this.store.get(txHash);
+    if (current && current.status !== TransactionStatus.PENDING) {
+      // Terminal state — nothing left to poll.
+      return;
+    }
 
-    if (!transaction) {
-      transaction = {
-        hash: txHash,
-        status: TransactionStatus.PENDING,
-        retryCount: 0,
-        startedAt: new Date(this.clock.now()),
-      };
-      this.store.set(txHash, transaction);
-    } else if (!transaction.startedAt) {
-      transaction.startedAt = new Date(this.clock.now());
-      this.store.set(txHash, transaction);
+    const now = this.clock.now();
+    const acquired = this.store.acquireLease(
+      txHash,
+      this.leaseToken,
+      new Date(now + this.leaseDurationMs),
+      now,
+      this.leaseSkewMs,
+    );
+    if (!acquired) {
+      // A live lease is held by another poller instance; defer to it. The
+      // transaction is picked up once that lease expires.
+      logger.debug('Transaction poll deferred: lease held by another instance', {
+        txHash,
+        leaseOwner: this.leaseToken,
+      });
+      return;
+    }
+
+    // Backfill startedAt for legacy rows created before the duration ceiling
+    // existed, so the ceiling can be enforced after an upgrade.
+    const afterAcquire = this.store.get(txHash);
+    if (afterAcquire && !afterAcquire.startedAt) {
+      this.store.setIfLeaseOwner(txHash, {
+        ...afterAcquire,
+        startedAt: new Date(now),
+        leaseOwner: this.leaseToken,
+        leaseExpiresAt: new Date(now + this.leaseDurationMs),
+      }, this.leaseToken);
     }
 
     const pollPromise = (async () => {
@@ -112,6 +216,11 @@ export class TransactionPoller {
   /**
    * Recovers and resumes polling for any transactions left in a PENDING state
    * (e.g., after an application restart).
+   *
+   * Only transactions whose lease is free, expired, or already owned by this
+   * instance are resumed; transactions with a live lease held by another
+   * poller instance are skipped so the fencing guarantee holds across restarts
+   * and concurrent workers.
    */
   public async recoverPendingTransactions(): Promise<void> {
     const pendingTransactions = Array.from(this.store.values()).filter(
@@ -119,6 +228,23 @@ export class TransactionPoller {
     );
 
     for (const tx of pendingTransactions) {
+      const now = this.clock.now();
+      const acquired = this.store.acquireLease(
+        tx.hash,
+        this.leaseToken,
+        new Date(now + this.leaseDurationMs),
+        now,
+        this.leaseSkewMs,
+      );
+      if (!acquired) {
+        // Another poller instance holds a live lease; skip this transaction.
+        logger.debug('Recovery skipped: transaction lease held by another instance', {
+          txHash: tx.hash,
+          leaseOwner: this.leaseToken,
+        });
+        continue;
+      }
+
       // Re-enqueue the polling process in the background.
       this.pollWithBackoff(tx.hash).catch(error => {
         console.error(`Recovery polling failed for ${tx.hash}:`, error);
@@ -165,20 +291,33 @@ export class TransactionPoller {
   /**
    * Recursive implementation of exponential backoff polling.
    * Balances the need for low-latency confirmation against API rate limits.
+   *
+   * Every mutation of the transaction is fenced: the lease is renewed before
+   * each RPC call, ownership is re-checked after the call returns, and each
+   * write is a compare-and-swap that only applies while this instance still
+   * owns the lease. When the lease is lost the poll is abandoned and reported
+   * (see {@link TransactionPollerOptions.onPollAbandoned}) so the work can be
+   * retried by the new owner.
    */
   private async pollWithBackoff(txHash: string): Promise<void> {
     const transaction = this.store.get(txHash);
-    
+
     // Stop early if transaction was completed externally or deleted
     if (!transaction || transaction.status !== TransactionStatus.PENDING) {
       return;
     }
 
+    // Fence check: only the current lease owner may touch the transaction.
+    // A live lease held by another instance means the poll must be abandoned
+    // and reported for retry by that instance.
+    if (transaction.leaseOwner !== this.leaseToken) {
+      this.reportAbandoned(txHash, 'lease-lost-before-poll');
+      return;
+    }
+
     // Circuit breaker for long-running pending transactions
     if (transaction.retryCount >= this.maxRetries) {
-      transaction.status = TransactionStatus.TIMEOUT;
-      transaction.lastCheckedAt = new Date(this.clock.now());
-      this.store.set(txHash, transaction);
+      this.writeTerminal(txHash, TransactionStatus.TIMEOUT);
       return;
     }
 
@@ -186,37 +325,127 @@ export class TransactionPoller {
     if (this.maxTotalDurationMs !== undefined && transaction.startedAt) {
       const elapsedMs = this.clock.now() - transaction.startedAt.getTime();
       if (elapsedMs >= this.maxTotalDurationMs) {
-        transaction.status = TransactionStatus.TIMEOUT;
-        transaction.lastCheckedAt = new Date(this.clock.now());
-        this.store.set(txHash, transaction);
+        this.writeTerminal(txHash, TransactionStatus.TIMEOUT);
         return;
       }
     }
 
-    try {
-      const receipt = await this.provider.getTransactionReceipt(txHash);
+    // Renew the lease so it covers the upcoming RPC call. Renewal fails when
+    // another instance took the lease over while we were sleeping.
+    const now = this.clock.now();
+    const renewed = this.store.acquireLease(
+      txHash,
+      this.leaseToken,
+      new Date(now + this.leaseDurationMs),
+      now,
+      this.leaseSkewMs,
+    );
+    if (!renewed) {
+      this.reportAbandoned(txHash, 'lease-renewal-failed');
+      return;
+    }
 
-      if (receipt) {
-        // Map common blockchain status codes (1: Success, 0: Reverted)
-        transaction.status = receipt.status === 1 ? TransactionStatus.SUCCESS : TransactionStatus.FAILED;
-        transaction.receipt = receipt;
-        transaction.lastCheckedAt = new Date(this.clock.now());
-        this.store.set(txHash, transaction);
-        return;
-      }
+    let receipt: any;
+    try {
+      receipt = await this.provider.getTransactionReceipt(txHash);
     } catch (error) {
       // Non-fatal error; log for observability and retry on the next interval
       console.warn(`RPC error while fetching receipt for ${txHash}:`, error);
     }
 
-    transaction.retryCount++;
-    transaction.lastCheckedAt = new Date(this.clock.now());
-    this.store.set(txHash, transaction);
+    // The lease may have expired — and been taken over by another instance —
+    // while the RPC call was in flight. Re-check ownership before writing.
+    const afterRpc = this.store.get(txHash);
+    if (!afterRpc) {
+      // Row deleted while the RPC was in flight — stop without resurrecting it.
+      return;
+    }
+    if (afterRpc.leaseOwner !== this.leaseToken) {
+      this.reportAbandoned(txHash, 'lease-lost-during-rpc');
+      return;
+    }
 
-    const delay = calculateDelay(transaction.retryCount - 1, this.initialDelay, Infinity, true);
-    
+    if (receipt) {
+      // Map common blockchain status codes (1: Success, 0: Reverted)
+      const status = receipt.status === 1 ? TransactionStatus.SUCCESS : TransactionStatus.FAILED;
+      this.writeTerminal(txHash, status, receipt);
+      return;
+    }
+
+    // Re-read the current row before incrementing so overlapping iterations
+    // (e.g. recovery plus poll, or batched timer fire in tests) cannot lose
+    // retry-count increments by writing from a stale snapshot.
+    const current = this.store.get(txHash);
+    if (!current) {
+      return;
+    }
+    if (current.leaseOwner !== this.leaseToken) {
+      this.reportAbandoned(txHash, 'fence-rejected-write');
+      return;
+    }
+
+    const updated: Transaction = {
+      ...current,
+      retryCount: current.retryCount + 1,
+      lastCheckedAt: new Date(this.clock.now()),
+      leaseOwner: this.leaseToken,
+      leaseExpiresAt: new Date(this.clock.now() + this.leaseDurationMs),
+    };
+    if (!this.store.setIfLeaseOwner(txHash, updated, this.leaseToken)) {
+      this.reportAbandoned(txHash, 'fence-rejected-write');
+      return;
+    }
+
+    const delay = calculateDelay(current.retryCount, this.initialDelay, Infinity, true);
+
     // Enforce backoff delay using the event loop to avoid blocking resources
     await new Promise(resolve => setTimeout(resolve, delay));
     return this.pollWithBackoff(txHash);
+  }
+
+  /**
+   * Fenced terminal write (SUCCESS / FAILED / TIMEOUT). Re-reads the current
+   * row so retryCount and other state are preserved, clears the lease, and
+   * applies the write only while this instance still owns the lease.
+   */
+  private writeTerminal(txHash: string, status: TransactionStatus, receipt?: any): void {
+    const current = this.store.get(txHash);
+    if (!current) {
+      return;
+    }
+
+    const updated: Transaction = {
+      ...current,
+      status,
+      ...(receipt !== undefined ? { receipt } : {}),
+      lastCheckedAt: new Date(this.clock.now()),
+      // Terminal state releases the lease so a later cycle can start fresh.
+      leaseOwner: undefined,
+      leaseExpiresAt: undefined,
+    };
+
+    if (!this.store.setIfLeaseOwner(txHash, updated, this.leaseToken)) {
+      this.reportAbandoned(txHash, 'fence-rejected-write');
+    }
+  }
+
+  /**
+   * Records an abandoned poll: increments the abandonment counter, emits a
+   * structured warning, and invokes the optional callback so callers can
+   * re-enqueue the transaction for retry.
+   */
+  private reportAbandoned(txHash: string, reason: AbandonReason): void {
+    this.abandonedPollCount += 1;
+    logger.warn('Transaction poll abandoned — lease no longer held', {
+      txHash,
+      leaseOwner: this.leaseToken,
+      reason,
+    });
+    this.onPollAbandoned?.({
+      txHash,
+      reason,
+      leaseOwner: this.leaseToken,
+      abandonedAt: new Date(this.clock.now()),
+    });
   }
 }


### PR DESCRIPTION
## Summary

Two `TransactionPoller` instances can update the same transaction after a lease owner has changed. Concretely: worker A starts polling a transaction and its RPC call hangs; A's lease lapses; worker B (or a restarted process) takes over and completes the transaction; A's RPC finally returns and A writes its stale result — clobbering B's state.

This PR adds **lease-token fencing** to the transaction poller so that only the current lease owner may ever mutate a transaction, and abandoned polls are **reported for retry**.

## What changed

- **Lease state on transactions** (`src/models/Transaction.ts`): `Transaction` gains `leaseOwner` (per-instance token) and `leaseExpiresAt`. New store APIs on `TransactionsDbInterface`:
  - `acquireLease(hash, owner, expiresAt, now, skewMs)` — atomic acquire/renew; creates the row as `PENDING` when unknown; refuses live leases held by another owner.
  - `isLeaseOwner(hash, owner)` — fencing check.
  - `setIfLeaseOwner(hash, tx, owner)` — compare-and-swap write that only applies while the caller still owns the lease.
- **SQLite migration v14** (`src/db/migrations.ts`): adds `lease_owner` / `lease_expires_at` columns to `transactions`. Lease acquisition runs in an exclusive transaction (`BEGIN IMMEDIATE` where available); the fenced write is a single atomic `UPDATE … WHERE hash = ? AND lease_owner = ?`.
- **Poller fencing** (`src/services/TransactionPoller.ts`):
  - `poll()` / `recoverPendingTransactions()` acquire the lease before polling; a live foreign lease is deferred/skipped.
  - The lease is **renewed before every RPC call** and ownership is **re-checked after** the call returns.
  - Every write (SUCCESS / FAILED / TIMEOUT / retry-count bump) goes through `setIfLeaseOwner`. A poller that lost its lease abandons the poll instead of writing.
  - Abandonment is reported via a structured `warn` log, an `abandonedPolls` counter, and an optional `onPollAbandoned` callback so callers can re-enqueue the hash for retry.
  - New `TransactionPollerOptions`: `leaseDurationMs` (default 30s), `leaseSkewMs` (default 5s clock-skew tolerance), `leaseToken` (default per-instance UUID), `onPollAbandoned`. All existing constructor call sites remain compatible (options is a new trailing argument).

## Edge cases covered by tests

| Edge case | Behavior | Test |
|---|---|---|
| Lease acquired | Owner recorded while polling; released on terminal write | `TransactionPoller.fencing.test.ts`, `Transaction.lease.test.ts` |
| Lease expires during RPC call | Old worker abandons after the RPC returns; no write | `TransactionPoller.fencing.test.ts` |
| Old worker completes late | Late write is fenced out; new owner's state preserved | unit + integration (in-memory and SQLite paths) |
| Process restart | Recovery resumes only expired/unowned leases; live foreign leases skipped | unit + integration (SQLite) |
| Clock skew | Lease not stealable within `expiresAt + skewMs`; stealable after | `Transaction.lease.test.ts`, fencing unit tests |

## Test evidence

- `npm test` — **203 suites, 4320 tests, all passing** (incl. the 37 new lease-fencing tests: 22 store-level, 11 poller unit, 4 integration). No regressions in the pre-existing suite.
- `npm run lint` — passes (0 errors; only pre-existing warnings in unrelated files).
- `npm run build` — passes (`tsc -p tsconfig.build.json --noCheck`).

## Security & operations notes

- **Structured, secret-safe logging**: abandonment is emitted through the project's structured logger (`logger.warn`) with `txHash` / `reason` / `leaseOwner` context; the logger redacts sensitive keys and never serialises stack traces in production. The lease token is an internal per-instance UUID, not a credential.
- **Tenant isolation**: leases are scoped per transaction row and keyed by hash; no cross-tenant state is introduced or touched. The feature does not change any HTTP API contract — the poller is an internal background service.
- **Clock skew**: `leaseSkewMs` (default 5s) prevents a node with a fast clock from stealing a lease the owner still considers valid; a lease is expired only when `expiresAt + skewMs < now`.
- **Retry semantics**: when a poll is abandoned, the new lease owner is already polling the transaction, so the abandoned work is naturally retried by that owner. `onPollAbandoned` additionally surfaces the event for observability/re-enqueue, and the store keeps the transaction `PENDING` so recovery re-acquires it once the current lease lapses.
- **Failure handling**: all fence failures are non-fatal and bounded — the poll stops, the event is reported, and the loop terminates without unhandled rejections (existing orchestrator catch preserved).

## Compatibility

- No changes to public HTTP API, error envelopes, or the audit surface.
- `Transaction` and `TransactionsDbInterface` gain additive optional fields/methods; both store implementations were updated. Legacy rows without lease fields are treated as unleased and remain recoverable.
- Migration v14 is additive and idempotent (guarded `ALTER TABLE`).

Closes #1210
