### PR TITLE
feat: add projection replay command

### DIFF
--- a/src/operations/projection-replay.test.ts
+++ b/src/operations/projection-replay.test.ts
@@ -1,0 +1,78 @@
+import { ProjectionReplayer, ProjectionEvent } from './projection-replay';
+
+describe('ProjectionReplayer', () => {
+  let replayer: ProjectionReplayer;
+
+  beforeEach(() => {
+    replayer = new ProjectionReplayer();
+  });
+
+  it('handles empty range', () => {
+    const result = replayer.replay({ events: [] });
+    expect(result.status).toBe('success');
+    expect(result.after?.version).toBe(0);
+  });
+
+  it('handles duplicate events', () => {
+    const events: ProjectionEvent[] = [
+      { id: '1', type: 'test', payload: { a: 1 }, timestamp: 100 },
+      { id: '1', type: 'test', payload: { a: 2 }, timestamp: 200 },
+    ];
+    const result = replayer.replay({ events });
+    expect(result.status).toBe('success');
+    expect(result.after?.version).toBe(1);
+    expect(result.after?.data.a).toBe(1);
+  });
+
+  it('handles unknown schema', () => {
+    const events: ProjectionEvent[] = [
+      { id: '1', type: '', payload: { a: 1 }, timestamp: 100 }
+    ];
+    const result = replayer.replay({ events });
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/Unknown schema/);
+  });
+
+  it('replays against current state', () => {
+    const events: ProjectionEvent[] = [
+      { id: '1', type: 'test', payload: { b: 2 }, timestamp: 100 }
+    ];
+    const initialState = { version: 5, data: { a: 1 } };
+    const result = replayer.replay({ events, initialState });
+    expect(result.status).toBe('success');
+    expect(result.after?.version).toBe(6);
+    expect(result.after?.data).toEqual({ a: 1, b: 2 });
+  });
+
+  it('enforces tenant isolation', () => {
+    const events: ProjectionEvent[] = [
+      { id: '1', type: 'test', tenantId: 'tenant-a', payload: { a: 1 }, timestamp: 100 }
+    ];
+    const result = replayer.replay({ events, tenantId: 'tenant-b' });
+    expect(result.status).toBe('error');
+    expect(result.error).toMatch(/Tenant isolation violation/);
+  });
+
+  it('redacts sensitive payloads', () => {
+    const events: ProjectionEvent[] = [
+      { id: '1', type: 'test', payload: { authorization: 'secret-token', a: 1 }, timestamp: 100 }
+    ];
+    const result = replayer.replay({ events });
+    expect(result.status).toBe('success');
+    expect(result.after?.data.authorization).toBe('[REDACTED]');
+    expect(result.after?.data.a).toBe(1);
+  });
+
+  it('handles large range', () => {
+    const events: ProjectionEvent[] = Array.from({ length: 1000 }).map((_, i) => ({
+      id: `evt-${i}`,
+      type: 'test',
+      payload: { [`k-${i}`]: i },
+      timestamp: i
+    }));
+    const result = replayer.replay({ events });
+    expect(result.status).toBe('success');
+    expect(result.after?.version).toBe(1000);
+    expect(Object.keys(result.after!.data).length).toBe(1000);
+  });
+});

--- a/src/operations/projection-replay.ts
+++ b/src/operations/projection-replay.ts
@@ -1,0 +1,133 @@
+import { readFileSync, writeFileSync } from 'fs';
+import { redact } from '../events/redact';
+import { logger } from '../logger';
+
+export interface ProjectionEvent {
+  id: string;
+  type: string;
+  tenantId?: string;
+  payload: any;
+  timestamp: number;
+}
+
+export interface ProjectionState {
+  version: number;
+  data: Record<string, any>;
+}
+
+export interface ProjectionReplayInput {
+  initialState?: ProjectionState;
+  events: ProjectionEvent[];
+  tenantId?: string; // If set, enforce tenant isolation
+}
+
+export interface ProjectionReplayOutput {
+  status: 'success' | 'error';
+  before?: ProjectionState;
+  after?: ProjectionState;
+  diff?: Record<string, { from: any; to: any }>;
+  error?: string;
+}
+
+export class ProjectionReplayer {
+  public replay(input: ProjectionReplayInput): ProjectionReplayOutput {
+    try {
+      const { events, tenantId } = input;
+      const initialState = input.initialState || { version: 0, data: {} };
+      
+      const before = JSON.parse(JSON.stringify(initialState));
+      const state = JSON.parse(JSON.stringify(initialState));
+      
+      if (!events || events.length === 0) {
+        return { status: 'success', before, after: state, diff: {} };
+      }
+
+      const sortedEvents = [...events].sort((a, b) => a.timestamp - b.timestamp);
+      const seenEvents = new Set<string>();
+
+      for (const event of sortedEvents) {
+        if (seenEvents.has(event.id)) {
+          logger.warn(`Skipping duplicate event ${event.id}`);
+          continue;
+        }
+        seenEvents.add(event.id);
+
+        if (!event.type) {
+           throw new Error(`Unknown schema for event ${event.id}`);
+        }
+
+        if (tenantId && event.tenantId && event.tenantId !== tenantId) {
+          throw new Error(`Tenant isolation violation: event ${event.id} belongs to ${event.tenantId}, expected ${tenantId}`);
+        }
+
+        const redactedPayload = redact(event.payload);
+
+        // Replay logic: merge payload into state.data
+        state.data = { ...state.data, ...redactedPayload };
+        state.version += 1;
+      }
+
+      // Compute diff
+      const diff: Record<string, any> = {};
+      for (const key of Object.keys(state.data)) {
+        if (JSON.stringify(before.data[key]) !== JSON.stringify(state.data[key])) {
+          diff[key] = { from: before.data[key], to: state.data[key] };
+        }
+      }
+      for (const key of Object.keys(before.data)) {
+        if (!(key in state.data)) {
+          diff[key] = { from: before.data[key], to: undefined };
+        }
+      }
+
+      // auditability
+      logger.info('Projection replay completed successfully', {
+        eventCount: events.length,
+        tenantId,
+        resultingVersion: state.version
+      });
+
+      return {
+        status: 'success',
+        before,
+        after: state,
+        diff
+      };
+    } catch (err: any) {
+      logger.error('Projection replay failed', { error: err.message });
+      return {
+        status: 'error',
+        error: err.message
+      };
+    }
+  }
+}
+
+// CLI entry point
+export function runCommand(args: string[]) {
+  if (args.length < 2) {
+    console.error("Usage: ts-node src/operations/projection-replay.ts <input-file> <output-file>");
+    process.exit(1);
+  }
+
+  const inputFile = args[0];
+  const outputFile = args[1];
+
+  let inputData: ProjectionReplayInput;
+  try {
+    inputData = JSON.parse(readFileSync(inputFile, 'utf-8'));
+  } catch (err: any) {
+    console.error("Failed to read input file:", err.message);
+    process.exit(1);
+  }
+
+  const replayer = new ProjectionReplayer();
+  const result = replayer.replay(inputData);
+
+  writeFileSync(outputFile, JSON.stringify(result, null, 2));
+  console.log(`Replay complete. Results written to ${outputFile}`);
+}
+
+if (require.main === module) {
+  runCommand(process.argv.slice(2));
+}


### PR DESCRIPTION
Closes #1231 

## Summary
Investigating a projection discrepancy requires a repeatable way to replay a bounded event slice in isolation. This PR introduces a read-only replay command with fixed inputs and outputs that compares generated projection changes while redacting sensitive payloads.

## Changes Made
* Created `src/operations/projection-replay.ts` containing the core replay logic and a CLI entry point for feeding it bounded event slices.
* The script gracefully merges payloads, computes differences between the initial and resultant states, and writes the results to a specified output file.
* Enforced tenant isolation by failing if events breach expected scope bounds.
* Used the existing `redact()` utility to ensure no sensitive payloads are leaked.
* Added `src/operations/projection-replay.test.ts` with focused unit tests.

## Edge Cases Handled
* **Empty range:** safely handled returning base state.
* **Duplicate events:** ignores occurrences using tracking sets.
* **Unknown schema:** validates event types explicitly.
* **Replay against current state:** supports passing in a seeded `initialState`.
* **Large range:** cleanly parses batches and scales linearly in memory.

